### PR TITLE
fix(deploy): Qdrant API Key 改为必填，并修复 preflight 脚本的语法错误

### DIFF
--- a/kb-rag-deploy/.env.example
+++ b/kb-rag-deploy/.env.example
@@ -22,8 +22,9 @@ ES_URI=http://127.0.0.1:9200
 
 # Qdrant：仅 full 模式使用；lite 模式下留空即可（VECTOR_ENGINE=es 时不会读取此项）
 QDRANT_URI=
-# Qdrant 访问密钥：留空即免鉴权（本机部署默认），填写后需与容器的 QDRANT__SERVICE__API_KEY 一致
-QDRANT_API_KEY=
+# 必填（full 模式）：Qdrant 只要收到该变量就开启鉴权，留空等于"鉴权已开但密钥为空"，
+# 应用侧每次读写向量都会 401；lite 模式不启动 Qdrant，此项不生效
+QDRANT_API_KEY=CHANGE_ME_qdrant_api_key
 
 # MinIO：应用侧对象存储（文档原件 + 解析产物）；Qdrant 自带存储，不再需要专属 MinIO
 MINIO_ENDPOINT=http://127.0.0.1:9000
@@ -171,7 +172,9 @@ APP_SNAPSHOT_RETAIN_COUNT=3
 # 单库快照创建整体超时，毫秒（ES _clone 毫秒级；Qdrant 批量拷贝场景才可能逼近）
 APP_SNAPSHOT_TIMEOUT_MS=300000
 # 快照保留清理任务调度（Spring cron）与开关
-APP_SNAPSHOT_CLEANUP_CRON=0 15 4 * * *
+# 值含空格，必须加引号：.env 会被 shell source（preflight.sh 与自测流程都如此），
+# 不加引号会被解析成 "临时变量+命令"，改动静默失效
+APP_SNAPSHOT_CLEANUP_CRON="0 15 4 * * *"
 APP_SNAPSHOT_CLEANUP_ENABLED=true
 # 检索版本可见集缓存（管理台/测试版路径；快照路径不走缓存）
 RETRIEVAL_VISIBLE_VERSION_CACHE_TTL_MINUTES=5

--- a/kb-rag-deploy/docker-compose.yml
+++ b/kb-rag-deploy/docker-compose.yml
@@ -26,14 +26,16 @@ services:
   # 单进程自带存储，不需要额外的元数据服务或对象存储，full 模式因此只比 lite 多这一个容器。
   #
   # 数据落在 kb_rag_qdrant_data 卷的 /qdrant/storage 下，容器重建不丢数据。
-  # QDRANT_API_KEY 留空即免鉴权（本机部署默认），填写后所有请求需带 api-key 头。
+  # QDRANT_API_KEY 必填：Qdrant 只要收到 QDRANT__SERVICE__API_KEY 这个变量就开启鉴权，
+  # 留空传下去等于"鉴权已开但密钥为空"，任何请求都会 401（/healthz 例外，所以容器仍显示 healthy）。
+  # 设好后应用侧与 curl 都需带 api-key 头。
   # ------------------------------------------------------------------
   qdrant:
     image: qdrant/qdrant:v1.18.3
     container_name: kb-rag-qdrant
     restart: unless-stopped
     environment:
-      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-CHANGE_ME_qdrant_api_key}
     volumes:
       - kb_rag_qdrant_data:/qdrant/storage
     ports:

--- a/kb-rag-deploy/scripts/preflight.sh
+++ b/kb-rag-deploy/scripts/preflight.sh
@@ -91,7 +91,7 @@ get_total_mem_gb() {
 }
 
 REQUIRED_GB=8
-[[ "${DEPLOY_PROFILE}" == "full" ]] && REQUIRED_GB=24
+[[ "${DEPLOY_PROFILE}" == "full" ]] && REQUIRED_GB=16
 
 TOTAL_GB="$(get_total_mem_gb)"
 if [[ "${TOTAL_GB}" -eq 0 ]]; then
@@ -157,6 +157,9 @@ check_secret "MYSQL_PASSWORD"            "${MYSQL_PASSWORD:-CHANGE_ME_mysql_pass
 check_secret "MINIO_ACCESS_KEY"          "${MINIO_ACCESS_KEY:-CHANGE_ME_minio_access_key}"
 check_secret "MINIO_SECRET_KEY"          "${MINIO_SECRET_KEY:-CHANGE_ME_minio_secret_key}"
 if [[ "${DEPLOY_PROFILE}" == "full" ]]; then
+  # Qdrant 的 API Key 必填：容器只要收到 QDRANT__SERVICE__API_KEY 这个变量就会开启鉴权，
+  # 留空反而变成"鉴权已开但没有可用密钥"，届时应用侧每次读写向量都会拿到 401。
+  check_secret "QDRANT_API_KEY" "${QDRANT_API_KEY:-CHANGE_ME_qdrant_api_key}"
 fi
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
修复 PR #6 引入的三个缺陷，都是在本地实际拉起 full 模式时暴露出来的。

## 1. Qdrant API Key：留空会让 full 模式完全不可用

compose 原写法：

```yaml
QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
```

留空时传的是**空字符串**，而不是不传该变量。实测两者行为完全不同：

| 环境变量 | Qdrant 行为 |
| --- | --- |
| `QDRANT__SERVICE__API_KEY=`（空字符串） | **开启鉴权**，所有请求 401 |
| 完全不设该变量 | 免鉴权，200 |

于是 `.env.example` 注释宣称的「留空即免鉴权」实际变成了「鉴权已开但没有可用密钥」——应用侧每次读写向量都拿 401。更麻烦的是 `/healthz` 不需要鉴权，**容器照样 healthy**，把问题完全盖住了；PR #6 当时用 `docker run` 验证（没传这个变量），所以没暴露。

**为什么不做成「留空即免鉴权」**：compose 的列表继承写法（`- QDRANT__SERVICE__API_KEY`）确实能做到留空就不传，但它继承的变量名必须与容器内变量同名，而应用侧读的是 `QDRANT_API_KEY`——用户得在 `.env` 里设两个名字不同的变量。单变量下这个承诺实现不了，故改为**必填**，与仓库里 MySQL / MinIO / Neo4j 口令的处理保持一致（由 preflight 拦截 `CHANGE_ME_*` 占位值）。对存放知识库全文向量的服务来说，默认开启鉴权也更合理。

验证 compose 在三种情形下都传非空值，不会再出现死锁：

| `.env` 状态 | 容器收到 |
| --- | --- |
| 占位值 | `CHANGE_ME_qdrant_api_key`（preflight 拦截） |
| 真实值 | 真实值 |
| 该行不存在 | `CHANGE_ME_qdrant_api_key`（preflight 拦截） |

## 2. preflight.sh 有 bash 语法错误，脚本跑不完

PR #6 删掉 `check_secret "MILVUS_MINIO_SECRET_KEY"` 时，那是 `if` 块里唯一的语句，删完留下空块：

```bash
if [[ "${DEPLOY_PROFILE}" == "full" ]]; then
fi
```

bash 空块是语法错误，脚本从第 160 行起直接崩：

```
scripts/preflight.sh: line 160: syntax error near unexpected token `fi'
```

也就是说 **PR #6 合并后 preflight 一直是坏的**。当时我跑 `bash -n` 是在改端口之后、删这行之前，所以没抓到。现在由 `QDRANT_API_KEY` 的校验填补这个空块，一举两得。

## 3. full 模式内存门槛与文档不一致

PR #6 把文档的 full 内存要求从 24GB 改成 16GB（三容器合并为一个 qdrant），但 `preflight.sh` 里仍是 `REQUIRED_GB=24`，一并对齐。

## 4. 顺带：`.env.example` 的 cron 未加引号

```
APP_SNAPSHOT_CLEANUP_CRON=0 15 4 * * *
```

值含空格且未加引号。`.env` 会被 shell `source`（preflight 与自测流程都如此），这行被解析成「临时变量 `=0` + 执行命令 `15 4 * * *`」，结果**变量根本没被设置**，同时报一行 `15: command not found`。

后果是用户在 `.env` 里改 cron 表达式会**静默失效**，server 仍用代码里的默认值。加引号后实测 `source` 得到完整值 `0 15 4 * * *`。

（这是既有问题、非 PR #6 引入，但它正是 preflight 报错的来源，在同一文件同一场景下顺手修掉。）

## 验证

- `bash -n scripts/preflight.sh` 通过
- `preflight.sh full` + 占位 key → 拦截并报错；换真实 key → 放行；`preflight.sh lite` → 不校验 Qdrant
- full 模式内存检查输出已显示 `>= 16GB`
- `docker compose config` 三种 `.env` 情形下 API key 均为非空
- `source .env.example` 后 `APP_SNAPSHOT_CLEANUP_CRON` 取到完整 cron 表达式
- preflight 运行时不再出现 `command not found`

## 升级影响

已有 full 模式部署需要在 `.env` 里设置 `QDRANT_API_KEY`（原先留空的话，本来也是 401 状态、根本没跑起来）。lite 模式不启动 Qdrant，不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
