### PR TITLE
fix(web): dev server 绑定双栈，修复 127.0.0.1:20002 不可达

### DIFF
--- a/kb-rag-web/vite.config.ts
+++ b/kb-rag-web/vite.config.ts
@@ -8,6 +8,12 @@ const BACKEND_ORIGIN = 'http://127.0.0.1:20000';
 export default defineConfig({
   plugins: [react()],
   server: {
+    // Bind dual-stack. Vite's default host is `localhost`, which Node 18+ resolves to
+    // ::1 only — 127.0.0.1:20002 is then unreachable, breaking IPv4-only clients and
+    // any tooling that does not follow the IPv6 loopback. '::' accepts both families
+    // via IPv4-mapped addresses. Trade-off: this also binds every interface, so the
+    // dev server is reachable from the LAN.
+    host: '::',
     port: 20002,
     proxy: {
       '/api': {


### PR DESCRIPTION
web dev server 此前只监听 IPv6 环回，`http://127.0.0.1:20002` 连不上。

## 根因

[vite.config.ts](kb-rag-web/vite.config.ts) 的 `server` 块只配了 `port`，没配 `host`。Vite 在 `server.host` 未定义时默认使用 `localhost`，而 Node 18+ 将 `localhost` 解析为 `::1`，于是 dev server 实际绑定 `[::1]:20002` —— 纯 IPv6 环回。

这与裸 Node 的行为不同：`app.listen(20002)` 不指定 host 时绑定 `::` 且非 IPv6-only，天然双栈。Vite 的默认值改变了这个行为。

## 改动

```diff
  server: {
+   host: '::',
    port: 20002,
```

`::` 在非 IPv6-only 的 socket 上通过 IPv4-mapped 地址同时接受两个协议族。

**代价**：`::` 绑定全部接口，dev server 在局域网内可达。这一点已写进代码注释，避免后来者误以为它仍只在本机可访问。Vite 的 `host` 只接受单个地址，无法表达「仅环回但双栈」，故取此权衡。

## 验证

用改后的配置实际启动 dev server（20099，避开运行中的实例）：

| 检查项 | 改前 | 改后 |
| --- | --- | --- |
| 监听地址 | `[::1]:20002` | `*:20099`（IPv6 socket，双栈） |
| `http://127.0.0.1` | 连接失败 | HTTP 200 |
| `http://[::1]` | HTTP 200 | HTTP 200 |
| `http://localhost` | 依赖解析结果 | HTTP 200 |

`npm run lint` 通过（3 个既有的 react fast-refresh warning 与本次改动无关），`npm run build`（`tsc -b && vite build`）通过。

## 生效方式

正在运行的 dev server 需重启才生效（`npm run dev`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
