### PR TITLE
fix(api): 路径不存在返回 404 而非 500

### DIFF
--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/advice/GlobalExceptionHandler.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/advice/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -141,6 +142,24 @@ public class GlobalExceptionHandler {
         log.info("upload rejected, errorCode={}, reason=size limit exceeded", ErrorCode.INVALID_PARAM);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(Result.failure(ErrorCode.INVALID_PARAM, "file exceeds the configured size limit"));
+    }
+
+    /**
+     * Handles requests whose path matches no handler.
+     *
+     * <p>Exists because the catch all below would otherwise answer a mistyped URL with
+     * {@code 500 INTERNAL_ERROR} and log a full stack trace: the caller is told the service broke when
+     * the path is simply wrong, and every wrong URL an integration tries buries real failures under
+     * error level noise. A path that does not exist is a client error, so it gets 404 and one info line.
+     *
+     * @param e resource not found exception
+     * @return error envelope mapped to {@link ErrorCode#NOT_FOUND}
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Result<Void>> handleNoResourceFound(NoResourceFoundException e) {
+        log.info("request rejected, errorCode={}, path={}", ErrorCode.NOT_FOUND, e.getResourcePath());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Result.failure(ErrorCode.NOT_FOUND, "no handler for " + e.getResourcePath()));
     }
 
     /**

--- a/kb-rag-server/kb-api/src/test/java/io/kbrag/api/advice/GlobalExceptionHandlerTest.java
+++ b/kb-rag-server/kb-api/src/test/java/io/kbrag/api/advice/GlobalExceptionHandlerTest.java
@@ -4,9 +4,11 @@ import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.api.Result;
 import io.kbrag.common.exception.BizException;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.io.UnsupportedEncodingException;
 
@@ -65,6 +67,19 @@ class GlobalExceptionHandlerTest {
                 handler.handleBiz(BizException.invalidParam("bad input"), request, response);
 
         assertNotNull(entity);
+    }
+
+    @Test
+    void shouldAnswerAnUnknownPathWithNotFoundRatherThanInternalError() {
+        ResponseEntity<Result<Void>> entity = handler.handleNoResourceFound(
+                new NoResourceFoundException(HttpMethod.POST, "api/v1/knowledge/search/api/v1/knowledge/search"));
+
+        assertNotNull(entity);
+        assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), entity.getStatusCode().value());
+        assertNotNull(entity.getBody());
+        assertEquals(ErrorCode.NOT_FOUND.name(), entity.getBody().getCode());
+        // 报文里回显路径，调用方一眼能看出是自己把 baseURL 和路径拼了两遍
+        assertTrue(entity.getBody().getMessage().contains("api/v1/knowledge/search/api/v1/knowledge/search"));
     }
 
     @Test


### PR DESCRIPTION
路径不存在时返回 `404 NOT_FOUND`，不再被兜底成 `500 INTERNAL_ERROR`。

## 问题

`GlobalExceptionHandler` 没有 `NoResourceFoundException` 的分支，于是每个匹配不到 handler 的请求都掉进最后的 `@ExceptionHandler(Exception.class)`：

```java
log.error("request failed, errorCode={}", ErrorCode.INTERNAL_ERROR, e);
return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
```

三个后果：

1. **调用方被误导** —— 收到 500 会以为服务端挂了，实际只是自己 URL 写错
2. **日志被淹没** —— 每个错误 URL 都产生一条 ERROR 加约 50 行堆栈，真故障淹在噪音里
3. **语义错误** —— 路径不存在是客户端错误，不该记为服务端内部错误

## 两个真实案例

**外部服务调用**：baseURL 和请求路径都写成了完整路径，拼出

```
/api/v1/knowledge/search/api/v1/knowledge/search
```

服务端答 `500 INTERNAL_ERROR`，日志里一条 ERROR 加满屏堆栈。调用方从这个响应完全看不出是自己拼错了。

**本项目排查时**：请求模型状态接口写成 `/api/v1/settings/model-status`（正确是 `/api/v1/system/model-status`），拿到 `INTERNAL_ERROR`，一度误判成模型服务不可用，绕了一圈才发现只是路径错。

## 改动

新增一个 handler，放在兜底之前：

```java
@ExceptionHandler(NoResourceFoundException.class)
public ResponseEntity<Result<Void>> handleNoResourceFound(NoResourceFoundException e) {
    log.info("request rejected, errorCode={}, path={}", ErrorCode.NOT_FOUND, e.getResourcePath());
    return ResponseEntity.status(HttpStatus.NOT_FOUND)
            .body(Result.failure(ErrorCode.NOT_FOUND, "no handler for " + e.getResourcePath()));
}
```

`ErrorCode.NOT_FOUND(404)` 是既有错误码，无需新增。报文回显请求路径，调用方一眼能看出问题；日志降为一行 info，不打堆栈。

## 验证

**单测**：新增 `shouldAnswerAnUnknownPathWithNotFoundRatherThanInternalError`，断言状态码、错误码与路径回显。`GlobalExceptionHandlerTest` 4 → 5 个用例，全仓 833 → 834 个测试，全部通过。

**真实请求**（临时端口 20010 起服务，带合法 JWT）：

| 请求 | 结果 |
| --- | --- |
| `/api/v1/settings/model-status`（错误路径） | `404`，body `{"code":"NOT_FOUND","message":"no handler for api/v1/settings/model-status"}` |
| `/api/v1/system/model-status`（正确路径） | `200` |
| 服务端日志 | `INFO` 一行，**Spring 堆栈 0 行** |

## 未覆盖的同类情况

`HttpRequestMethodNotSupportedException`（方法不匹配，应 405）目前仍走兜底报 500，是同一类问题。本次没动，因为它需要单独确认对现有客户端的影响面 —— 如果需要，可以另开一个 PR 一并规整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
