### PR TITLE
feat: 检索质量闭环、内容治理、URL 导入与可观测（M10-M13），并修复图谱抽取被截断

### DIFF
--- a/kb-rag-deploy/.env.example
+++ b/kb-rag-deploy/.env.example
@@ -194,3 +194,35 @@ GRAPH_ENTITY_MATCH_LIMIT=10
 # 抽取任务一轮提交的分片数（进度上报粒度；每次 LLM 调用固定 1 分片）与轮内并发
 GRAPH_EXTRACT_BATCH_SIZE=10
 GRAPH_EXTRACT_CONCURRENCY=2
+# 单次抽取的生成上限。不能复用 CHAT_MAX_TOKENS（那是给一行 query 改写用的 128）：
+# 抽取要输出整段的实体关系 JSON，预算耗尽会把 JSON 截断，解析器只能拒绝，分片被计入"跳过"
+GRAPH_EXTRACT_MAX_TOKENS=2048
+
+# --- 检索质量闭环（M10，docs/M10-CONTRACTS.md §2.2）---
+# 检索洞察记录开关：关闭后仅停止新增记录，报表端点与清理仍对存量行生效
+INSIGHT_ENABLED=true
+# 洞察行保留天数：洞察是统计不是取证，到期直接删除，不像审计那样先归档到对象存储
+INSIGHT_RETENTION_DAYS=90
+# 到期清理每批删除行数与调度（cron 含空格必须加引号，理由同 APP_SNAPSHOT_CLEANUP_CRON）
+INSIGHT_CLEANUP_BATCH_SIZE=5000
+INSIGHT_CLEANUP_CRON="0 45 3 * * *"
+# --- 内容治理（M11，docs/M11-CONTRACTS.md §2.2）---
+# 回收站保留天数：超期后定时任务自动彻底删除（等同 purge，含两个检索引擎副本）
+TRASH_RETENTION_DAYS=30
+# 自动清除每批处理的文档数与调度（cron 含空格必须加引号，理由同 INSIGHT_CLEANUP_CRON）
+TRASH_PURGE_BATCH_SIZE=100
+TRASH_PURGE_CRON="0 10 4 * * *"
+# 定时清除总开关：关闭后回收站文档永久保留，仅能手动 purge
+TRASH_PURGE_ENABLED=true
+
+# --- 数据接入：URL 导入与增量同步（M12，docs/M12-CONTRACTS.md §3）---
+# 单页抓取超时（毫秒）与页面体积上限（MB，流式计数，超限即断）
+WEB_IMPORT_FETCH_TIMEOUT_MS=10000
+WEB_IMPORT_MAX_PAGE_SIZE_MB=10
+# 手动跟随重定向的最大跳数（每一跳都重过 SSRF 防线）
+WEB_IMPORT_MAX_REDIRECTS=3
+# 定时同步调度与开关（cron 含空格必须加引号，理由同 APP_SNAPSHOT_CLEANUP_CRON）
+WEB_IMPORT_SYNC_CRON="0 30 2 * * *"
+WEB_IMPORT_SYNC_ENABLED=true
+# 单轮定时同步处理的登记数上限（按 id 升序取一批，单条失败不中断本轮）
+WEB_IMPORT_SYNC_BATCH_SIZE=50

--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -6,6 +6,62 @@
 
 ## [Unreleased]
 
+### Added
+
+- **运维可观测：Prometheus 业务指标（M13，docs/M13-CONTRACTS.md）**：kb-rag-server 自本版起
+  可被 Prometheus 抓取——补齐 `micrometer-registry-prometheus` 依赖激活既有 actuator 的
+  `/actuator/prometheus` 端点（JVM/HTTP 基础指标随 actuator 自动配置免费提供）；新增业务
+  指标：`kb_search_seconds`（Timer，标签 source=console/open_api、zero_hit、degraded，
+  preview 管理流量不计入）、`kb_task_completed_total`（Counter，type × success/failed）、
+  `kb_task_backlog`（Gauge，pending/running 抓取时实查 DB，DB 异常返回 NaN 不影响抓取）、
+  `kb_openapi_rejected_total`（Counter，按 error_code）、`kb_websource_sync_total`
+  （Counter，M12 四态）。纯新增：无表变更、无新环境变量、无端点行为变化；该端点与
+  health 同口径暂无鉴权，生产由部署侧网络隔离
+- **数据接入：URL 导入与增量同步（M12，docs/M12-CONTRACTS.md）**：①网页登记——
+  `POST/GET /kb/{kbId}/web-sources` 登记即抓/列表，`POST /web-sources/{id}/sync` 手动同步，
+  `PUT`/`DELETE /web-sources/{id}` 定时同步开关与移除登记；抓取产物统一走文档上传
+  管线（URL 派生稳定文件名，重抓同名加版本、content_hash 去重），登记与文档为弱绑定——
+  移除登记不删文档；②增量同步四态结果（SUCCESS/UNCHANGED/SKIPPED/FAILED）落行可见，
+  内容 hash 未变不建版本，绑定文档在回收站则跳过；③SSRF 防线：仅 http/https、拒内网/
+  回环/链路本地地址，重定向手动跟随且逐跳复验；④parser 新增通用 HTML 页面解析器
+  （非聊天记录通道）；web 知识库详情新增「网页导入」Tab；新增 `WEB_IMPORT_FETCH_TIMEOUT_MS` /
+  `WEB_IMPORT_MAX_PAGE_SIZE_MB` / `WEB_IMPORT_MAX_REDIRECTS` / `WEB_IMPORT_SYNC_CRON` /
+  `WEB_IMPORT_SYNC_ENABLED` / `WEB_IMPORT_SYNC_BATCH_SIZE`；OpenAPI 升 0.13.0-m12
+- **内容治理（M11，docs/M11-CONTRACTS.md）**：①审核发布——知识库级 `review_required`
+  开关（`PUT /kb/{kbId}/governance`），开启后新上传文档初始为 DRAFT，经
+  submit-review/approve/reject 状态机（DRAFT|REJECTED → PENDING_REVIEW →
+  PUBLISHED|REJECTED）发布后才参与检索；②文档有效期——`PUT /documents/{docId}/validity`
+  设置/清除 `effective_at`/`expires_at` 窗口，仅窗口内参与检索，expires_at 设为过去即
+  立即下架；③回收站——trash 列表/restore/purge 端点，超过保留期由定时任务自动清除；
+  治理三态均收敛为检索时的活跃集 DB 谓词过滤，不写引擎，状态变更即时生效（时间窗
+  穿越靠缓存 TTL 5 分钟内收敛）；web 知识库详情新增发布状态/有效期列、审核操作、
+  「回收站」Tab 与审核开关；新增 `TRASH_RETENTION_DAYS` / `TRASH_PURGE_BATCH_SIZE` /
+  `TRASH_PURGE_CRON` / `TRASH_PURGE_ENABLED`；OpenAPI 升 0.12.0-m11；存量文档升级后
+  默认 PUBLISHED/无有效期/不在回收站，检索结果与升级前一致；已发布应用快照不受
+  治理影响
+
+### Changed
+
+- **上传白名单默认值变更（M12，醒目提示）**：`UPLOAD_ALLOWED_EXTENSIONS` 默认值新增
+  `html`（网页抓取产物走上传管线的前提）。显式设置过该变量的部署需自行追加 `html`，
+  否则 URL 导入首次同步即报“不支持的文件类型”；html 无魔数，与 txt/md/csv 同样仅验
+  扩展名与大小
+- **`DELETE /api/v1/documents/{docId}` 语义变更（M11，醒目提示）**：URL 不变，但删除
+  由不可逆改为移入回收站（检索立即下线、数据保留、保留期内可 `POST
+  /documents/{docId}/restore` 还原）；原来的不可逆删除（含两个检索引擎副本）迁移至
+  `DELETE /documents/{docId}/purge`，且仅对回收站内文档有效（两段式防误删）。依赖旧
+  语义的调用方需改为先 DELETE 再 purge
+
+### Added
+
+- **检索质量闭环（M10，docs/M10-CONTRACTS.md）**：①检索反馈从 log-only 升级为持久化闭环——
+  `POST /retrieval-feedback` payload 不变（兼容红线）但落库为可管理行，新增知识库维度的反馈
+  列表与转评测集（case source=FEEDBACK）/忽略端点，web 知识库详情新增「反馈管理」Tab；
+  ②检索洞察：控制台调试与 OpenAPI 检索自动记录脱敏摘要/命中数/降级标记（评测运行不记录，
+  不存原文），新增明细分页与内容缺口报表端点（零命中率/Top 未命中 query 归一化分组），
+  web 新增「检索洞察」Tab；新增 `INSIGHT_ENABLED` / `INSIGHT_RETENTION_DAYS` /
+  `INSIGHT_CLEANUP_BATCH_SIZE` / `INSIGHT_CLEANUP_CRON`；OpenAPI 升 0.11.0-m10
+
 ### Changed
 
 - **full 模式向量引擎定为 Qdrant（不兼容变更）**：`VECTOR_ENGINE` 合法取值为 `es | qdrant`。

--- a/kb-rag-deploy/README.md
+++ b/kb-rag-deploy/README.md
@@ -9,13 +9,15 @@ OpenAPI 接口契约、备份/预检脚本与总体文档。
 React 管理台，三者围绕 MySQL（事实源）/ Elasticsearch 与 Qdrant（检索引擎）/
 MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过 docker-compose 一键拉起中间件。**
 
-> 本仓库当前状态：**一期（M1-M7）已完成，二期进行中（M8 已完成、M9 开发中）**。
+> 本仓库当前状态：**一期（M1-M7）与二期（M8-M9）已完成，核心能力增强（M10-M13）已完成**。
 > 一期交付上传解析→混合检索（向量+BM25+图路三路融合）→分片标注→评测闭环→应用发布→
-> 多知识库路由→索引快照回滚→GraphRAG 的完整链路；二期在此基础上增强聊天记录导入
-> （TXT/HTML 格式、本地 OCR 兜底、重叠滑窗归并、映射档案维护界面，M8 已完成）与标注
-> 语义/图搜能力（M9，开发中，其内容暂不纳入本文档范围）。
+> 多知识库路由→索引快照回滚→GraphRAG 的完整链路；二期增强聊天记录导入
+> （TXT/HTML 格式、本地 OCR 兜底、重叠滑窗归并、映射档案维护界面，M8）与标注
+> 语义/图搜能力（M9）；核心能力增强补齐检索质量闭环（M10）、内容治理（M11）、
+> URL 导入与增量同步（M12）、Prometheus 业务指标（M13），见下文
+> [核心能力增强（M10-M13）](#核心能力增强m10-m13)。
 > 各里程碑契约见 [`docs/M1-CONTRACTS.md`](docs/M1-CONTRACTS.md) ~
-> [`docs/M9-CONTRACTS.md`](docs/M9-CONTRACTS.md)；系统整体架构与核心流程图见
+> [`docs/M13-CONTRACTS.md`](docs/M13-CONTRACTS.md)；系统整体架构与核心流程图见
 > [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) 与 [`docs/FLOWS.md`](docs/FLOWS.md)。
 
 ## 目录
@@ -34,6 +36,7 @@ MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过 dock
 - [GraphRAG 知识图谱（M7，可选）](#graphrag-知识图谱m7可选)
 - [Demo 数据集与聊天记录映射（M3）](#demo-数据集与聊天记录映射m3)
 - [聊天记录格式扩展与映射维护（M8）](#聊天记录格式扩展与映射维护m8)
+- [核心能力增强（M10-M13）](#核心能力增强m10-m13)
 - [接口契约（OpenAPI）](#接口契约openapi)
 - [开源工程文档](#开源工程文档)
 
@@ -376,6 +379,24 @@ docker compose -f docker-compose.lite.yml --profile graph up -d
 
 详见 [`docs/M8-CONTRACTS.md`](docs/M8-CONTRACTS.md)。
 
+## 核心能力增强（M10-M13）
+
+四个里程碑均为纯新增能力，无端点行为变化；契约见 `docs/M10~M13-CONTRACTS.md`：
+
+- **M10 检索质量闭环**：检索反馈持久化与转评测集、检索洞察（脱敏摘要/零命中/
+  降级标记）与内容缺口报表；新增 `INSIGHT_ENABLED` / `INSIGHT_RETENTION_DAYS` /
+  `INSIGHT_CLEANUP_BATCH_SIZE` / `INSIGHT_CLEANUP_CRON`
+- **M11 内容治理**：库级审核开关与 DRAFT→PENDING_REVIEW→PUBLISHED|REJECTED 状态机、
+  文档有效期窗口、回收站（trash/restore/purge + 保留期自动清除）；新增
+  `TRASH_RETENTION_DAYS` / `TRASH_PURGE_BATCH_SIZE` / `TRASH_PURGE_CRON` / `TRASH_PURGE_ENABLED`；
+  注意 `DELETE /documents/{docId}` 语义已改为移入回收站（见 CHANGELOG 醒目提示）
+- **M12 URL 导入与增量同步**：网页登记即抓、定时增量同步（四态结果、hash 去重）、
+  SSRF 防线；新增 `WEB_IMPORT_*` 六个变量；注意 `UPLOAD_ALLOWED_EXTENSIONS` 默认值已含 `html`
+- **M13 Prometheus 业务指标**：`/actuator/prometheus` 可抓取 `kb_search_seconds` /
+  `kb_task_completed_total` / `kb_task_backlog` / `kb_openapi_rejected_total` /
+  `kb_websource_sync_total` 及 JVM/HTTP 基础指标；无新环境变量，该端点与 health 同口径
+  暂无鉴权，生产由部署侧网络隔离
+
 ## 接口契约（OpenAPI）
 
 - [`docs/openapi/kb-server.yaml`](docs/openapi/kb-server.yaml)：kb-rag-server 管理台
@@ -415,6 +436,6 @@ python3 -c "import yaml, sys; yaml.safe_load(open(sys.argv[1]))" docs/openapi/kb
 - [知识库需求文档（v1.14，唯一事实源）](docs/知识库需求文档.md)
 - [系统架构总览（ARCHITECTURE.md）](docs/ARCHITECTURE.md) /
   [核心流程图（FLOWS.md）](docs/FLOWS.md)
-- [M1](docs/M1-CONTRACTS.md) ~ [M9 开发契约](docs/M9-CONTRACTS.md)（按里程碑记录
+- [M1](docs/M1-CONTRACTS.md) ~ [M13 开发契约](docs/M13-CONTRACTS.md)（按里程碑记录
   实现细节与已接受偏离）
 - [OpenAPI 定义](docs/openapi/)

--- a/kb-rag-deploy/docs/ARCHITECTURE.md
+++ b/kb-rag-deploy/docs/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # kb-rag 架构文档
 
-> 版本：v1.1（基线 = 一期 M1-M7 + 二期 M8/M9 及其后修复合并进各仓 main 的状态，2026-07-27；v1.0 基线为 M8）
-> 日期：2026-07-27
+> 版本：v1.2（基线 = 一期 M1-M7 + 二期 M8/M9 + 核心能力增强 M10-M13，2026-07-28；v1.1 基线为 M9，v1.0 基线为 M8）
+> 日期：2026-07-28
 > 作者：RichardFyoung / Claude
 >
 > **文档定位**：本文描述系统的实际实现架构（以代码为准），与以下文档互补——
 > - `知识库需求文档.md`：需求与设计决策的唯一事实源（"为什么做、做什么"）
-> - `M1~M9-CONTRACTS.md`：各里程碑的实现契约与已接受偏离（"每一期怎么做的"）
+> - `M1~M13-CONTRACTS.md`：各里程碑的实现契约与已接受偏离（"每一期怎么做的"）
 > - `openapi/kb-server.yaml`、`openapi/kb-parser.yaml`：HTTP 接口的唯一契约源
 > - `FLOWS.md`：核心流程图（与本文配套阅读）
 
@@ -91,14 +91,14 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | 模块 | 职责 | 关键内容 |
 |---|---|---|
 | **kb-common** | 无 Spring 依赖的基础件 | `Result` 统一响应信封、`ErrorCode`、`BizException`/`ProviderException`、`JsonUtil`/`HashUtil`、`RequestIdHolder`、`KbConstants`（业务 ID 前缀与 `kb-sk-` Key 前缀） |
-| **kb-domain** | 实体 + 端口 + 纯领域算法 | MyBatis-Plus 实体/Mapper（与 23 张业务表一一对应）、30+ 枚举、60+ 领域模型、**13 个出站端口接口**（`domain.port`）、无状态领域服务（切分/融合/指纹/评测指标/门禁裁决/标注迁移相似度等纯函数）、`KbProperties`（`@ConfigurationProperties(prefix="kb")`，二十余个嵌套段） |
-| **kb-infrastructure** | 端口实现，按外部依赖分包 | `search.es` / `search.qdrant` / `graph` / `provider.{chat,embedding,rerank,vision}` / `storage` / `parser` / `notify` / `config` |
-| **kb-app** | 应用编排层（架构主体） | 15 个业务域包：`kb` / `document` / `index` / `retrieval` / `graph` / `annotation` / `eval` / `appcenter` / `openapi` / `chat` / `alert` / `dict` / `auth` / `system` / `config` |
-| **kb-api** | HTTP 边界与装配点 | 23 个 Controller、过滤器/拦截器、SSE、健康探针、`application.yml`、Flyway 脚本；`@SpringBootApplication(scanBasePackages="io.kbrag")` 为唯一装配点 |
+| **kb-domain** | 实体 + 端口 + 纯领域算法 | MyBatis-Plus 实体/Mapper（与 26 张业务表一一对应）、30+ 枚举、60+ 领域模型、**14 个出站端口接口**（`domain.port`）、无状态领域服务（切分/融合/指纹/评测指标/门禁裁决/标注迁移相似度等纯函数）、`KbProperties`（`@ConfigurationProperties(prefix="kb")`，二十余个嵌套段） |
+| **kb-infrastructure** | 端口实现，按外部依赖分包 | `search.es` / `search.qdrant` / `graph` / `provider.{chat,embedding,rerank,vision}` / `storage` / `parser` / `notify` / `web` / `config` |
+| **kb-app** | 应用编排层（架构主体） | 20 个业务域包：`kb` / `document` / `index` / `retrieval` / `graph` / `annotation` / `eval` / `appcenter` / `openapi` / `chat` / `alert` / `dict` / `auth` / `system` / `config` / `feedback` / `insight` / `governance` / `websource` / `metrics` |
+| **kb-api** | HTTP 边界与装配点 | 24 个 Controller、过滤器/拦截器、SSE、健康探针、`application.yml`、Flyway 脚本；`@SpringBootApplication(scanBasePackages="io.kbrag")` 为唯一装配点 |
 
 分层规则：Controller 只依赖 kb-app 的 Service 与 kb-domain 的 model/enum；kb-app 只依赖端口接口，**从不依赖 kb-infrastructure 具体类**；kb-infrastructure 实现端口，与 kb-app 互不感知。
 
-### 3.2 领域端口与实现（13 个）
+### 3.2 领域端口与实现（14 个）
 
 | 端口 | 实现（默认 / 降级） | 说明 |
 |---|---|---|
@@ -115,6 +115,7 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | `WebhookNotifier` | `HttpWebhookNotifier` | 告警外发 |
 | `TokenEstimator` | `SimpleTokenEstimator` | 分片长度以 token 计、`max_content_length` 预算 |
 | `VersionPinChecker` | `AppVersionPinChecker` | 被应用版本可见集引用的文档版本禁止归档（已下线版本同样 pin——chunk 正文只在 MySQL） |
+| `WebPageFetcher`（M12） | `HttpWebPageFetcher` | 网页抓取（URL 导入/增量同步）：SSRF 防护由调用侧经 kb-domain 的 `UrlGuard` 前置校验，Content-Type 白名单、体积上限、超时控制 |
 
 **零 Key / 能力开关统一装置**：`ModelProviderConfig` 是唯一读模型凭据的地方，凭据为空即注入 `Unconfigured*` 实现；`GraphStoreConfig`（NEO4J_URI 空 → `DisabledGraphStore`）与 `QdrantClientConfig`（QDRANT_URI 空 → 不建 client、不注册健康探针）镜像同一模式。上游代码只写 `isConfigured()/isEnabled()` 一个分支，全链路无 null 检查——这是需求 §5"防御式编程只做一处且高复用"的落地点。
 
@@ -198,9 +199,9 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | `ApiAuditArchiveService` | cron 03:30 | 审计日志归档 MinIO → 分批物理删除 |
 | `AppSnapshotRetentionService` | cron 04:15 | SUPERSEDED 版本快照按保留数清理（RELEASED 永不清理） |
 
-### 3.8 数据模型（23 张业务表，Flyway V1-V11）
+### 3.8 数据模型（26 张业务表，Flyway V1-V14）
 
-全部 InnoDB，统一 `id / created_at / updated_at / lock_version / deleted`，审计字段由 `AuditFieldFiller` 填充，业务 ID 带类型前缀（kb/doc/dv/ck/task/img/upt/an/evds/evc/evr/evre/app/av/ak/aud/smp）。
+全部 InnoDB，统一 `id / created_at / updated_at / lock_version / deleted`，审计字段由 `AuditFieldFiller` 填充，业务 ID 带类型前缀（kb/doc/dv/ck/task/img/upt/an/evds/evc/evr/evre/app/av/ak/aud/smp/rfb/si/ws）。
 
 | 迁移 | 表 / 变更 |
 |---|---|
@@ -215,6 +216,9 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | V9（M8） | `t_kb_source_mapping`（映射档案，启动播种内置模板、只补缺不覆盖） |
 | V10（M9） | `t_kb_chunk` 加 `parent_start_offset` / `parent_end_offset`（子片在父片中的 [起,止) 字符偏移，切分副产物、不做事后反查；子片编辑/合并/拆分及父片编辑时失效置 null） |
 | V11（M9 后修复） | `t_kb_auth_token`（管理台登录 Token 落库，仅存 SHA-256 哈希，24h TTL 语义不变） |
+| V12（M10） | `t_kb_retrieval_feedback`（检索反馈，带幂等键）/ `t_kb_search_insight`（检索洞察埋点，只增不改） |
+| V13（M11） | `t_kb_document` 加 `publish_status` / `review_note` / `effective_at` / `expires_at` / `trashed` / `trashed_at`；`t_kb_knowledge_base` 加 `review_required` |
+| V14（M12） | `t_kb_web_source`（网页来源登记：URL/content_hash/四态同步状态/派生文档关联） |
 
 引擎侧可过滤字段全集（Qdrant 标量 / ES filter，建索引时显式声明）：`kb_id`、`doc_id`、`document_version_id`、`enabled`、`parent_id`、`chunk_type`、`tag_ids`、`session_id`、`sender`、`msg_time`、`chunk_seq`；其余 metadata 只存 MySQL。新增可过滤维度视为 schema 变更，走索引重建迁移。
 
@@ -233,14 +237,14 @@ Python 3.11+ / FastAPI + Uvicorn / pydantic 2。解析实现：**PyMuPDF**（pdf
 | 端点 | 用途 |
 |---|---|
 | `GET /health` | 存活探针 |
-| `POST /api/v1/parse` | multipart `file` + `file_ext`（pdf/docx/txt/md/xlsx/csv）→ markdown + 按页文本（`scanned`/`ocr_source` 标记）+ 图片 base64（`kind=embedded|page_render`）+ `warnings[]` |
+| `POST /api/v1/parse` | multipart `file` + `file_ext`（pdf/docx/txt/md/xlsx/csv/html/htm，html 为 M12 增量）→ markdown + 按页文本（`scanned`/`ocr_source` 标记）+ 图片 base64（`kind=embedded|page_render`）+ `warnings[]` |
 | `POST /api/v1/parse/chat` | multipart `file` + `file_ext`（csv/xlsx/txt/html）+ 可选 `mapping_profile`/`profile_yaml` → 统一 ChatMessage 会话结构 + `skipped` 统计 |
 
 ### 4.3 模块结构
 
 - `main.py`：端点 + `ThreadPoolExecutor(4)` 跑阻塞解析 + `asyncio.wait_for` 300s 超时；所有可恢复失败归一化为信封错误。
 - `config.py`：全部常量单点（100MB 文件上限、zip 解压 500MB/2000 条目上限、扫描页文本阈值、图片 100 张/10MB 上限、TXT 不匹配行 30% 失败线等）。
-- `parsers/`：`BaseParser` 策略接口 + `registry.py` 查表分派；pdf（扫描页判定 + 渲染，扫描页不再另抽内嵌图防双计）/ docx（段落表格图片按原始顺序，占位符插回）/ excel+csv（markdown 表格，每 sheet 一个 page_no）/ text。
+- `parsers/`：`BaseParser` 策略接口 + `registry.py` 查表分派；pdf（扫描页判定 + 渲染，扫描页不再另抽内嵌图防双计）/ docx（段落表格图片按原始顺序，占位符插回）/ excel+csv（markdown 表格，每 sheet 一个 page_no）/ text / html（M12 通用 HTML 页面：仅标准库 html.parser，标题/块级分段→markdown，零出站请求）。
 - `chat/`：`parser.py` 按格式编排；`mapping.py`（MappingProfile：csv/xlsx 候选列名 + txt 行正则 + html 选择器三段配置，来源优先级 请求内联 profile_yaml > 本地 mappings/*.yml > 按扩展名内置默认）；`txt_adapter.py`（行首正则 + 续行归并）；`html_adapter.py`（仅标准库的最小 DOM 选择器引擎，剥 script/style，img 只判存在不下载）；`normalize.py`（时间戳/消息类型归一）。语音/视频消息剔除并计入 `skipped`。
 - `ocr/engine.py`：`OcrEngine` 策略（NoOp / Paddle 懒加载），`OCR_ENGINE=paddle` 未装依赖时启动 fast-fail；单页 30s 超时、按页降级绝不整篇失败。三级次序：**server 侧 VLM（有 Key）→ 本地 PaddleOCR（离线）→ 跳过**；本地 OCR 成功回填 `pages[].text` 并置 `ocr_source=paddle`，server 据此跳过 VLM。
 - `security.py`：zip-slip/zip 炸弹校验、defusedxml 全局加固（XXE）；解析阶段无任何出站网络请求（SSRF 基线）。
@@ -265,7 +269,7 @@ Vite 8 + React 18 + TypeScript 6 + Ant Design 5 + react-router-dom 6 + axios；l
 | 路由 | 页面 |
 |---|---|
 | `/login`、`/change-password` | 登录（防爆破提示）、首登强制改密 |
-| `/kb`、`/kb/:kbId` | 知识库列表；详情（文档上传/状态轮询/分片标注 ChunkDrawer/版本 VersionDrawer/索引配置/聊天导入向导/图谱 GraphTab） |
+| `/kb`、`/kb/:kbId` | 知识库列表；详情（文档上传/状态轮询/审核与有效期操作/分片标注 ChunkDrawer/版本 VersionDrawer/索引配置/聊天导入向导；图谱 GraphTab / 反馈管理 / 检索洞察 / 回收站 / 网页导入等 Tab） |
 | `/search` | 检索调试（参数面板、分数明细、degraded 告警、收进评测集） |
 | `/chat` | 问答调试（JWT 走 `/apps/{id}/chat-preview` SSE） |
 | `/apps`、`/apps/:appId` | 应用中心（配置 / 版本与门禁 / API 调试三 tab） |
@@ -298,7 +302,7 @@ Vite 8 + React 18 + TypeScript 6 + Ant Design 5 + react-router-dom 6 + axios；l
 | `scripts/benchmark.sh` | 纯 bash+curl 压测（P50/P95/P99），验收口径 P95<2s；`seed-bench.py` 零 Key 直灌 10 万分片种子数据 |
 | `demo/` | 4 篇原创文档（md/docx/pdf/xlsx 各一，字节级可复现生成）+ `eval-cases.json`（10 条，含文档级锚定图片 case，按文件名+content_hash 关联导入） |
 | `mappings/` | 聊天记录列名映射模板分发（memotrace 等） |
-| `docs/` | 需求文档、M1-M9 契约、OpenAPI（`kb-server.yaml` 0.10.0-m9，75 条路径 / `kb-parser.yaml` 0.9.0-m8，3 端点）、备份恢复手册、本文档与 `FLOWS.md` |
+| `docs/` | 需求文档、M1-M13 契约、OpenAPI（`kb-server.yaml` 0.13.0-m12，92 条路径 / `kb-parser.yaml` 0.12.0-m12，3 端点）、备份恢复手册、本文档与 `FLOWS.md` |
 
 ---
 
@@ -318,6 +322,7 @@ Vite 8 + React 18 + TypeScript 6 + Ant Design 5 + react-router-dom 6 + axios；l
 
 - `request_id` 全链路：`RequestIdFilter` 入口生成 → MDC → 响应头 → `X-Request-Id` 透传 parser 与 Provider 调用日志 → `TaskDecorator` 带入异步线程。
 - 健康：Actuator 组合探针（ES 必选；Qdrant/Neo4j 仅配置时注册；MinIO；parser `/health`）。
+- 指标（M13）：`/actuator/prometheus` 可直接抓取（micrometer-registry-prometheus，与 health 同口径暂不鉴权）；`KbMetrics` 门面承载四类业务指标——`kb_search_seconds`（Timer，source/zero_hit/degraded 标签）、`kb_task_completed_total`、`kb_openapi_rejected_total`、`kb_websource_sync_total`；`TaskBacklogMetrics` 提供 `kb_task_backlog`（pending/running 两支 gauge，DB 异常回 NaN 不失败抓取）；埋点全部骑在既有横切点上，记录失败绝不影响业务路径。
 - 告警：`AlertEvaluator` 三类触发 + 静默期，Webhook 未配置降级界面红点；日志仅 info/error、英文、错误码占位符。
 
 ### 7.4 一致性手法汇总

--- a/kb-rag-deploy/docs/FLOWS.md
+++ b/kb-rag-deploy/docs/FLOWS.md
@@ -1,7 +1,7 @@
 # kb-rag 流程图文档
 
-> 版本：v1.1（基线与 `ARCHITECTURE.md` 相同 = M1-M9 及其后修复合并进 main 的状态）
-> 日期：2026-07-27
+> 版本：v1.2（基线与 `ARCHITECTURE.md` 相同 = M1-M13 及其后修复的状态）
+> 日期：2026-07-28
 > 作者：RichardFyoung / Claude
 >
 > 图使用 Mermaid 绘制（GitHub / 主流 IDE 原生渲染）。每张图标注对应的核心类与契约出处，与代码不一致时以代码为准并须在同一 PR 内修订本文档（项目铁律②）。

--- a/kb-rag-deploy/docs/M10-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M10-CONTRACTS.md
@@ -1,0 +1,67 @@
+# M10 开发契约（检索质量闭环 · 增量于 M1-M9 契约）
+
+> 需求依据：知识库需求文档 §4.5（检索结果反馈"沉淀为评测集素材"——M4b 只落了 GOOD 的收集端点、BAD 仅打日志，本期把反馈真正持久化并闭环到评测集）、§4.6（评测体系，本期不改运行器）、§4.7（发布门禁已于 M4c 完整落地，本期**不重复建设**）。新增能力：**检索洞察（未命中/降级分析）**——管理台检索与开放 API 检索均落洞察行，聚合出"内容缺口报表"，回答"用户在搜什么却搜不到"。
+> 全局约定沿用 M1 §0（@author owlzhangfq@gmail.com、英文注释、info/error 日志带错误码、lombok、CollectionUtils 判空、无魔法值、fast-fail 一处、不主动 commit）；web 枚举展示走 metaOf。
+
+## 0. 范围与边界
+
+- **本期做**：①反馈持久化与管理（列表/转评测用例/忽略）；②检索洞察记录与聚合报表（零命中、降级、Top 未命中 query 分组）；③洞察数据保留期清理。
+- **本期不做**：发布前评测卡点（M4c ReleaseGateService 已交付双跑+三态裁决+容差，验收沿用）；开放 API 的最终用户反馈端点（需要终端用户身份，属权限体系后期）；洞察数据 MinIO 归档（保留期直接删，量级与审计不同）。
+- **兼容红线**：`POST /api/v1/retrieval-feedback` 入参 payload 不变（`kb_id/query/chunk_id/verdict`），行为从"仅日志"升级为"落库"；前端旧调用无需改动即获得持久化。
+
+## 1. 数据模型（Flyway V12）
+
+| 表 | 列 |
+|---|---|
+| t_kb_retrieval_feedback | `feedback_id` UK、`kb_id` IDX、`query` TEXT（原文，供转 case 用）、`chunk_id`、`doc_id`（服务端由 chunk 反查冗余，chunk 已删时可空）、`verdict`(GOOD/BAD)、`status`(NEW/CONVERTED/DISMISSED) IDX、`converted_case_id`（可空，转换后回填）、`note`（可空）+ 通用列；复合索引 `idx_kb_status(kb_id, status)` |
+| t_kb_search_insight | `insight_id` UK、`kb_id` IDX、`source`(CONSOLE/OPEN_API)、`query_digest` VARCHAR(200)（**按 KB 脱敏规则处理后截断，绝不存原文**，与 t_kb_api_audit_log 同口径）、`query_hash` CHAR(64) IDX（归一化后 SHA-256，未命中分组键：trim + 小写 + 连续空白折叠）、`result_count`、`top_score` DOUBLE（可空，首节点分数）、`zero_hit` TINYINT（`result_count=0` 派生冗余，聚合扫描列）、`degraded` JSON（可空）、`request_id` + 通用列；复合索引 `idx_kb_zero_created(kb_id, zero_hit, created_at)` |
+
+- `t_kb_eval_case.source` 枚举增 `FEEDBACK`（varchar 列无 DDL；CaseSource 枚举与 web metaOf 同步增）
+- 洞察行**不含用户身份**（当前无用户体系），request_id 供与日志/审计关联
+
+## 2. kb-rag-server
+
+### 2.1 反馈闭环（RetrievalFeedbackService，kb-app 新包 feedback）
+- `POST /api/v1/retrieval-feedback`：落库（GOOD 与 BAD 均落）；服务端由 chunk_id 反查 doc_id（chunk 不存在不拒绝——反馈可能晚于分片删除，doc_id 置空并 info 日志）；重复提交不去重（反馈是事件不是状态）
+- `GET /api/v1/kb/{kbId}/retrieval-feedback?verdict=&status=&page=&size=`：分页列表，最新优先（分页默认/上限沿用 20/200 惯例）
+- `POST /api/v1/retrieval-feedback/{feedbackId}/convert`：`{dataset_id}` → 复用 `EvalDatasetService.collectFromRetrieval` 建 case（`source=FEEDBACK`），成功后 `status=CONVERTED` 且回填 `converted_case_id`；仅 `status=NEW` 可转，`verdict=BAD` 不可转（BAD 的价值在洞察与统计，不构成正向证据）；chunk 已删 → INVALID_PARAM 明确提示
+- `POST /api/v1/retrieval-feedback/{feedbackId}/dismiss`：`status=DISMISSED`；仅 NEW 可忽略
+- 状态机：`NEW → CONVERTED | DISMISSED`，终态不可再变（重复调用 → INVALID_PARAM）
+
+### 2.2 检索洞察（SearchInsightService，kb-app 新包 insight）
+- **记录点在 API 边界而非 RetrievalService 内部**：评测运行、门禁双跑复用同一检索链路，若埋在链路内会把离线跑污染进报表——
+  - 管理台调试：`SearchController` 检索成功返回后异步记录（source=CONSOLE）
+  - 开放 API：`KnowledgeApiService` 的 search 与 chat 检索完成后异步记录（source=OPEN_API；chat 记录其检索环节的 result_count）；**被拒绝的调用不记洞察**（审计已覆盖）
+- 异步写复用 `AUDIT_EXECUTOR`；写失败仅 error 日志，绝不影响检索响应（与 ApiAuditService 同原则）
+- `GET /api/v1/kb/{kbId}/search-insights?zero_hit=&from=&to=&page=&size=`：分页明细，最新优先
+- `GET /api/v1/kb/{kbId}/search-insights/stats?from=&to=`：聚合报表 `{total, zero_hit_count, zero_hit_rate, degraded_count, top_zero_hit_queries:[{query_digest, count, last_at}]}`——Top 分组按 `query_hash` group by 取 count 前 10，query_digest 取组内最新一条；时间窗缺省近 7 天
+- 保留期清理：`@Scheduled` 每日删除 `kb.insight.retention-days`（默认 90，INSIGHT_RETENTION_DAYS）之前的行，单批 ≤5000 防长事务（沿用审计归档惯例，无 MinIO 归档）
+
+### 2.3 配置键（application.yml 接环境占位符，KbProperties 承载）
+- `kb.insight.retention-days=90`（INSIGHT_RETENTION_DAYS）
+- `kb.insight.enabled=true`（INSIGHT_ENABLED，false 时记录点直接短路，报表端点照常可查历史）
+
+### 2.4 单测（必须，精确断言）
+- 反馈：GOOD/BAD 均落库且 doc_id 反查、chunk 缺失落库不拒绝、convert 委托 collectFromRetrieval 且回填 case id、BAD 不可转、DISMISSED/CONVERTED 终态重复操作被拒、状态机全路径
+- 洞察：query_hash 归一化（大小写/空白折叠等价、不同 query 不同 hash）、zero_hit 派生、digest 脱敏截断复用 QueryDigestFactory、stats 聚合（零命中率、Top 分组排序与取最新 digest）、enabled=false 短路、清理任务边界（保留期内不删）
+- 记录点：评测/门禁路径不产生洞察行（构造 RetrievalService 直调不触发记录的断言）
+
+## 3. kb-rag-web
+
+- 检索调试页：好/坏按钮沿用现端点（行为自动升级为落库），BAD 提交后 toast 文案改"已记录，可在反馈管理查看"
+- 知识库详情新增两个入口（沿用现有 tab/菜单惯例）：
+  - **反馈管理**：列表（verdict/status 筛选）+ 行操作"转入评测集"（评测集选择弹窗）/"忽略"；status 走 metaOf
+  - **检索洞察**：统计卡片（总检索/零命中率/降级次数）+ Top 未命中 query 表 + 明细列表（zero_hit 筛选、时间范围）
+- api 层：`retrievalFeedback.ts` 扩展列表/convert/dismiss；新增 `searchInsight.ts`；types.ts 增 RetrievalFeedbackEntry/SearchInsightEntry/SearchInsightStats/CaseSource 增 FEEDBACK
+
+## 4. kb-rag-deploy（收尾）
+
+- OpenAPI kb-server.yaml：retrieval-feedback 语义更新 + 新增 5 个端点与 schema；版本升 0.11.0-m10
+- .env.example 增 INSIGHT_RETENTION_DAYS/INSIGHT_ENABLED；CHANGELOG 记录
+
+## 5. 验收
+
+1. 调试页点"坏"→ 反馈管理出现 NEW/BAD 行；点"好"后转入评测集 → case source=FEEDBACK 且反馈行 CONVERTED
+2. 发起零命中检索（无关 query）→ 洞察明细出现 zero_hit 行，stats 的 top_zero_hit_queries 含该 query 的脱敏摘要；同 query 大小写变体命中同一分组
+3. 评测运行全程不产生洞察行
+4. `mvn -B -ntp verify` 全绿

--- a/kb-rag-deploy/docs/M11-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M11-CONTRACTS.md
@@ -1,0 +1,83 @@
+# M11 开发契约（内容治理 · 增量于 M1-M10 契约）
+
+> 需求依据：知识库需求文档 §4.2（文档生命周期——本期补齐"入库≠可检索"的治理层：审核发布、有效期、回收站）。当前无用户体系，审核操作不记录"谁"，完整审计属权限体系后期（与 M10 同口径）；本期先把状态机、时间窗与可恢复删除做正确。
+> 全局约定沿用 M1 §0（@author owlzhangfq@gmail.com、英文注释、info/error 日志带错误码、lombok、CollectionUtils 判空、无魔法值、fast-fail 只在 Controller、不主动 commit）；web 枚举展示走 metaOf。
+
+## 0. 范围与边界
+
+- **本期做**：①文档审核发布（KB 级开关 `review_required`，DRAFT→PENDING_REVIEW→PUBLISHED/REJECTED 状态机，未发布不进检索）；②文档有效期（`effective_at`/`expires_at` 时间窗，窗外自动退出检索）；③回收站（删除改为可恢复的移入回收站，超期定时彻底清除，另设立即彻底删除端点）。
+- **本期不做**：审核人身份与审批流（无用户体系）；chunk 级治理（文档级足够，chunk 已有 enabled 开关）；已发布应用版本快照的治理回溯（快照冻结语料是 M4c 的既定语义，见 §2.1）。
+- **核心机制（一个卡点）**：治理三态全部收敛为 `ActiveVersionResolver` 的行过滤——在线检索的可见版本集只从这里出，一行 `trashed=0 AND publish_status='PUBLISHED' AND (effective_at IS NULL OR effective_at<=now) AND (expires_at IS NULL OR expires_at>now)` 即完成门控。**不写任何状态进 ES/Qdrant**：状态变更只翻 DB 行 + invalidate 缓存，无索引重建。有效期的时间性穿越（无人操作、窗口自然到/过期）由可见集缓存 TTL（5 分钟）兜底生效，属可接受延迟。
+- **兼容红线**：
+  - V13 存量文档默认 `publish_status='PUBLISHED'`、无有效期、不在回收站——升级后语料检索行为零变化；
+  - `review_required` 默认 0，新上传自动 PUBLISHED——旧"上传即可检索"流程不变；
+  - `DELETE /api/v1/documents/{docId}` URL 与响应不变，语义从"不可逆硬删"升级为"移入回收站（可恢复）"；原硬删行为由新端点 `DELETE /documents/{docId}/purge` 承接；
+  - 已发布应用版本的快照上下文不经过 ActiveVersionResolver（M4c 冻结语义），治理变更不影响已发布快照的应答——这是特性不是缺陷（发布物答门禁测过的语料）。
+
+## 1. 数据模型（Flyway V13，纯 ALTER 无新表）
+
+| 表 | 变更 |
+|---|---|
+| t_kb_document | 增 `publish_status` VARCHAR(16) NOT NULL DEFAULT 'PUBLISHED'（DRAFT/PENDING_REVIEW/PUBLISHED/REJECTED）、`review_note` VARCHAR(512) NULL（最近一次驳回理由）、`effective_at` DATETIME NULL、`expires_at` DATETIME NULL（NULL=不设界）、`trashed` TINYINT NOT NULL DEFAULT 0、`trashed_at` DATETIME NULL；索引 `idx_kb_publish(kb_id, publish_status)`、`idx_kb_trashed(kb_id, trashed)`、`idx_trashed_at(trashed_at)`（清理扫描列） |
+| t_kb_knowledge_base | 增 `review_required` TINYINT NOT NULL DEFAULT 0 |
+
+- 不用 @TableLogic 的 `deleted` 做回收站：逻辑删行对所有 MP 查询不可见，"回收站列表"将无从查起；`trashed` 是业务态不是删除态。
+- 回收站不清引擎数据：chunk/ES/Qdrant 原样保留，靠可见版本集把它挡在检索外——恢复才能是瞬时翻标志；引擎清理只发生在彻底删除（purge）。
+
+## 2. kb-rag-server
+
+### 2.1 检索门控（ActiveVersionResolver，唯一卡点）
+- `load(kbId)` 的查询追加治理谓词（见 §0）；`snapshotBound` 上下文（已发布版本）不受影响
+- 所有治理变更（审核状态、有效期、回收站进出、彻底删除）成功后 `invalidate(kbId)`，操作者在调试页立即可见效果；时间窗自然穿越靠 TTL 兜底
+
+### 2.2 文档治理（DocumentGovernanceService，kb-app 新包 governance）
+- 审核状态机：`DRAFT|REJECTED → PENDING_REVIEW → PUBLISHED|REJECTED`；PUBLISHED 为终态不可回退（下架用有效期或回收站，不走审核回退）；非法迁移 → INVALID_PARAM
+  - `POST /api/v1/documents/{docId}/submit-review`：提交审核
+  - `POST /api/v1/documents/{docId}/approve`：通过 → PUBLISHED，清空 review_note
+  - `POST /api/v1/documents/{docId}/reject`：`{note}`（必填）→ REJECTED，回填 review_note
+- 上传落点（DocumentService）：新建文档时按所属 KB 的 `review_required` 决定初始态（0→PUBLISHED，1→DRAFT）；**追加新版本不重置发布态**（审核的是文档准入，不是每个版本——版本内容治理由 M4a 版本机制覆盖）
+- 有效期：`PUT /api/v1/documents/{docId}/validity`：`{effective_at, expires_at}` 均可空（空=清除该界）；两者都给时要求 `effective_at < expires_at`；允许设置过去的 expires_at（运营者要的就是立即下架）
+- 回收站：
+  - `DELETE /api/v1/documents/{docId}`：`trashed=1` + `trashed_at=now`（幂等：已在回收站 → INVALID_PARAM）
+  - `GET /api/v1/kb/{kbId}/trash?page=&size=`：回收站分页列表，trashed_at 最新优先（分页默认/上限 20/200）
+  - `POST /api/v1/documents/{docId}/restore`：翻回 `trashed=0`、清 trashed_at（仅回收站内可恢复）
+  - `DELETE /api/v1/documents/{docId}/purge`：彻底删除，复用原 DocumentService 硬删链路（chunk+引擎副本+版本+标注+文档行）；仅回收站内可 purge（两段式防误删）
+  - 定时清理：`@Scheduled` 每日 purge `trashed_at` 早于 `kb.governance.trash-retention-days` 的文档，单批 ≤ `trash-purge-batch-size` 个文档（purge 含引擎删除，重操作按文档数限批）；失败仅 error 日志不重抛
+- KB 开关：`PUT /api/v1/kb/{kbId}/governance`：`{review_required}`；GET /kb 响应增 `review_required`
+- 存量查询隔离：文档列表（DocumentService.list）与上传归并查找（findLogicalDocument）排除 `trashed=1`——同名文件在回收站时新上传建新文档，不给回收站里的文档追加版本
+
+### 2.3 配置键（application.yml 接环境占位符，KbProperties.Governance 承载）
+- `kb.governance.trash-retention-days=30`（TRASH_RETENTION_DAYS）
+- `kb.governance.trash-purge-batch-size=100`（TRASH_PURGE_BATCH_SIZE）
+- `kb.governance.trash-purge-cron=0 10 4 * * *`（TRASH_PURGE_CRON）
+- `kb.governance.trash-purge-enabled=true`（TRASH_PURGE_ENABLED）
+
+### 2.4 单测（必须，精确断言）
+- 状态机：全部合法迁移 + 全部非法迁移（PUBLISHED 不可再审、PENDING 不可重复提交、reject 必带 note）；review_required=0/1 上传初始态；追加版本不重置发布态
+- 有效期：区间校验（effective>=expires 拒）、单边清除、设置后 invalidate 被调用
+- 回收站：trash 幂等拒绝、restore 仅回收站内、purge 仅回收站内且委托硬删链路、列表只出 trashed 行
+- 定时清理：保留期内不删、批大小边界、disabled 短路
+- 可见集：ActiveVersionResolver 过滤谓词生效（trashed/未发布/窗外文档的 version 不出现在可见集）
+
+## 3. kb-rag-web
+
+- 文档列表（KbDetailPage documents tab）：
+  - 新列：发布状态 Tag（PUBLISH_STATUS_META 走 metaOf；驳回态 Tooltip 展示 review_note）、有效期（未设不显示；已过期/未生效给 warning 色提示）
+  - 行操作按状态机出现：提交审核（DRAFT/REJECTED）/ 通过·驳回（PENDING_REVIEW，驳回弹窗必填理由）/ 设置有效期（弹窗，两个 DatePicker 可清空）
+  - 删除按钮文案与确认语改为"移入回收站（可在回收站恢复，N 天后自动彻底删除）"
+- 知识库详情新增 tab **回收站**：列表（文件名/移入时间/原状态）+ 行操作"恢复"/"彻底删除"（danger 确认）
+- KB 治理开关：documents tab 工具栏 Switch"新文档需审核后发布"（PUT governance）
+- api 层：document.ts 增 submit-review/approve/reject/validity/restore/purge/trash 列表与 governance 开关；types.ts 增 PublishStatus，KbDocument 增 publish_status/review_note/effective_at/expires_at/trashed_at，KnowledgeBase 增 review_required
+
+## 4. kb-rag-deploy（收尾）
+
+- OpenAPI kb-server.yaml：文档 schema 增治理字段 + 新增 8 个端点；版本升 0.12.0-m11
+- .env.example 增 TRASH_RETENTION_DAYS/TRASH_PURGE_BATCH_SIZE/TRASH_PURGE_CRON/TRASH_PURGE_ENABLED；CHANGELOG 记录（含 DELETE 语义变更的醒目说明）
+
+## 5. 验收
+
+1. review_required=0 上传 → 直接可检索；开关打开后上传 → DRAFT 且检索不到 → 提交审核并通过 → 可检索；驳回 → 列表可见理由
+2. 给已发布文档设 expires_at=过去 → 5 分钟内（或触发 invalidate 的任意治理操作后）检索不到；清除有效期恢复
+3. 删除文档 → 检索不到但回收站可见 → 恢复 → 立即可检索（无重建）；彻底删除 → 引擎/chunk/版本全清
+4. 存量库升级后（V13 默认值）检索结果与升级前一致
+5. `mvn -B -ntp verify` 全绿

--- a/kb-rag-deploy/docs/M12-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M12-CONTRACTS.md
@@ -1,0 +1,97 @@
+# M12 开发契约（数据接入：URL 导入与增量同步 · 增量于 M1-M11 契约）
+
+> 需求依据：知识库需求文档未含 URL 导入条款，本期为新增能力（数据接入渠道扩展）：把"上传文件"之外的第二条入库通道——**登记网页 URL → 抓取 → 解析入库**——补齐，并配套**增量同步**（定时/手动重抓，内容未变不产生新版本）。当前无用户体系，来源登记不记录"谁"，与 M10/M11 同口径。
+> 全局约定沿用 M1 §0（@author owlzhangfq@gmail.com、英文注释、info/error 日志带错误码、lombok、CollectionUtils 判空、无魔法值、fast-fail 只在 Controller、不主动 commit）；web 枚举展示走 metaOf。
+
+## 0. 范围与边界
+
+- **本期做**：①URL 导入（`POST /kb/{kbId}/web-sources` 登记并立即抓取，抓到的页面走既有上传链路入库）；②HTML 通用解析（kb-rag-parser 注册 html 解析器，顺带解锁 .html 文件直接上传）；③增量同步（来源登记表 + 手动 sync 端点 + 每日定时重抓，`content_hash` 未变则跳过、变了走 M4a 版本机制产生新版本）。
+- **本期不做**：站点级爬取/多页递归（一条登记=一个 URL=一个文档，站点地图属后期）；JS 渲染页面（仅抓服务端返回的 HTML，SPA 空壳页属后期，抓到什么入什么）；登录态/带 Cookie 抓取（仅公开可匿名访问的 URL）；RSS/API 等其他数据源。
+- **核心机制（复用不重造）**：抓取产物统一收敛到 `DocumentService.upload(kbId, fileName, bytes)`——文件名由 URL 派生且稳定，重抓同一 URL 天然命中"同名加版本"路径，`DocumentVersionPlanner` 的 content_hash 去重免费提供"内容未变→不产生新版本"；治理（M11 review_required/回收站）、版本保留（M4a）、索引管道全部免费继承，**本期不新增任何入库旁路**。
+- **安全红线（SSRF）**：项目现有 HTTP 出站（webhook/parser/模型端点）都是运营者配置的固定地址，无用户输入 URL；本期是第一处"用户给什么就请求什么"，必须新建 SSRF 防线（见 §3.2）：仅 http/https、禁 userinfo、解析后拒绝回环/私网/链路本地/组播地址、重定向逐跳重验、限时限体积限跳数。
+- **兼容红线**：
+  - 纯新增表与端点，存量行为零变化；
+  - `UPLOAD_ALLOWED_EXTENSIONS` 默认值追加 `html`——已显式配置该环境变量的部署需自行追加，CHANGELOG 醒目说明；
+  - 来源登记与文档是**弱绑定**：移除登记不动文档，删除文档（回收站）不动登记（同步时跳过并记因）；文档被彻底删除后，下次同步重新建档并重绑。
+
+## 1. 数据模型（Flyway V14，新表）
+
+| 表 | 定义 |
+|---|---|
+| t_kb_web_source | `id` BIGINT PK AUTO、`source_id` VARCHAR(64) UK（biz id，ws_ 前缀）、`kb_id` VARCHAR(64) NOT NULL、`url` VARCHAR(2048) NOT NULL、`url_hash` CHAR(64) NOT NULL（url 的 sha256，等值定位用）、`doc_id` VARCHAR(64) NULL（绑定文档，首抓成功后回填）、`file_name` VARCHAR(255) NULL（派生文件名，稳定）、`sync_enabled` TINYINT NOT NULL DEFAULT 1、`last_content_hash` CHAR(64) NULL、`last_fetch_at` DATETIME NULL、`last_fetch_status` VARCHAR(16) NULL（SUCCESS/UNCHANGED/SKIPPED/FAILED）、`last_error` VARCHAR(512) NULL、`created_at`/`updated_at` DATETIME；索引 UK `uk_kb_url(kb_id, url_hash)`、KEY `idx_kb(kb_id)` |
+
+- 同一 KB 内同一 URL 只允许登记一次（UK 兜底 + 服务层友好拒绝）；不同 KB 可各自登记同一 URL（各建各的文档）。
+- 派生文件名规则：`{host}-{path slug}-{url_hash 前 8 位}.html`（slug 化去非法字符、总长截到 200）；hash 后缀保证不同 URL 不会撞名合并成一个文档。
+
+## 2. kb-rag-parser（HTML 解析器）
+
+- 新增 `app/parsers/html.py`：`HtmlParser(BaseParser)`，registry 注册 `html`/`htm` 两个扩展名。
+- 实现沿用 chat html_adapter 的先例：**只用标准库 `html.parser.HTMLParser`，不引 bs4**（避免新依赖，app/security.py 的 XML 防线不适用于事件式解析器，无 XXE 面）。
+- 解析语义：丢弃 `script/style/noscript/head`（`<title>` 除外）；`<title>` 作为一级标题输出；`h1-h6` 映射 markdown 标题；块级元素（p/div/li/tr/br 等）断行；`<a>` 只留文本；连续空行折叠。产出 `ParseData(markdown=..., pages=[单页], images=[])`——图片外链不下载（SSRF 面留在 server 侧防线之外，解析器不发任何网络请求）。
+- 编码走既有 `decode_bytes`；解析失败抛 `ParseError`（PARSE_FAILED），与其他解析器同模式。
+- 单测 `tests/test_parse_html.py`：标签剥离、script/style 丢弃、title→标题、标题层级映射、编码兜底、损坏输入报 PARSE_FAILED。
+
+## 3. kb-rag-server
+
+### 3.1 上传白名单（UploadValidator，一行配置）
+- `application.yml` `kb.upload.allowed-extensions` 默认值追加 `html`（html 无魔数，UploadValidator 的 MAGIC 表不动——文本格式本就"仅验扩展名与大小"）。
+
+### 3.2 SSRF 防线（UrlGuard，kb-domain service）
+- `UrlGuard.validate(url)`：仅 `http/https`；禁 userinfo（`user@host` 形态直接拒）；host 解析出的**每个** InetAddress 均须非回环/非私网（10/172.16-31/192.168）/非链路本地（169.254）/非组播/非通配（0.0.0.0）；解析失败 → INVALID_PARAM。中文拒绝消息（如"该地址指向内网，禁止抓取"）。
+- 重定向不交给 HttpURLConnection 自动跟随：抓取器手动跟随 ≤ `max-redirects`（默认 3）次，**每一跳重新过 UrlGuard**——防"公网 URL 302 到 169.254.169.254"的经典绕过。
+
+### 3.3 抓取器（WebPageFetcher：kb-domain 定义 port，kb-infrastructure 实现）
+- `FetchedPage fetch(String url)`：RestClient + `SimpleClientHttpRequestFactory`（连接/读取超时 = `fetch-timeout-ms`），流式读且累计超过 `max-page-size-mb` 即中止（不能只信 Content-Length）。
+- Content-Type 白名单：`text/html`、`application/xhtml+xml`、`text/plain`、`text/markdown`（缺省按 text/html 处理）；白名单外（pdf/图片/二进制）→ INVALID_PARAM"仅支持网页与文本类内容"。text/plain、text/markdown 派生文件名后缀相应用 .txt/.md。
+- 非 2xx → 抓取失败（不是参数错误，登记仍成立，状态记 FAILED）。
+
+### 3.4 来源服务（WebSourceService，kb-app 包 websource）
+- `POST /api/v1/kb/{kbId}/web-sources`：`{url, sync_enabled?=true}`——UrlGuard 校验 → 落登记行 → **立即执行一次同步**（同步失败不回滚登记，状态记 FAILED 供列表可见）；同 KB 重复 URL → INVALID_PARAM。
+- `GET /api/v1/kb/{kbId}/web-sources?page=&size=`：登记列表，created 最新优先（分页默认/上限 20/200）。
+- `POST /api/v1/web-sources/{sourceId}/sync`：手动同步，返回本次结果（status + doc_id + version 变化与否）。
+- `PUT /api/v1/web-sources/{sourceId}`：`{sync_enabled}`，只开关自动同步。
+- `DELETE /api/v1/web-sources/{sourceId}`：移除登记（硬删登记行；**不动文档**，文档去留走 M11 回收站流程）。
+- **单次同步语义**（登记即抓、手动 sync、定时任务三处共用同一方法）：
+  1. UrlGuard 重验（登记后 DNS 可能已变，防 rebinding）→ fetch；
+  2. `sha256(body)` == `last_content_hash` → 记 UNCHANGED，不触上传链路（连"planner 判重"都不进，省一次对象存储写）；
+  3. 绑定文档在回收站（trashed=1）→ 记 SKIPPED + last_error"文档在回收站，恢复或彻底删除后才会继续同步"——不给回收站文档追加版本（与 M11 findLogicalDocument 同一语义），也不另建新档（避免恢复后一个 URL 两个文档）；
+  4. 其余 → `DocumentService.upload(kbId, fileName, bytes)`：绑定文档已被彻底删除时该调用自然重新建档，回填 doc_id；
+  5. 无论成败回填 `last_fetch_at/last_fetch_status/last_error(截 512)/last_content_hash(仅成功)`；异常仅 error 日志带错误码，不重抛（定时批次内单条失败不中断他条）。
+- 定时同步：`@Scheduled(cron = kb.web-import.sync-cron)`，`sync-enabled=false` 短路；每轮取 `sync_enabled=1` 的登记按 id 升序、单轮 ≤ `sync-batch-size` 条（抓取是外网慢操作，按条数限批）。
+
+### 3.5 配置键（application.yml 接环境占位符，KbProperties.WebImport 承载）
+- `kb.web-import.fetch-timeout-ms=10000`（WEB_IMPORT_FETCH_TIMEOUT_MS）
+- `kb.web-import.max-page-size-mb=10`（WEB_IMPORT_MAX_PAGE_SIZE_MB）
+- `kb.web-import.max-redirects=3`（WEB_IMPORT_MAX_REDIRECTS）
+- `kb.web-import.sync-cron=0 30 2 * * *`（WEB_IMPORT_SYNC_CRON）
+- `kb.web-import.sync-enabled=true`（WEB_IMPORT_SYNC_ENABLED）
+- `kb.web-import.sync-batch-size=50`（WEB_IMPORT_SYNC_BATCH_SIZE）
+
+### 3.6 单测（必须，精确断言）
+- UrlGuard：scheme 白名单、userinfo 拒、回环/私网/链路本地/组播/0.0.0.0 各一例拒、公网放行、解析失败拒
+- 派生文件名：稳定性（同 URL 两次同名）、不同 URL 不撞名、长路径截断、Content-Type 决定后缀
+- 同步语义：hash 未变→UNCHANGED 且不触 upload、变了→upload 被调且回填、trashed 文档→SKIPPED 不触 upload、doc 已彻底删→重新建档重绑、失败→FAILED+last_error 回填不重抛
+- 登记：同 KB 重复 URL 拒、跨 KB 同 URL 允许、登记即触发一次同步、移除登记不动文档
+- 定时：disabled 短路、批大小边界、单条失败不中断批次
+- 抓取器（infrastructure 侧）：超体积中止、Content-Type 白名单外拒、重定向逐跳重验（302 到私网地址被拦）
+
+## 4. kb-rag-web
+
+- 知识库详情新增 tab **网页来源**（WebSourcesTab，kb/components）：
+  - 顶部行内表单：URL 输入 + "添加并抓取"按钮（成功后刷新列表与文档列表）
+  - 列表列：URL（ellipsis+Tooltip）/ 最近抓取时间 / 抓取结果 Tag（WEB_SOURCE_STATUS_META 走 metaOf，FAILED/SKIPPED 的 Tooltip 展示 last_error）/ 自动同步 Switch（行内 PUT）/ 操作（立即同步、移除登记 Popconfirm——文案明确"仅移除登记，已入库文档不受影响"）
+- api 层：新增 `webSource.ts`（register/list/sync/update/remove 五函数）；types.ts 增 `WebSource`、`WebSourceFetchStatus` 及 `WEB_SOURCE_STATUS_META`
+
+## 5. kb-rag-deploy（收尾）
+
+- OpenAPI kb-server.yaml：新增 `web-sources` tag + 5 端点 + WebSource schema；版本升 0.13.0-m12
+- .env.example 增 WEB_IMPORT_ 六变量；CHANGELOG 记录（含 UPLOAD_ALLOWED_EXTENSIONS 默认值追加 html 的醒目说明）
+
+## 6. 验收
+
+1. 登记一个公网文档页 URL → 立即入库可检索，文档列表出现派生名 .html 文档；.html 文件直接上传同样入库
+2. 登记指向 `http://127.0.0.1`、`http://192.168.x.x`、`http://user@host/` 的 URL → 均被拒绝且给中文原因；302 跳内网的 URL 抓取被拦（FAILED）
+3. 内容未变时手动 sync → 结果 UNCHANGED，文档版本数不变；改动页面后 sync → 产生新版本，旧版本按 M4a 保留策略处理
+4. 将绑定文档移入回收站后 sync → SKIPPED 且原因可见；彻底删除后 sync → 重新建档
+5. review_required=1 的 KB 登记 URL → 新文档为 DRAFT（治理链路继承验证）
+6. `mvn -B -ntp verify` 全绿；kb-rag-parser `pytest` 全绿

--- a/kb-rag-deploy/docs/M13-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M13-CONTRACTS.md
@@ -1,0 +1,65 @@
+# M13 开发契约（运维可观测：Prometheus 业务指标暴露 · 增量于 M1-M12 契约）
+
+> 需求依据：知识库需求文档 §5 运维性要求（可监控、可告警）。M4c/M8 已有的告警体系（AlertService/TaskFailureTracker）解决"出事推 webhook"，本期补齐它的前半段——**业务指标以 Prometheus 文本格式持续暴露**，让运营者接 Grafana 看趋势、配阈值，而不是只在越线瞬间收到一条消息。
+> 全局约定沿用 M1 §0（@author owlzhangfq@gmail.com、英文注释、info/error 日志带错误码、lombok、CollectionUtils 判空、无魔法值、不主动 commit）。
+
+## 0. 范围与边界
+
+- **本期做**：①激活既有 actuator 的 `/actuator/prometheus` 端点（`management.endpoints.web.exposure.include` 早已含 prometheus，缺的只是 `micrometer-registry-prometheus` 依赖）；②新增业务指标门面 `KbMetrics`（kb-app），在既有横切汇聚点埋计数器/计时器；③任务积压 gauge。JVM/HTTP 等基础指标由 actuator 自动配置免费提供，不重造。
+- **本期不做**：Grafana 面板与告警规则文件（部署侧资产，属运维文档范畴）；指标持久化（Prometheus 拉走即可）；per-KB / per-key 维度标签（kb_id、key_id 是无界基数，Prometheus 反模式——需要按库统计时用 M10 洞察报表，按 key 统计时用 M4c 审计统计，各有专门端点）；`@Timed` AOP（项目横切惯例是显式调用，不引 AOP）。
+- **埋点原则（与 M10 洞察同一哲学）**：只在**既有的横切汇聚点**搭车，不进 `RetrievalService` 内部——评测运行与发布卡点复用检索管线，不能污染在线指标。指标失败绝不影响业务路径（micrometer 计数本身无 IO，不会失败；gauge 的 DB 查询包 try/catch）。
+- **兼容红线**：纯新增，无表变更、无端点行为变化、无新环境变量；`/actuator/prometheus` 与 health 同属管理端口面，当前无鉴权（与 health 一致，生产由部署侧网络隔离，权限属后期统一补充范畴）。
+
+## 1. 依赖（版本一律由 Spring Boot BOM 管理）
+
+| 模块 | 新增依赖 | 理由 |
+|---|---|---|
+| kb-app | `io.micrometer:micrometer-core` | KbMetrics 门面在 kb-app（埋点都在 app 层服务），kb-app 现依赖 spring-boot-starter 不含 micrometer |
+| kb-api | `io.micrometer:micrometer-registry-prometheus`（runtime） | actuator 自动配置发现 registry 后即暴露 `/actuator/prometheus` |
+
+## 2. 指标清单（命名 micrometer 点分风格，Prometheus 侧自动转下划线）
+
+| 指标 | 类型 | 标签 | 埋点位置（既有汇聚点） |
+|---|---|---|---|
+| `kb.search` | Timer | `source`（console/open_api）、`zero_hit`（true/false）、`degraded`（true/false） | 与 M10 洞察相同的两个 API 边界：SearchController（console）、KnowledgeApiService 三个开放流程的洞察点（open_api，计时为检索阶段，不含生成） |
+| `kb.task.completed` | Counter | `type`（TaskType 小写）、`status`（success/failed） | TaskFailureTracker.recordSuccess/recordFailure——索引管线成败的既有唯一漏斗 |
+| `kb.task.backlog` | Gauge | `status`（pending/running） | TaskBacklogMetrics 按需 selectCount t_kb_task（idx_status 索引，抓取周期级频率，代价可忽略；DB 异常返回 NaN 不抛） |
+| `kb.openapi.rejected` | Counter | `error_code`（ErrorCode 名，有界枚举） | ApiKeyAuthFilter.writeError——401/429 的既有唯一出口（审计因无 key id 不记 401，指标无此约束，两类都计） |
+| `kb.websource.sync` | Counter | `status`（WebSourceFetchStatus 小写四态） | WebSourceService.record——四态结果的既有唯一落点 |
+
+- 上传量不单独设指标：每次成功上传必然产生 PARSE/INDEX 任务，`kb.task.completed` 已覆盖；重复上传（planner 判重）无任务但也无新内容，不是容量信号。
+- preview（管理台问答调试）与洞察同口径**不计入** `kb.search`：管理流量不进外部调用量统计。
+
+## 3. 实现形态
+
+### 3.1 KbMetrics（kb-app 新包 metrics）
+- 构造注入 `MeterRegistry`，方法即指标语义：`recordSearch(source, latencyMs, resultCount, degraded)`、`recordTaskCompleted(taskType, success)`、`recordOpenApiRejected(errorCode)`、`recordWebSourceSync(status)`。
+- 标签值全部小写、来自有界枚举或布尔，杜绝无界基数；调用方传 null 枚举时静默丢弃该样本（防御性，不抛）。
+
+### 3.2 TaskBacklogMetrics（kb-app 包 metrics）
+- 构造注入 `MeterRegistry` + `KbTaskMapper`，构造期注册 PENDING/RUNNING 两支 gauge；查询失败 error 日志带错误码并返回 NaN（Prometheus 语义上等于本轮无数据，绝不让抓取拖垮应用）。
+
+### 3.3 埋点接线（每处一行调用，零逻辑改动）
+- SearchController：检索调用前后取毫秒差，`recordSearch(CONSOLE, ...)`；
+- KnowledgeApiService：`insight(...)` 私有方法增加 startedAt 入参，洞察写入旁 `recordSearch(OPEN_API, ...)`（三个开放流程共用此点，天然排除 preview）；
+- TaskFailureTracker / ApiKeyAuthFilter / WebSourceService：各自的既有唯一漏斗处一行计数。
+
+## 4. 单测（必须，精确断言；registry 用 SimpleMeterRegistry，不起容器）
+
+- KbMetrics：每个 record 方法计一次后 registry 内 counter/timer 值与标签精确匹配；zero_hit/degraded 布尔映射；null 枚举不抛不计。
+- TaskBacklogMetrics：mock KbTaskMapper 返回计数 → gauge 值匹配；mapper 抛异常 → gauge 为 NaN 不抛。
+- 既有测试适配：AlertServiceTest（TaskFailureTracker 构造）、WebSourceServiceTest、KnowledgeApiServiceTest 增注入并断言关键路径计数被触发。
+
+## 5. kb-rag-deploy（收尾）
+
+- 无新环境变量（.env.example 不动）；OpenAPI 不涉及业务端点（actuator 面不进 kb-server.yaml）。
+- CHANGELOG：新增 M13 条目，说明 `/actuator/prometheus` 自本版起可抓取及指标清单。
+
+## 6. 验收
+
+1. 启动 kb-rag-server → `curl :20000/actuator/prometheus` 可见 `kb_search_seconds_*`、`kb_task_backlog` 等指标及 JVM/HTTP 基础指标
+2. 管理台执行一次检索 → `kb_search_seconds_count{source="console"}` 递增；零命中查询 → `zero_hit="true"` 系列递增
+3. 上传一篇文档索引完成 → `kb_task_completed_total{type="index",status="success"}` 递增
+4. 用错误 API Key 调开放接口 → `kb_openapi_rejected_total{error_code="INVALID_API_KEY"}` 递增
+5. 网页登记同步一次 → `kb_websource_sync_total` 对应四态递增
+6. `mvn -B -ntp verify` 全绿

--- a/kb-rag-deploy/docs/openapi/kb-parser.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-parser.yaml
@@ -26,7 +26,13 @@ info:
     依赖则启动 fast-fail）；扫描页三级次序 kb-server 侧 VLM → parser 侧 PaddleOCR
     → 跳过降级；OCR 成功的扫描页文本直接回填并标记 `pages[].ocr_source=paddle`，
     kb-rag-server 对带该标记的页不再调 VLM。
-  version: "0.9.0-m8"
+
+    M12 增量（docs/M12-CONTRACTS.md §2）：`/api/v1/parse` 的 `file_ext` 白名单扩为
+    pdf/docx/txt/md/xlsx/csv/html/htm——新增通用 HTML 页面解析器（仅标准库
+    html.parser，title 与 h1-h6 映射标题、块级元素分段，剔除
+    script/style/noscript/template，单页返回、不产出图片、绝不请求任何远程资源；
+    URL 抓取与 SSRF 防护在 kb-rag-server 侧）。
+  version: "0.12.0-m12"
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -48,7 +54,8 @@ paths:
       tags: [parse]
       summary: 解析文档
       description: |
-        支持格式：pdf(pymupdf) / docx(python-docx) / txt / md / xlsx(openpyxl) / csv。
+        支持格式：pdf(pymupdf) / docx(python-docx) / txt / md / xlsx(openpyxl) / csv /
+        html·htm(标准库 html.parser，M12)。
         multipart 请求：`file` 为二进制文件，`file_ext` 为表单字段声明的扩展名
         （用于分派到对应解析策略，独立于文件名后缀，避免伪造扩展名绕过策略选择）。
 
@@ -178,7 +185,9 @@ components:
   schemas:
     SupportedFileExt:
       type: string
-      enum: [pdf, docx, txt, md, xlsx, csv]
+      description: |
+        html/htm 为 M12 增量（docs/M12-CONTRACTS.md §2，通用 HTML 页面解析）。
+      enum: [pdf, docx, txt, md, xlsx, csv, html, htm]
 
     ChatFileExt:
       type: string

--- a/kb-rag-deploy/docs/openapi/kb-server.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-server.yaml
@@ -110,8 +110,39 @@ info:
 
     split_strategy（新增 `SplitStrategy` 枚举，两个成员）与只读的 embedding_model。
 
+
+    0.11.0-m10（检索质量闭环，docs/M10-CONTRACTS.md）：①`retrieval-feedback` 提交由
+
+    log-only 升级为持久化行并返回该行；②新增反馈管理端点（列表/转评测集/忽略）；
+
+    ③新增检索洞察端点（明细分页 + 内容缺口统计报表）；④`CaseSource` 枚举新增 FEEDBACK。
+
+
+    0.12.0-m11（内容治理，docs/M11-CONTRACTS.md）：①`Document` 新增治理字段
+
+    publish_status/review_note/effective_at/expires_at/trashed_at（新增 `PublishStatus`
+
+    枚举），`KnowledgeBase` 新增 review_required；②新增审核发布端点（submit-review/
+
+    approve/reject）、有效期端点（validity）、回收站端点（trash 列表/restore/purge）与
+
+    KB 级治理开关（governance）；③**DELETE /api/v1/documents/{docId} 语义变更**：
+
+    由不可逆删除改为移入回收站（可还原），不可逆删除迁移至 purge 端点。
+
+
+    0.13.0-m12（数据接入：URL 导入与增量同步，docs/M12-CONTRACTS.md）：①新增网页登记端点
+
+    （登记即抓 / 列表 / 手动同步 / 定时同步开关 / 移除登记，新增 `WebSource` schema 与
+
+    `WebSourceFetchStatus` 枚举）；②抓取产物统一走文档上传管线（同名加版本、content_hash
+
+    去重），登记与文档为弱绑定——移除登记不删文档；③上传白名单扩展 html 后缀
+
+    （UPLOAD_ALLOWED_EXTENSIONS 新增 html）。
+
     '
-  version: 0.10.1-m9
+  version: 0.13.0-m12
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -139,6 +170,12 @@ tags:
   description: Demo 一键导入（M3，docs/M3-CONTRACTS.md §3.7）
 - name: eval
   description: 评测体系：评测集/case/证据复核/评测运行与报告（M4b，docs/M4b-CONTRACTS.md）
+- name: insight
+  description: 检索洞察：零命中/降级记录明细与内容缺口报表（M10，docs/M10-CONTRACTS.md §2.2）
+- name: governance
+  description: 内容治理：审核发布/有效期/回收站（M11，docs/M11-CONTRACTS.md §2.2）
+- name: web-source
+  description: 数据接入：URL 登记导入与增量同步（M12，docs/M12-CONTRACTS.md §3.4）
 - name: app-center
   description: 应用中心：应用/版本/发布门禁与控制台 chat 预览（M4c，docs/M4c-CONTRACTS.md §2）
 - name: api-key
@@ -647,6 +684,372 @@ paths:
                 $ref: '#/components/schemas/DocumentPreviewResult'
         '400':
           $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/documents/{docId}:
+    parameters:
+    - $ref: '#/components/parameters/DocId'
+    delete:
+      tags:
+      - governance
+      summary: 删除文档（M11 起：移入回收站，可还原）
+      description: 'M11-CONTRACTS.md §2.2：URL 早于 M11，语义由不可逆删除升级为移入回收站——
+        文档立即从检索中下线但数据保留，保留期内可通过 restore 还原；不可逆删除迁移至
+        purge 端点。已在回收站的文档重复删除返回 INVALID_PARAM。'
+      responses:
+        '200':
+          description: 已移入回收站
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/documents/{docId}/submit-review:
+    parameters:
+    - $ref: '#/components/parameters/DocId'
+    post:
+      tags:
+      - governance
+      summary: 提交审核（DRAFT|REJECTED → PENDING_REVIEW）
+      description: 'M11-CONTRACTS.md §2.2：仅 DRAFT/REJECTED 可提交；其余状态返回
+        INVALID_PARAM；回收站内文档需先还原。'
+      responses:
+        '200':
+          description: 更新后的文档
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/documents/{docId}/approve:
+    parameters:
+    - $ref: '#/components/parameters/DocId'
+    post:
+      tags:
+      - governance
+      summary: 审核通过（PENDING_REVIEW → PUBLISHED，清空 review_note）
+      description: 'M11-CONTRACTS.md §2.2：PUBLISHED 为终态，下架靠有效期或回收站；
+        非 PENDING_REVIEW 状态返回 INVALID_PARAM。'
+      responses:
+        '200':
+          description: 更新后的文档
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/documents/{docId}/reject:
+    parameters:
+    - $ref: '#/components/parameters/DocId'
+    post:
+      tags:
+      - governance
+      summary: 审核驳回（PENDING_REVIEW → REJECTED，note 必填）
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [note]
+              properties:
+                note:
+                  type: string
+                  maxLength: 512
+                  description: 驳回理由，落入 Document.review_note
+      responses:
+        '200':
+          description: 更新后的文档
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/documents/{docId}/validity:
+    parameters:
+    - $ref: '#/components/parameters/DocId'
+    put:
+      tags:
+      - governance
+      summary: 设置/清除文档有效期窗口
+      description: 'M11-CONTRACTS.md §2.2：两端均可为 null 表示不设界；expires_at 允许
+        为过去时刻（立即下架）；两端都非空时要求 expires_at > effective_at；时间为
+        无时区 ISO 字面量（如 2026-07-26T00:00:00）。'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                effective_at:
+                  type: string
+                  format: date-time
+                  nullable: true
+                expires_at:
+                  type: string
+                  format: date-time
+                  nullable: true
+      responses:
+        '200':
+          description: 更新后的文档
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/documents/{docId}/restore:
+    parameters:
+    - $ref: '#/components/parameters/DocId'
+    post:
+      tags:
+      - governance
+      summary: 从回收站还原文档
+      description: 'M11-CONTRACTS.md §2.2：纯 DB 标记翻转，无需重建索引，还原后立即恢复
+        可检索（受其发布状态/有效期约束）；不在回收站的文档返回 INVALID_PARAM。'
+      responses:
+        '200':
+          description: 更新后的文档
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/documents/{docId}/purge:
+    parameters:
+    - $ref: '#/components/parameters/DocId'
+    delete:
+      tags:
+      - governance
+      summary: 彻底删除（仅限回收站内文档，不可逆）
+      description: 'M11-CONTRACTS.md §2.2：M11 前 DELETE 的不可逆删除迁移到这里：连同
+        全部版本/分片/两个检索引擎副本一并删除。仅对回收站内文档有效（两段式防误删），
+        否则返回 INVALID_PARAM。超过保留期的回收站文档由定时任务自动执行同一逻辑。'
+      responses:
+        '200':
+          description: 已彻底删除
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/kb/{kbId}/trash:
+    parameters:
+    - $ref: '#/components/parameters/KbId'
+    get:
+      tags:
+      - governance
+      summary: 回收站列表（按移入时间倒序分页）
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentListResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/kb/{kbId}/governance:
+    parameters:
+    - $ref: '#/components/parameters/KbId'
+    put:
+      tags:
+      - governance
+      summary: 更新 KB 级治理开关（review_required）
+      description: 'M11-CONTRACTS.md §2.2：仅影响开关翻转后新上传的文档（含新版本不重置
+        存量状态），存量文档发布状态不变。'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [review_required]
+              properties:
+                review_required:
+                  type: boolean
+      responses:
+        '200':
+          description: 更新后的知识库
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeBaseResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/kb/{kbId}/web-sources:
+    parameters:
+    - $ref: '#/components/parameters/KbId'
+    post:
+      tags:
+      - web-source
+      summary: 登记网页地址并立即抓取入库
+      description: 'M12-CONTRACTS.md §3.4：同步执行首次抓取，响应行携带抓取结果（last_fetch_status）；
+        抓取失败不回滚登记（FAILED + last_error 落在行上）。同库同 URL（规范化后）重复登记返回
+        INVALID_PARAM；非 http/https、内网/回环地址被 SSRF 防线拒绝（重定向逐跳复验）。抓取产物走
+        文档上传管线：同名加版本、content_hash 去重。'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url:
+                  type: string
+                  maxLength: 2048
+                sync_enabled:
+                  type: boolean
+                  default: true
+                  description: 缺省开启定时同步
+      responses:
+        '200':
+          description: 登记行（含首次抓取结果）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebSourceResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    get:
+      tags:
+      - web-source
+      summary: 网页登记列表（按登记时间倒序分页）
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebSourceListResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/web-sources/{sourceId}/sync:
+    parameters:
+    - name: sourceId
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      tags:
+      - web-source
+      summary: 手动触发一次同步
+      description: 'M12-CONTRACTS.md §3.4：抓取结果不以请求错误形式暴露——响应永远 200，四态结果
+        （SUCCESS/UNCHANGED/SKIPPED/FAILED）落在行的 last_fetch_status/last_error 上，与定时
+        同步记录方式一致。绑定文档被彻底删除后，下次同步用存储的文件名重新建档并重新绑定。'
+      responses:
+        '200':
+          description: 同步后的登记行
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebSourceResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/web-sources/{sourceId}:
+    parameters:
+    - name: sourceId
+      in: path
+      required: true
+      schema:
+        type: string
+    put:
+      tags:
+      - web-source
+      summary: 开关定时同步
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [sync_enabled]
+              properties:
+                sync_enabled:
+                  type: boolean
+      responses:
+        '200':
+          description: 更新后的登记行
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebSourceResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+      - web-source
+      summary: 移除登记（弱绑定：已入库文档保留）
+      description: 'M12-CONTRACTS.md §3.4：物理删除登记行（释放同库同 URL 的唯一约束，允许
+        重新登记）；它喂过的文档不受影响，删文档走回收站/purge 通道。'
+      responses:
+        '200':
+          description: 已移除
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyResult'
         '404':
           $ref: '#/components/responses/NotFound'
   /api/v1/kb/{kbId}/graph/config:
@@ -1543,8 +1946,9 @@ paths:
       tags:
       - eval
       summary: 检索结果反馈标注
-      description: 'verdict=GOOD 即一键收进评测集（同 cases/from-retrieval 语义承载，source=DEBUG_PAGE）；
-        verdict=BAD 记 info 日志且不落库（M4b-CONTRACTS.md §2）。'
+      description: 'payload 与 M4b 完全兼容（M10 兼容红线）。M10 起不再是 log-only：GOOD/BAD
+        均落库为一条 status=NEW 的反馈行，返回该行；后续可在反馈管理中转评测集（仅 GOOD）或忽略
+        （M10-CONTRACTS.md §2.1）。'
       requestBody:
         required: true
         content:
@@ -1553,11 +1957,190 @@ paths:
               $ref: '#/components/schemas/RetrievalFeedbackRequest'
       responses:
         '200':
-          description: 已受理
+          description: 已落库（status=NEW）
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmptyResult'
+                $ref: '#/components/schemas/RetrievalFeedbackResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/kb/{kbId}/retrieval-feedback:
+    parameters:
+    - $ref: '#/components/parameters/KbId'
+    get:
+      tags:
+      - eval
+      summary: 反馈管理列表（倒序分页）
+      description: 知识库维度分页列出反馈行，可按 verdict/status 过滤（M10-CONTRACTS.md §2.1）。
+      parameters:
+      - name: verdict
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/RetrievalFeedbackVerdict'
+      - name: status
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/FeedbackStatus'
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrievalFeedbackPageResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/retrieval-feedback/{feedbackId}/convert:
+    parameters:
+    - $ref: '#/components/parameters/FeedbackId'
+    post:
+      tags:
+      - eval
+      summary: 反馈转评测 case
+      description: '仅 verdict=GOOD 且 status=NEW 的行可转：按反馈的 query+chunk 建一条
+        source=FEEDBACK 的评测 case，反馈行置 CONVERTED 并回填 converted_case_id；
+        CONVERTED/DISMISSED 均为终态，重复操作返回 INVALID_PARAM（M10-CONTRACTS.md §2.1）。'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConvertFeedbackRequest'
+      responses:
+        '200':
+          description: 已转化（status=CONVERTED）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrievalFeedbackResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/retrieval-feedback/{feedbackId}/dismiss:
+    parameters:
+    - $ref: '#/components/parameters/FeedbackId'
+    post:
+      tags:
+      - eval
+      summary: 忽略反馈
+      description: 仅 status=NEW 的行可忽略；DISMISSED 为终态（M10-CONTRACTS.md §2.1）。
+      responses:
+        '200':
+          description: 已忽略（status=DISMISSED）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrievalFeedbackResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/kb/{kbId}/search-insights:
+    parameters:
+    - $ref: '#/components/parameters/KbId'
+    get:
+      tags:
+      - insight
+      summary: 检索洞察明细（倒序分页）
+      description: '检索发生时自动记录（控制台调试 + OpenAPI；评测运行不记录），仅存脱敏摘要不存原文；
+        可按 zero_hit 与时间范围过滤（M10-CONTRACTS.md §2.2）。'
+      parameters:
+      - name: zero_hit
+        in: query
+        required: false
+        schema:
+          type: boolean
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          example: 2026-07-26T00:00:00
+        description: ISO 本地日期时间下界（不带时区后缀）
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          example: 2026-07-27T00:00:00
+        description: ISO 本地日期时间上界（不带时区后缀）
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchInsightPageResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/kb/{kbId}/search-insights/stats:
+    parameters:
+    - $ref: '#/components/parameters/KbId'
+    get:
+      tags:
+      - insight
+      summary: 内容缺口统计报表
+      description: '总检索/零命中数与占比/降级数 + Top 零命中 query 分组（大小写与空白归一化分组，
+        展示该组最新一条脱敏摘要）；from 缺省为最近 7 天（M10-CONTRACTS.md §2.2）。'
+      parameters:
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          example: 2026-07-26T00:00:00
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          example: 2026-07-27T00:00:00
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchInsightStatsResult'
         '400':
           $ref: '#/components/responses/InvalidParam'
         '404':
@@ -2389,6 +2972,13 @@ components:
       schema:
         type: string
       description: API Key 业务主键（key_id，M4c）
+    FeedbackId:
+      name: feedbackId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: 检索反馈业务主键（feedback_id，M10）
   responses:
     InvalidParam:
       description: 参数校验失败
@@ -2599,6 +3189,10 @@ components:
         graph_enabled:
           type: boolean
           description: M7 GraphRAG：本库是否开启实体关系抽取与图检索路（M7-CONTRACTS.md §0.3）
+        review_required:
+          type: boolean
+          description: M11 内容治理：开启后新上传文档初始为 DRAFT，需审核通过后才参与检索；
+            仅影响开关翻转后的新上传，存量文档状态不变（M11-CONTRACTS.md §2.2）
         description:
           type: string
           nullable: true
@@ -2646,6 +3240,16 @@ components:
       - INDEXING
       - INDEXED
       - INDEX_FAILED
+    PublishStatus:
+      type: string
+      description: '文档发布状态（t_kb_document.publish_status，M11-CONTRACTS.md §2.1），与
+        process_status 正交。状态机：DRAFT|REJECTED → PENDING_REVIEW → PUBLISHED|REJECTED，
+        PUBLISHED 为终态（下架靠有效期或回收站，不退回草稿）。M11 前存量文档一律 PUBLISHED。'
+      enum:
+      - DRAFT
+      - PENDING_REVIEW
+      - PUBLISHED
+      - REJECTED
     Document:
       type: object
       properties:
@@ -2672,6 +3276,28 @@ components:
           type: string
           nullable: true
           maxLength: 1024
+        publish_status:
+          $ref: '#/components/schemas/PublishStatus'
+        review_note:
+          type: string
+          nullable: true
+          maxLength: 512
+          description: 最近一次驳回理由；仅 REJECTED 状态非空，审核通过时清空
+        effective_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 有效期下界（含）；null 表示不设下界（M11-CONTRACTS.md §2.1）
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 有效期上界（不含）；null 表示永久有效；允许设为过去时刻实现立即下架
+        trashed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 进入回收站的时刻；不在回收站时为 null（文档列表不含回收站文档）
         created_at:
           type: string
           format: date-time
@@ -2706,6 +3332,74 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/Document'
+              page:
+                type: integer
+              total:
+                type: integer
+    WebSourceFetchStatus:
+      type: string
+      description: '最近一次同步结果（t_kb_web_source.last_fetch_status，M12-CONTRACTS.md §3.4）。
+        UNCHANGED/SKIPPED 是“抓到但不应写”：页面内容 hash 未变 / 绑定文档在回收站中。'
+      enum:
+      - SUCCESS
+      - UNCHANGED
+      - SKIPPED
+      - FAILED
+    WebSource:
+      type: object
+      description: 网页登记行（M12-CONTRACTS.md §1）。doc_id/file_name 首次成功抓取前为 null；
+        登记与文档为弱绑定，移除登记不删文档，删文档不动登记
+      properties:
+        source_id:
+          type: string
+        kb_id:
+          type: string
+        url:
+          type: string
+        doc_id:
+          type: string
+          nullable: true
+        file_name:
+          type: string
+          nullable: true
+          description: 由 URL 派生的稳定文件名（host-path摘要-urlHash前8位.后缀），重抓同名加版本
+        sync_enabled:
+          type: boolean
+        last_fetch_status:
+          allOf:
+          - $ref: '#/components/schemas/WebSourceFetchStatus'
+          nullable: true
+        last_fetch_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_error:
+          type: string
+          nullable: true
+          maxLength: 512
+          description: FAILED/SKIPPED 的原因；成功/未变时为 null
+        created_at:
+          type: string
+          format: date-time
+    WebSourceResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            $ref: '#/components/schemas/WebSource'
+    WebSourceListResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            type: object
+            properties:
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WebSource'
               page:
                 type: integer
               total:
@@ -3851,12 +4545,13 @@ components:
       - DEPRECATED
     CaseSource:
       type: string
-      description: case 来源。DEBUG_PAGE 来自检索调试页一键收进（含检索结果反馈 GOOD 判定），IMPORTED
-        来自 Demo 评测集导入
+      description: case 来源。DEBUG_PAGE 来自检索调试页一键收进，IMPORTED 来自 Demo 评测集导入，
+        FEEDBACK 来自反馈管理的转评测集操作（M10-CONTRACTS.md §2.1）
       enum:
       - MANUAL
       - DEBUG_PAGE
       - IMPORTED
+      - FEEDBACK
     RunStatus:
       type: string
       description: t_kb_eval_run.status。零 Key 环境下 VECTOR_ONLY/HYBRID/HYBRID_RERANK
@@ -3883,10 +4578,179 @@ components:
       - DEPRECATE
     RetrievalFeedbackVerdict:
       type: string
-      description: 检索结果反馈判定（M4b-CONTRACTS.md §2）
+      description: 检索结果反馈判定（M10-CONTRACTS.md §2.1）
       enum:
       - GOOD
       - BAD
+    FeedbackStatus:
+      type: string
+      description: t_kb_retrieval_feedback.status；CONVERTED/DISMISSED 均为终态（M10-CONTRACTS.md
+        §2.1）
+      enum:
+      - NEW
+      - CONVERTED
+      - DISMISSED
+    RetrievalFeedback:
+      type: object
+      description: t_kb_retrieval_feedback 行；query 为原文（管理台鉴权后可见），doc_id 在
+        分片已删时为空
+      properties:
+        feedback_id:
+          type: string
+        kb_id:
+          type: string
+        query:
+          type: string
+        chunk_id:
+          type: string
+        doc_id:
+          type: string
+          nullable: true
+        verdict:
+          $ref: '#/components/schemas/RetrievalFeedbackVerdict'
+        status:
+          $ref: '#/components/schemas/FeedbackStatus'
+        converted_case_id:
+          type: string
+          nullable: true
+        note:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+    RetrievalFeedbackResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            $ref: '#/components/schemas/RetrievalFeedback'
+    RetrievalFeedbackPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/RetrievalFeedback'
+        page:
+          type: integer
+        size:
+          type: integer
+        total:
+          type: integer
+    RetrievalFeedbackPageResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            $ref: '#/components/schemas/RetrievalFeedbackPage'
+    ConvertFeedbackRequest:
+      type: object
+      required:
+      - dataset_id
+      properties:
+        dataset_id:
+          type: string
+          description: 目标评测集（须属于反馈所在知识库）
+    SearchInsightSource:
+      type: string
+      description: 检索洞察记录入口（M10-CONTRACTS.md §2.2）
+      enum:
+      - CONSOLE
+      - OPEN_API
+    SearchInsight:
+      type: object
+      description: t_kb_search_insight 行；仅存脱敏截断后的 query_digest，不存原文；
+        top_score 零命中时为空；degraded 为降级标记数组（无降级时为空数组）
+      properties:
+        insight_id:
+          type: string
+        kb_id:
+          type: string
+        source:
+          $ref: '#/components/schemas/SearchInsightSource'
+        query_digest:
+          type: string
+        result_count:
+          type: integer
+        top_score:
+          type: number
+          format: double
+          nullable: true
+        zero_hit:
+          type: boolean
+        degraded:
+          type: array
+          items:
+            type: string
+        request_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+    SearchInsightPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchInsight'
+        page:
+          type: integer
+        size:
+          type: integer
+        total:
+          type: integer
+    SearchInsightPageResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            $ref: '#/components/schemas/SearchInsightPage'
+    TopZeroHitQuery:
+      type: object
+      description: 零命中 query 分组（大小写与空白归一化后同组），展示该组最新一条的脱敏摘要
+      properties:
+        query_digest:
+          type: string
+        count:
+          type: integer
+          format: int64
+        last_at:
+          type: string
+          format: date-time
+          nullable: true
+    SearchInsightStats:
+      type: object
+      description: 内容缺口统计报表（M10-CONTRACTS.md §2.2）；窗口内无记录时各项为 0
+      properties:
+        total:
+          type: integer
+          format: int64
+        zero_hit_count:
+          type: integer
+          format: int64
+        zero_hit_rate:
+          type: number
+          format: double
+        degraded_count:
+          type: integer
+          format: int64
+        top_zero_hit_queries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TopZeroHitQuery'
+    SearchInsightStatsResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            $ref: '#/components/schemas/SearchInsightStats'
     EvalCaseEvidence:
       type: object
       description: t_kb_eval_case.evidences 数组元素；DOCUMENT 锚定时 span 为空
@@ -4174,8 +5038,8 @@ components:
           nullable: true
     RetrievalFeedbackRequest:
       type: object
-      description: 'M4b-CONTRACTS.md §2：verdict=GOOD 等价于一键收进评测集（source=DEBUG_PAGE 草稿
-        case）；verdict=BAD 仅记 info 日志，不落库。'
+      description: 'M10-CONTRACTS.md §2.1：payload 与 M4b 完全兼容；GOOD/BAD 均落库为
+        status=NEW 的反馈行，后续在反馈管理中处置。'
       required:
       - kb_id
       - query

--- a/kb-rag-parser/CHANGELOG.md
+++ b/kb-rag-parser/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式。
 
+## [未发布] - M12
+
+### 新增
+
+- `POST /api/v1/parse` 的 `file_ext` 扩展至 `html`/`htm`（M12-CONTRACTS.md §2，通用网页解析通道，与 M8 的聊天记录 HTML 适配器无关）：`app/parsers/html.py` 仅用标准库 `html.parser`（不引入 bs4/markdownify），事件式提取为 markdown——`<title>` 提为 `# 标题`，`h1..h6` 映射 markdown 标题前缀，块级标签切段、内联标签并入所在段；`script`/`style`/`noscript`/`template` 内容整体丢弃；固定单页、无图片产出。解析全程**零网络 I/O**（外部图片/脚本/样式一律不拉取），URL 导入的 SSRF 面全部收敛在 kb-rag-server 的抓取器侧。
+- pytest 新增（`tests/test_parse_html.py`）：标题/小标题/段落提取、script/style 丢弃、实体解码、空白归并、破损标记容错、htm 后缀注册等。
+
 ## [未发布] - M8
 
 ### 新增

--- a/kb-rag-parser/README.md
+++ b/kb-rag-parser/README.md
@@ -1,12 +1,12 @@
 # kb-rag-parser
 
-kb-rag 知识库项目的 Python 文档解析微服务（M1 基线 + M3 多模态/聊天记录增量 + M8 导入与解析增强增量）。只负责"文件解析"这一件事：把上传的文档转成结构化的 `markdown` + 按页文本 + 图片二进制，把聊天记录导出（csv/xlsx/txt/html）转成结构化会话消息；不做任何模型调用（VLM 图文理解/嵌入/切分等由 kb-rag-server 侧负责，见需求文档 §4.2 服务职责边界、M3-CONTRACTS.md §0），扫描页 OCR 的 PaddleOCR 兜底（M8-CONTRACTS.md §0.4）是唯一例外，且默认关闭。
+kb-rag 知识库项目的 Python 文档解析微服务（M1 基线 + M3 多模态/聊天记录增量 + M8 导入与解析增强增量 + M12 通用 HTML 页面解析增量）。只负责"文件解析"这一件事：把上传的文档转成结构化的 `markdown` + 按页文本 + 图片二进制，把聊天记录导出（csv/xlsx/txt/html）转成结构化会话消息；不做任何模型调用（VLM 图文理解/嵌入/切分等由 kb-rag-server 侧负责，见需求文档 §4.2 服务职责边界、M3-CONTRACTS.md §0），扫描页 OCR 的 PaddleOCR 兜底（M8-CONTRACTS.md §0.4）是唯一例外，且默认关闭。
 
 ## 技术栈
 
 - Python 3.11+
 - FastAPI + Uvicorn
-- PyMuPDF（pdf）/ python-docx（docx）/ openpyxl（xlsx）/ 标准库 csv（csv）/ 标准库 html.parser（html 聊天记录）/ PyYAML（聊天列名映射/行模板/DOM 选择器档案）
+- PyMuPDF（pdf）/ python-docx（docx）/ openpyxl（xlsx）/ 标准库 csv（csv）/ 标准库 html.parser（html 聊天记录 + M12 通用 HTML 页面）/ PyYAML（聊天列名映射/行模板/DOM 选择器档案）
 - 可选：PaddleOCR（`requirements-ocr.txt`，`OCR_ENGINE=paddle` 时才需要，默认不装）
 
 ## 许可注意
@@ -82,7 +82,7 @@ python3 -m venv .venv
 | 字段 | 类型 | 说明 |
 |---|---|---|
 | `file` | file | 待解析的文档 |
-| `file_ext` | form 字段 | 文件扩展名（不带点），如 `pdf`/`docx`/`txt`/`md`/`xlsx`/`csv` |
+| `file_ext` | form 字段 | 文件扩展名（不带点），如 `pdf`/`docx`/`txt`/`md`/`xlsx`/`csv`/`html`/`htm` |
 
 成功响应 `data` 结构（M3-CONTRACTS.md §2.1，向后兼容 M1）：
 
@@ -159,6 +159,7 @@ html（M8-CONTRACTS.md §0.2，DOM 选择器）：
 | `md` | 标准库 | 原样透传，本身已是 markdown |
 | `xlsx` | openpyxl | 每个 sheet 对应一个 `page_no`，同时渲染为 markdown 表格 |
 | `csv` | 标准库 `csv` | 自动探测分隔符（逗号/分号/tab），渲染为 markdown 表格 |
+| `html` / `htm` | 标准库 `html.parser`（M12） | 通用 HTML 页面→markdown：`<title>` 与 h1-h6 映射为标题、块级元素分段，剔除 script/style/noscript/template；单页返回（`page_no=1`）、不产出图片、绝不请求远程资源（URL 抓取与 SSRF 防护在 kb-rag-server 侧） |
 
 新增文档格式只需在 `app/parsers/` 下新增一个 `BaseParser` 实现，并在 `app/parsers/registry.py` 里注册一行 —— 策略注册表模式，主流程 `app/main.py` 无需改动。
 
@@ -193,6 +194,7 @@ app/
     docx.py           docx 解析（python-docx）：段落/表格 + 内嵌图片
     text.py           txt/md 解析
     excel.py          xlsx（openpyxl）/ csv（标准库）解析
+    html.py           M12 通用 HTML 页面解析（标准库 html.parser）：标题/块级分段→markdown，零出站请求
     images.py         pdf/docx 共用的图片采集与数量/字节上限保护
   chat/
     mapping.py         映射档案加载：csv/xlsx 列名候选 + M8 txt 行模板/html 选择器（app/mappings/*.yml 或随请求传入的 profile_yaml）
@@ -240,7 +242,7 @@ M8（M8-CONTRACTS.md §0.1/§0.2/§0.3/§0.4，均待真实样例到位后校准
   `docs/ARCHITECTURE.md` §4（kb-rag-parser 架构）
 - 端到端业务流程（文档导入、聊天记录导入等完整链路，本服务只是其中一环）：`docs/FLOWS.md`
 - 各里程碑契约（本服务行为的规范来源，本仓库的实现与偏离说明均以其为准）：
-  `docs/M1-CONTRACTS.md`、`docs/M3-CONTRACTS.md`、`docs/M8-CONTRACTS.md`
+  `docs/M1-CONTRACTS.md`、`docs/M3-CONTRACTS.md`、`docs/M8-CONTRACTS.md`、`docs/M12-CONTRACTS.md`
 - 接口契约（OpenAPI）：`docs/openapi/kb-parser.yaml`
 - 贡献与安全：本仓库的 `CONTRIBUTING.md` / `SECURITY.md`；跨仓库通用约定另见
   kb-rag-deploy 仓库同名文件

--- a/kb-rag-parser/app/parsers/html.py
+++ b/kb-rag-parser/app/parsers/html.py
@@ -1,0 +1,147 @@
+"""HTML parser for .html / .htm files (M12-CONTRACTS.md section 2).
+
+Uses only the standard library's ``html.parser.HTMLParser``, following the
+precedent set by app/chat/html_adapter.py: an event-based tokenizer has no
+DTD/entity machinery, so the XXE guardrails in app/security.py (which
+target ``xml.etree``/``lxml``) do not apply, and no new dependency (bs4,
+markdownify) is introduced for what is a linear text extraction.
+
+The parser performs no network I/O whatsoever: external images, scripts
+and stylesheets referenced by the page are dropped, never fetched — the
+outbound-request ban of the requirement doc applies to web pages exactly
+as it does to files, and the SSRF surface of URL import lives entirely in
+kb-rag-server's fetcher, not here.
+
+Author: owlzhangfq@gmail.com
+"""
+
+import logging
+from html.parser import HTMLParser
+
+from app.encoding import decode_bytes
+from app.errors import ErrorCode, ParseError
+from app.models import PageContent, ParseData
+from app.parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+# Content inside these elements is invisible on the rendered page, so it is
+# noise for retrieval (tracking snippets, CSS rules, JS fallbacks).
+_SKIPPED_TAGS = frozenset({"script", "style", "noscript", "template"})
+
+# Elements that end the current line of text. Inline tags (a, span, b, em...)
+# are deliberately absent: their text flows into the surrounding block.
+_BLOCK_TAGS = frozenset({
+    "p", "div", "section", "article", "aside", "header", "footer", "main",
+    "nav", "ul", "ol", "li", "dl", "dt", "dd", "table", "thead", "tbody",
+    "tr", "blockquote", "pre", "figure", "figcaption", "br", "hr",
+})
+
+_HEADING_LEVELS = {"h1": 1, "h2": 2, "h3": 3, "h4": 4, "h5": 5, "h6": 6}
+
+
+class _MarkdownExtractor(HTMLParser):
+    """Event-based extractor turning an HTML byte stream into markdown lines.
+
+    Heading tags map to markdown heading prefixes, block boundaries flush
+    the inline buffer into a line, and everything below a skipped element
+    is discarded. ``convert_charrefs=True`` (the default) resolves entities
+    like ``&amp;`` before ``handle_data`` sees them.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lines: list[str] = []
+        self._buffer: list[str] = []
+        self._skip_depth = 0
+        self._in_title = False
+        self._title_parts: list[str] = []
+        self._heading_level = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in _SKIPPED_TAGS:
+            self._skip_depth += 1
+            return
+        if self._skip_depth > 0:
+            return
+        if tag == "title":
+            self._in_title = True
+            return
+        if tag in _HEADING_LEVELS:
+            self._flush()
+            self._heading_level = _HEADING_LEVELS[tag]
+            return
+        if tag in _BLOCK_TAGS:
+            self._flush()
+
+    def handle_endtag(self, tag):
+        if tag in _SKIPPED_TAGS:
+            # max() guards against a stray closing tag in malformed markup.
+            self._skip_depth = max(0, self._skip_depth - 1)
+            return
+        if self._skip_depth > 0:
+            return
+        if tag == "title":
+            self._in_title = False
+            return
+        if tag in _HEADING_LEVELS:
+            self._flush()
+            self._heading_level = 0
+            return
+        if tag in _BLOCK_TAGS:
+            self._flush()
+
+    def handle_data(self, data):
+        if self._skip_depth > 0:
+            return
+        if self._in_title:
+            self._title_parts.append(data)
+            return
+        self._buffer.append(data)
+
+    def result_markdown(self) -> str:
+        """Assembles the final markdown after ``close()`` has been called."""
+        self._flush()
+        lines = list(self._lines)
+        title = " ".join(" ".join(self._title_parts).split())
+        if title:
+            lines.insert(0, f"# {title}")
+        # Joining non-empty lines with a blank line yields clean markdown
+        # paragraphs and collapses whatever vertical whitespace the page had.
+        return "\n\n".join(lines)
+
+    def _flush(self) -> None:
+        # split()/join collapses the runs of indentation whitespace HTML
+        # sources are full of; an all-whitespace buffer produces no line.
+        text = " ".join("".join(self._buffer).split())
+        self._buffer.clear()
+        if not text:
+            return
+        if self._heading_level > 0:
+            self._lines.append(f"{'#' * self._heading_level} {text}")
+        else:
+            self._lines.append(text)
+
+
+class HtmlParser(BaseParser):
+    """Handles .html and .htm — one page, no images, markdown-ish output."""
+
+    def parse(self, content: bytes, filename: str) -> ParseData:
+        try:
+            extractor = _MarkdownExtractor()
+            extractor.feed(decode_bytes(content))
+            extractor.close()
+            markdown = extractor.result_markdown()
+        except Exception as exc:
+            logger.error(
+                "html parse failed, errorCode=%s, filename=%s",
+                ErrorCode.PARSE_FAILED,
+                filename,
+            )
+            raise ParseError(f"failed to parse html file: {exc}") from exc
+
+        return ParseData(
+            markdown=markdown,
+            pages=[PageContent(page_no=1, text=markdown)],
+            images=[],
+        )

--- a/kb-rag-parser/app/parsers/registry.py
+++ b/kb-rag-parser/app/parsers/registry.py
@@ -13,6 +13,7 @@ from app.errors import ErrorCode, UnsupportedFormatError
 from app.parsers.base import BaseParser
 from app.parsers.docx import DocxParser
 from app.parsers.excel import CsvParser, ExcelParser
+from app.parsers.html import HtmlParser
 from app.parsers.pdf import PdfParser
 from app.parsers.text import TextParser
 
@@ -23,6 +24,7 @@ _docx_parser = DocxParser()
 _text_parser = TextParser()
 _excel_parser = ExcelParser()
 _csv_parser = CsvParser()
+_html_parser = HtmlParser()
 
 # file_ext (lowercase, no leading dot) -> parser instance.
 _REGISTRY: dict[str, BaseParser] = {
@@ -32,6 +34,8 @@ _REGISTRY: dict[str, BaseParser] = {
     "md": _text_parser,
     "xlsx": _excel_parser,
     "csv": _csv_parser,
+    "html": _html_parser,
+    "htm": _html_parser,
 }
 
 

--- a/kb-rag-parser/tests/test_parse_html.py
+++ b/kb-rag-parser/tests/test_parse_html.py
@@ -1,0 +1,109 @@
+"""Tests for the general HTML parser (M12-CONTRACTS.md section 2).
+
+Author: owlzhangfq@gmail.com
+"""
+
+from tests.conftest import post_parse
+
+_SAMPLE_HTML = """<!DOCTYPE html>
+<html>
+<head>
+  <title>kb-rag 指南</title>
+  <meta charset="utf-8">
+  <style>body { color: red; }</style>
+  <script>console.log("tracking");</script>
+</head>
+<body>
+  <h1>快速开始</h1>
+  <p>第一段，包含一个 <a href="https://example.com/link">链接文本</a> 与 <b>加粗</b>。</p>
+  <h2>安装步骤</h2>
+  <ul>
+    <li>第一步</li>
+    <li>第二步</li>
+  </ul>
+  <script>alert("in body");</script>
+  <noscript>请开启 JS</noscript>
+</body>
+</html>
+"""
+
+
+def test_parse_html_returns_expected_structure(client):
+    response = post_parse(client, "guide.html", _SAMPLE_HTML.encode("utf-8"), "html")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] == "OK"
+    data = body["data"]
+    markdown = data["markdown"]
+    # Title becomes the top-level heading, tag headings keep their levels.
+    assert markdown.startswith("# kb-rag 指南")
+    assert "# 快速开始" in markdown
+    assert "## 安装步骤" in markdown
+    assert len(data["pages"]) == 1
+    assert data["pages"][0]["page_no"] == 1
+    assert data["images"] == []
+
+
+def test_parse_html_strips_invisible_content(client):
+    response = post_parse(client, "guide.html", _SAMPLE_HTML.encode("utf-8"), "html")
+
+    markdown = response.json()["data"]["markdown"]
+    # script/style/noscript bodies are invisible on the page, so they must
+    # not leak into the retrieval corpus.
+    assert "console.log" not in markdown
+    assert "color: red" not in markdown
+    assert "alert(" not in markdown
+    assert "请开启 JS" not in markdown
+
+
+def test_parse_html_keeps_anchor_text_drops_href(client):
+    response = post_parse(client, "guide.html", _SAMPLE_HTML.encode("utf-8"), "html")
+
+    markdown = response.json()["data"]["markdown"]
+    assert "链接文本" in markdown
+    assert "https://example.com/link" not in markdown
+
+
+def test_parse_html_blocks_become_separate_lines(client):
+    content = "<div>alpha</div><div>beta</div>".encode("utf-8")
+
+    response = post_parse(client, "blocks.html", content, "html")
+
+    markdown = response.json()["data"]["markdown"]
+    # Adjacent blocks must not run together into one word.
+    assert "alphabeta" not in markdown
+    assert "alpha" in markdown
+    assert "beta" in markdown
+
+
+def test_parse_htm_extension_registered(client):
+    content = "<p>htm works</p>".encode("utf-8")
+
+    response = post_parse(client, "legacy.htm", content, "htm")
+
+    assert response.status_code == 200
+    assert "htm works" in response.json()["data"]["markdown"]
+
+
+def test_parse_html_gbk_encoded(client):
+    content = "<html><body><p>中文编码测试</p></body></html>".encode("gbk")
+
+    response = post_parse(client, "gbk.html", content, "html")
+
+    assert response.status_code == 200
+    assert "中文编码测试" in response.json()["data"]["markdown"]
+
+
+def test_parse_html_malformed_markup_is_tolerated(client):
+    # The stdlib tokenizer is forgiving: unclosed tags and stray closers
+    # still yield the visible text instead of an error.
+    content = "<p>unclosed <b>bold</p></i><div>tail".encode("utf-8")
+
+    response = post_parse(client, "broken.html", content, "html")
+
+    assert response.status_code == 200
+    markdown = response.json()["data"]["markdown"]
+    assert "unclosed" in markdown
+    assert "bold" in markdown
+    assert "tail" in markdown

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -7,6 +7,44 @@
 
 尚未打过 tag，以下条目全部属于首个发布版本的内容，按里程碑倒序排列。
 
+### 新增（M13）
+
+- Prometheus 业务指标：`kb-api/pom.xml` 补齐 `micrometer-registry-prometheus` 依赖，激活既有 actuator 的 `/actuator/prometheus` 端点（JVM/HTTP 基础指标随自动配置免费提供）。业务指标经 `KbMetrics` 门面单点注册：`kb_search_seconds`（Timer，标签 source=console/open_api、zero_hit、degraded；chat-preview 管理流量不计入）、`kb_task_completed_total`（Counter，type × success/failed）、`kb_openapi_rejected_total`（Counter，按 error_code）、`kb_websource_sync_total`（Counter，按 M12 同步四态）、`kb_task_backlog`（`TaskBacklogMetrics` gauge，pending/running 两支，抓取时实查 DB，DB 异常返回 NaN 不使抓取失败）
+- 纯新增：无表变更、无新环境变量、无既有端点行为变化；该端点与 health 同口径暂不鉴权，生产由部署侧网络隔离
+
+### 新增（M12）
+
+- `[schema]` Flyway `V14__web_source.sql`：新增 `t_kb_web_source`（网页来源登记，ID 前缀 `ws`）
+- URL 导入登记即抓：`POST|GET /api/v1/kb/{kbId}/web-sources`、`POST /api/v1/web-sources/{id}/sync`（手动同步）、`PUT|DELETE /api/v1/web-sources/{id}`（定时同步开关 / 移除登记）；抓取产物统一走既有文档上传管线（URL 派生稳定文件名，重抓同名建新版本、`content_hash` 去重），登记与文档为弱绑定——移除登记不删文档
+- 增量同步四态（SUCCESS / UNCHANGED / SKIPPED / FAILED）落行可见：内容 hash 未变不建版本记 UNCHANGED，绑定文档在回收站则 SKIPPED；定时任务按批扫描（`WEB_IMPORT_SYNC_CRON`，默认 02:30）
+- SSRF 防线收敛在 kb-domain 领域服务 `UrlGuard`：仅 http/https、拒内网 / 回环 / 链路本地地址；重定向由 `HttpWebPageFetcher` 手动跟随且逐跳复验，Content-Type 白名单、流式体积上限（`WEB_IMPORT_MAX_PAGE_SIZE_MB`）、超时控制（`WEB_IMPORT_FETCH_TIMEOUT_MS`）
+- 新增出站端口 `WebPageFetcher`（实现 `HttpWebPageFetcher`）；新增环境变量 `WEB_IMPORT_FETCH_TIMEOUT_MS` / `WEB_IMPORT_MAX_PAGE_SIZE_MB` / `WEB_IMPORT_MAX_REDIRECTS` / `WEB_IMPORT_SYNC_CRON` / `WEB_IMPORT_SYNC_ENABLED` / `WEB_IMPORT_SYNC_BATCH_SIZE`
+
+### 变更（M12）
+
+- **上传白名单默认值变更（醒目提示）**：`UPLOAD_ALLOWED_EXTENSIONS` 默认值新增 `html`（网页抓取产物走上传管线的前提）。显式设置过该变量的部署需自行追加 `html`，否则 URL 导入首次同步即报「不支持的文件类型」；html 无魔数，与 txt/md/csv 同样仅验扩展名与大小
+
+### 新增（M11）
+
+- `[schema]` Flyway `V13__document_governance.sql`：`t_kb_document` 增 `publish_status` / `review_note` / `effective_at` / `expires_at` / `trashed` / `trashed_at`，`t_kb_knowledge_base` 增 `review_required`；存量文档升级后默认 PUBLISHED / 无有效期 / 不在回收站，检索结果与升级前一致
+- 审核发布：知识库级 `review_required` 开关（`PUT /api/v1/kb/{kbId}/governance`），开启后新上传文档初始为 DRAFT，经 submit-review / approve / reject 状态机（DRAFT|REJECTED → PENDING_REVIEW → PUBLISHED|REJECTED）发布后才参与检索
+- 文档有效期：`PUT /api/v1/documents/{docId}/validity` 设置 / 清除 `effective_at` / `expires_at` 窗口，仅窗口内参与检索，`expires_at` 设为过去即立即下架
+- 回收站：trash 列表 / restore / purge 端点，超过保留期（`TRASH_RETENTION_DAYS`，默认 30）由定时任务分批物理清除
+- 治理三态均收敛为检索时的活跃集 DB 谓词过滤，不写引擎，状态变更即时生效（时间窗穿越靠缓存 TTL 5 分钟内收敛）；已发布应用快照固化可见集，不受治理影响
+- 新增环境变量 `TRASH_RETENTION_DAYS` / `TRASH_PURGE_BATCH_SIZE` / `TRASH_PURGE_CRON` / `TRASH_PURGE_ENABLED`
+
+### 变更（M11）
+
+- **`DELETE /api/v1/documents/{docId}` 语义变更（醒目提示）**：URL 不变，但删除由不可逆改为移入回收站（检索立即下线、数据保留、保留期内可 `POST /api/v1/documents/{docId}/restore` 还原）；原来的不可逆删除（含两个检索引擎副本）迁移至 `DELETE /api/v1/documents/{docId}/purge`，且仅对回收站内文档有效（两段式防误删）。依赖旧语义的调用方需改为先 DELETE 再 purge
+
+### 新增（M10）
+
+- `[schema]` Flyway `V12__retrieval_feedback_and_search_insight.sql`：新增 `t_kb_retrieval_feedback`（ID 前缀 `rfb`）与 `t_kb_search_insight`（ID 前缀 `si`）
+- 检索反馈从 log-only 升级为持久化闭环：`POST /api/v1/retrieval-feedback` payload 不变（兼容红线）但落库为可管理行（有用 / 无用 + 原因，幂等键防重复提交）；新增知识库维度的反馈列表、转评测集（case source=FEEDBACK）与忽略端点
+- 检索洞察：控制台调试与 OpenAPI 检索自动记录脱敏摘要 / 命中数 / 降级标记（评测运行不记录，不存原文）；新增明细分页与内容缺口报表端点（零命中率 / Top 未命中 query 归一化分组）
+- 洞察行保留期清理（`INSIGHT_RETENTION_DAYS`，默认 90）：统计而非证据，到期分批直删、不做对象存储归档
+- 新增环境变量 `INSIGHT_ENABLED` / `INSIGHT_RETENTION_DAYS` / `INSIGHT_CLEANUP_BATCH_SIZE` / `INSIGHT_CLEANUP_CRON`
+
 ### 变更（M9 之后）
 
 - **full 模式向量引擎定为 Qdrant（不兼容变更）**：`VectorEngine` 枚举取值为 `ES` / `QDRANT`，

--- a/kb-rag-server/README.md
+++ b/kb-rag-server/README.md
@@ -12,7 +12,8 @@ kb-rag-server            # parent，统一依赖版本
 ├── kb-domain            # 实体 + Mapper + 枚举 + 纯领域算法（切分、融合、指纹、评测指标、门禁裁决）+ 出站端口接口
 ├── kb-infrastructure    # 端口实现：Elasticsearch、Qdrant、Neo4j、MinIO、模型 Provider、parser 客户端、Webhook
 ├── kb-app               # 应用编排：kb / document / index / retrieval / graph / annotation / eval /
-│                        #           appcenter / openapi / chat / alert / dict / auth / system / config
+│                        #           appcenter / openapi / chat / alert / dict / auth / system / config /
+│                        #           feedback / insight / governance / websource / metrics
 └── kb-api               # Controller + DTO + 过滤器 + 健康探针 + Flyway 脚本 + 启动类
 ```
 
@@ -40,6 +41,10 @@ kb-infrastructure 实现 kb-domain 定义的端口接口，kb-app 只依赖端�
 | M7 | GraphRAG：实体 / 关系抽取入 Neo4j、图路作为库内第三路进 RRF、级联清理、图谱管理端点 |
 | M8 | 导入与解析增强：聊天记录 TXT/HTML 格式、聊天聚合重叠滑窗与检索侧近重复归并、字段映射档案维护 |
 | M9 | 标注语义与图搜：父片按偏移精确剔除禁用子片、标注跨版本相似度辅助迁移（对称 Dice）、图片 query |
+| M10 | 检索质量闭环：检索反馈（有用 / 无用 + 原因）持久化、检索洞察埋点与统计报表、零命中问题与内容缺口清单 |
+| M11 | 内容治理：文档审核状态机（草稿 / 待审 / 已发布 / 已驳回）、有效期调度（生效 / 过期自动下线）、回收站软删除与恢复 |
+| M12 | 数据接入：网页 URL 导入（登记即抓取）、增量同步四态（成功 / 未变更 / 失败 / 跳过）、SSRF 防护、通用 HTML 解析 |
+| M13 | 运维指标：Prometheus 端点激活，检索耗时 / 任务完成 / 开放 API 拒绝 / 网页同步四类业务指标 + 任务积压 gauge |
 
 ## 环境要求
 
@@ -162,7 +167,7 @@ mvn -B -ntp -DskipTests package
 java -jar kb-api/target/kb-rag-server.jar
 ```
 
-启动时 Flyway 自动执行迁移（当前 V1–V11，23 张业务表）。数据库中没有管理员账号时会创建 `admin` 并把随机密码打印到启动日志（只打印一次），首次登录强制改密。
+启动时 Flyway 自动执行迁移（当前 V1–V14，26 张业务表）。数据库中没有管理员账号时会创建 `admin` 并把随机密码打印到启动日志（只打印一次），首次登录强制改密。
 
 跑测试：
 
@@ -175,7 +180,7 @@ mvn -B -ntp verify        # CI 跑的命令，等价于全量单测 + 打包
 
 ## 接口
 
-接口清单不在本文件维护，以 OpenAPI 契约为准：`kb-rag-deploy/docs/openapi/kb-server.yaml`（75 条路径 / 92 个操作）。契约先行——改动端点或 DTO 时先改 yaml 再改代码。
+接口清单不在本文件维护，以 OpenAPI 契约为准：`kb-rag-deploy/docs/openapi/kb-server.yaml`（92 条路径 / 111 个操作）。契约先行——改动端点或 DTO 时先改 yaml 再改代码。
 
 鉴权分两条完全独立的链路：
 
@@ -188,7 +193,7 @@ mvn -B -ntp verify        # CI 跑的命令，等价于全量单测 + 打包
 
 统一响应体：成功 `{"code":"OK","message":"success","data":...,"request_id":"..."}`，失败 `{"code":"...","message":"...","request_id":"..."}`。`request_id` 在入口过滤器生成（可由 `X-Request-Id` 请求头指定），写入日志 MDC，透传给 parser 服务，并随异步线程池的 `TaskDecorator` 传到 worker 线程。
 
-`/actuator` 的暴露白名单为 `health,info,prometheus`；健康探针含 MySQL、Elasticsearch、MinIO，配置了 Qdrant / Neo4j 时各自增加一项。指标端点需要额外引入 micrometer 的 Prometheus registry 才会真正出现，当前依赖里没有它，所以实际可用的是 `health` 与 `info`。
+`/actuator` 的暴露白名单为 `health,info,prometheus`；健康探针含 MySQL、Elasticsearch、MinIO，配置了 Qdrant / Neo4j 时各自增加一项。M13 起依赖里已包含 micrometer 的 Prometheus registry，`/actuator/prometheus` 可直接抓取：业务指标为 `kb_search_seconds`（Timer，source / zero_hit / degraded 标签）、`kb_task_completed_total`、`kb_openapi_rejected_total`、`kb_websource_sync_total` 三个 Counter 与 `kb_task_backlog`（pending / running 两支 gauge，数据库不可用时回 NaN 不失败）。该端点与 health 同口径暂不鉴权。
 
 ## 文档导航
 
@@ -198,7 +203,7 @@ mvn -B -ntp verify        # CI 跑的命令，等价于全量单测 + 打包
 |---|---|
 | `ARCHITECTURE.md` | 四仓总体架构；§3 是本服务的模块、端口、检索链路、索引管线、异步与数据模型 |
 | `FLOWS.md` | 端到端流程时序（上传入库、检索、发布、评测、导入） |
-| `M1~M9-CONTRACTS.md` | 各里程碑的开发契约与「实现期修订」——实现与契约的偏离都记在这里 |
+| `M1~M13-CONTRACTS.md` | 各里程碑的开发契约与「实现期修订」——实现与契约的偏离都记在这里 |
 | `openapi/kb-server.yaml` | 本服务的 API 契约 |
 | `openapi/kb-parser.yaml` | parser 服务的 API 契约 |
 | `backup-restore.md` | 备份与恢复演练步骤、RPO/RTO |

--- a/kb-rag-server/kb-api/pom.xml
+++ b/kb-rag-server/kb-api/pom.xml
@@ -35,6 +35,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <!--
+          Turns the already-exposed /actuator/prometheus endpoint live (M13): the actuator's
+          auto configuration only wires the endpoint once this registry is on the classpath.
+        -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/DocumentController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/DocumentController.java
@@ -7,6 +7,7 @@ import io.kbrag.api.dto.PageResponse;
 import io.kbrag.api.dto.ReparseRequest;
 import io.kbrag.app.document.DocumentPreviewService;
 import io.kbrag.app.document.DocumentService;
+import io.kbrag.app.governance.DocumentGovernanceService;
 import io.kbrag.common.api.Result;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.domain.enums.ProcessStatus;
@@ -42,6 +43,7 @@ public class DocumentController {
 
     private final DocumentService documentService;
     private final DocumentPreviewService documentPreviewService;
+    private final DocumentGovernanceService documentGovernanceService;
 
     /**
      * Uploads a document and hands it over to the asynchronous pipeline.
@@ -152,14 +154,18 @@ public class DocumentController {
     }
 
     /**
-     * Removes a document, its versions and its chunks, including the engine copies.
+     * Moves a document into the recycle bin, out of retrieval but restorable.
+     *
+     * <p>The URL predates M11 and keeps its meaning of "delete this document" for every caller; what
+     * changed is that the deletion is now reversible until the retention period runs out or an
+     * explicit purge follows. Chunks, versions and engine copies stay untouched until then.
      *
      * @param docId document business id
      * @return empty success envelope
      */
     @DeleteMapping("/api/v1/documents/{docId}")
     public Result<Void> delete(@PathVariable String docId) {
-        documentService.delete(docId);
+        documentGovernanceService.trash(docId);
         return Result.success(null);
     }
 

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/DocumentGovernanceController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/DocumentGovernanceController.java
@@ -1,0 +1,163 @@
+package io.kbrag.api.controller;
+
+import io.kbrag.api.dto.DocumentResponse;
+import io.kbrag.api.dto.PageResponse;
+import io.kbrag.api.dto.RejectDocumentRequest;
+import io.kbrag.api.dto.UpdateValidityRequest;
+import io.kbrag.app.governance.DocumentGovernanceService;
+import io.kbrag.common.api.Result;
+import io.kbrag.common.exception.BizException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Content governance endpoints of the console, the M11 contract section 2.2: the review state
+ * machine, the validity window and the recycle bin.
+ *
+ * <p>The document delete endpoint itself lives in {@link DocumentController} because its URL
+ * predates M11; only its semantics moved here, to a trash operation.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequiredArgsConstructor
+public class DocumentGovernanceController {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 200;
+
+    private final DocumentGovernanceService documentGovernanceService;
+
+    /**
+     * Submits a draft or a rejected document for review.
+     *
+     * @param docId document business id
+     * @return updated document
+     */
+    @PostMapping("/api/v1/documents/{docId}/submit-review")
+    public Result<DocumentResponse> submitReview(@PathVariable String docId) {
+        return Result.success(DocumentResponse.from(documentGovernanceService.submitReview(docId)));
+    }
+
+    /**
+     * Approves a pending document, admitting it to retrieval.
+     *
+     * @param docId document business id
+     * @return updated document
+     */
+    @PostMapping("/api/v1/documents/{docId}/approve")
+    public Result<DocumentResponse> approve(@PathVariable String docId) {
+        return Result.success(DocumentResponse.from(documentGovernanceService.approve(docId)));
+    }
+
+    /**
+     * Rejects a pending document with a reason the author will see.
+     *
+     * @param docId   document business id
+     * @param request rejection payload carrying the mandatory note
+     * @return updated document
+     */
+    @PostMapping("/api/v1/documents/{docId}/reject")
+    public Result<DocumentResponse> reject(@PathVariable String docId,
+                                           @Valid @RequestBody RejectDocumentRequest request) {
+        return Result.success(DocumentResponse.from(
+                documentGovernanceService.reject(docId, request.note().trim())));
+    }
+
+    /**
+     * Sets or clears the validity window of a document.
+     *
+     * @param docId   document business id
+     * @param request window bounds, {@code null} bounds are cleared
+     * @return updated document
+     */
+    @PutMapping("/api/v1/documents/{docId}/validity")
+    public Result<DocumentResponse> updateValidity(@PathVariable String docId,
+                                                   @RequestBody UpdateValidityRequest request) {
+        return Result.success(DocumentResponse.from(documentGovernanceService.updateValidity(docId,
+                parseTime(request.effectiveAt(), "effective_at"),
+                parseTime(request.expiresAt(), "expires_at"))));
+    }
+
+    /**
+     * Lists the recycle bin of a knowledge base, most recently trashed first.
+     *
+     * @param kbId knowledge base business id
+     * @param page one based page number
+     * @param size page size
+     * @return paged trashed documents
+     */
+    @GetMapping("/api/v1/kb/{kbId}/trash")
+    public Result<PageResponse<DocumentResponse>> listTrash(
+            @PathVariable String kbId,
+            @RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) long page,
+            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) long size) {
+        return Result.success(PageResponse.from(
+                documentGovernanceService.listTrash(kbId, normalizePage(page), normalizeSize(size)),
+                DocumentResponse::from));
+    }
+
+    /**
+     * Restores a trashed document to exactly the state it was deleted in.
+     *
+     * @param docId document business id
+     * @return updated document
+     */
+    @PostMapping("/api/v1/documents/{docId}/restore")
+    public Result<DocumentResponse> restore(@PathVariable String docId) {
+        return Result.success(DocumentResponse.from(documentGovernanceService.restore(docId)));
+    }
+
+    /**
+     * Irreversibly removes a trashed document, engine copies included.
+     *
+     * @param docId document business id
+     * @return empty success envelope
+     */
+    @DeleteMapping("/api/v1/documents/{docId}/purge")
+    public Result<Void> purge(@PathVariable String docId) {
+        documentGovernanceService.purge(docId);
+        return Result.success(null);
+    }
+
+    /**
+     * Parses an ISO local date time bound.
+     *
+     * @param value request literal
+     * @param field field name, for the rejection message
+     * @return timestamp, {@code null} when the bound is absent
+     */
+    private LocalDateTime parseTime(String value, String field) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDateTime.parse(value.trim());
+        } catch (DateTimeParseException e) {
+            throw BizException.invalidParam(field + " 需为 ISO 格式的日期时间，例如 2026-07-26T00:00:00");
+        }
+    }
+
+    private long normalizePage(long page) {
+        return page < DEFAULT_PAGE ? DEFAULT_PAGE : page;
+    }
+
+    private long normalizeSize(long size) {
+        if (size < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/KnowledgeBaseController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/KnowledgeBaseController.java
@@ -7,8 +7,10 @@ import io.kbrag.api.dto.CreateKnowledgeBaseRequest;
 import io.kbrag.api.dto.KnowledgeBaseResponse;
 import io.kbrag.api.dto.RebuildRequest;
 import io.kbrag.api.dto.UpdateIndexConfigRequest;
+import io.kbrag.api.dto.UpdateKbGovernanceRequest;
 import io.kbrag.app.chat.ChatImportService;
 import io.kbrag.app.document.DocumentPreviewService;
+import io.kbrag.app.governance.DocumentGovernanceService;
 import io.kbrag.app.index.RebuildService;
 import io.kbrag.app.kb.KnowledgeBaseService;
 import io.kbrag.common.api.Result;
@@ -53,6 +55,7 @@ public class KnowledgeBaseController {
     private final RebuildService rebuildService;
     private final DocumentPreviewService documentPreviewService;
     private final ChatImportService chatImportService;
+    private final DocumentGovernanceService documentGovernanceService;
 
     /**
      * Creates a knowledge base together with its physical indices and aliases.
@@ -180,6 +183,20 @@ public class KnowledgeBaseController {
             @Valid @RequestBody ChatImportConfirmRequest request) {
         List<String> imported = chatImportService.confirm(kbId, request.uploadToken(), request.sessionIds());
         return Result.success(Map.of(FIELD_IMPORTED_DOC_IDS, imported));
+    }
+
+    /**
+     * Flips the review switch of a knowledge base; only future uploads read it.
+     *
+     * @param kbId    business identifier
+     * @param request governance payload
+     * @return updated knowledge base
+     */
+    @PutMapping("/{kbId}/governance")
+    public Result<KnowledgeBaseResponse> updateGovernance(@PathVariable String kbId,
+                                                          @Valid @RequestBody UpdateKbGovernanceRequest request) {
+        return Result.success(toResponse(
+                documentGovernanceService.updateGovernance(kbId, request.reviewRequired())));
     }
 
     /**

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/RetrievalFeedbackController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/RetrievalFeedbackController.java
@@ -1,37 +1,139 @@
 package io.kbrag.api.controller;
 
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.kbrag.api.dto.ConvertFeedbackRequest;
+import io.kbrag.api.dto.PageResponse;
 import io.kbrag.api.dto.RetrievalFeedbackRequest;
+import io.kbrag.api.dto.RetrievalFeedbackResponse;
+import io.kbrag.app.feedback.RetrievalFeedbackService;
 import io.kbrag.common.api.Result;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.entity.RetrievalFeedback;
+import io.kbrag.domain.enums.FeedbackStatus;
+import io.kbrag.domain.enums.FeedbackVerdict;
 import jakarta.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Good/bad feedback on one debug page result, requirement section 4.5.
+ * Good/bad feedback on debug page results, requirement section 4.5 and the M10 contract section 2.1.
  *
- * <p>See the M4b contract section 2 and {@link RetrievalFeedbackRequest} for why this endpoint does
- * not persist anything: a {@code GOOD} verdict is already covered by
- * {@code POST /eval-datasets/{datasetId}/cases/from-retrieval}, which the debug page calls once an
- * operator names a target data set, and a standalone {@code BAD} table has no consumer this milestone.
+ * <p>The submission payload is unchanged from M4b - the compatibility line of the M10 contract - but
+ * the behaviour is upgraded from "log and forget" to a persisted row the console can list, convert
+ * into an evaluation case or dismiss.
  *
  * @author owlzhangfq@gmail.com
  */
-@Slf4j
 @RestController
+@RequiredArgsConstructor
 public class RetrievalFeedbackController {
 
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 200;
+
+    private final RetrievalFeedbackService retrievalFeedbackService;
+
     /**
-     * Records a feedback signal without persisting it.
+     * Records one feedback signal.
      *
      * @param request feedback payload
-     * @return empty payload
+     * @return persisted row, {@code status=NEW}
      */
     @PostMapping("/api/v1/retrieval-feedback")
-    public Result<Void> feedback(@Valid @RequestBody RetrievalFeedbackRequest request) {
-        log.info("retrieval feedback received, kbId={}, chunkId={}, verdict={}",
-                request.kbId(), request.chunkId(), request.verdict());
-        return Result.success(null);
+    public Result<RetrievalFeedbackResponse> feedback(@Valid @RequestBody RetrievalFeedbackRequest request) {
+        FeedbackVerdict verdict = FeedbackVerdict.from(request.verdict());
+        if (verdict == null) {
+            throw BizException.invalidParam("verdict 仅支持 GOOD 或 BAD");
+        }
+        RetrievalFeedback feedback = retrievalFeedbackService.record(
+                request.kbId(), request.query(), request.chunkId(), verdict);
+        return Result.success(RetrievalFeedbackResponse.from(feedback));
+    }
+
+    /**
+     * Pages the feedback of one knowledge base, newest first.
+     *
+     * @param kbId    knowledge base business id
+     * @param verdict optional {@code GOOD} or {@code BAD} filter
+     * @param status  optional {@code NEW}, {@code CONVERTED} or {@code DISMISSED} filter
+     * @param page    one based page number
+     * @param size    page size
+     * @return paged rows
+     */
+    @GetMapping("/api/v1/kb/{kbId}/retrieval-feedback")
+    public Result<PageResponse<RetrievalFeedbackResponse>> list(
+            @PathVariable String kbId,
+            @RequestParam(required = false) String verdict,
+            @RequestParam(required = false) String status,
+            @RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) long page,
+            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) long size) {
+        IPage<RetrievalFeedback> paged = retrievalFeedbackService.list(kbId,
+                parseVerdict(verdict), parseStatus(status), normalizePage(page), normalizeSize(size));
+        return Result.success(PageResponse.from(paged, RetrievalFeedbackResponse::from));
+    }
+
+    /**
+     * Converts one {@code GOOD} feedback into an evaluation case.
+     *
+     * @param feedbackId feedback business id
+     * @param request    target data set
+     * @return the same row, {@code status=CONVERTED} with the case id filled in
+     */
+    @PostMapping("/api/v1/retrieval-feedback/{feedbackId}/convert")
+    public Result<RetrievalFeedbackResponse> convert(@PathVariable String feedbackId,
+                                                     @Valid @RequestBody ConvertFeedbackRequest request) {
+        return Result.success(RetrievalFeedbackResponse.from(
+                retrievalFeedbackService.convert(feedbackId, request.datasetId())));
+    }
+
+    /**
+     * Dismisses one feedback.
+     *
+     * @param feedbackId feedback business id
+     * @return the same row, {@code status=DISMISSED}
+     */
+    @PostMapping("/api/v1/retrieval-feedback/{feedbackId}/dismiss")
+    public Result<RetrievalFeedbackResponse> dismiss(@PathVariable String feedbackId) {
+        return Result.success(RetrievalFeedbackResponse.from(
+                retrievalFeedbackService.dismiss(feedbackId)));
+    }
+
+    private FeedbackVerdict parseVerdict(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        FeedbackVerdict verdict = FeedbackVerdict.from(value);
+        if (verdict == null) {
+            throw BizException.invalidParam("verdict 仅支持 GOOD 或 BAD");
+        }
+        return verdict;
+    }
+
+    private FeedbackStatus parseStatus(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        FeedbackStatus status = FeedbackStatus.from(value);
+        if (status == null) {
+            throw BizException.invalidParam("status 仅支持 NEW、CONVERTED 或 DISMISSED");
+        }
+        return status;
+    }
+
+    private long normalizePage(long page) {
+        return page < DEFAULT_PAGE ? DEFAULT_PAGE : page;
+    }
+
+    private long normalizeSize(long size) {
+        if (size < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
     }
 }

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/SearchController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/SearchController.java
@@ -2,14 +2,22 @@ package io.kbrag.api.controller;
 
 import io.kbrag.api.dto.SearchRequest;
 import io.kbrag.api.dto.SearchResponse;
+import io.kbrag.app.insight.SearchInsightService;
+import io.kbrag.app.metrics.KbMetrics;
 import io.kbrag.app.retrieval.RetrievalService;
+import io.kbrag.app.retrieval.SearchOutcome;
 import io.kbrag.common.api.Result;
+import io.kbrag.common.context.RequestIdHolder;
+import io.kbrag.domain.enums.InsightSource;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * Retrieval debug endpoint of the console.
@@ -18,6 +26,11 @@ import org.springframework.web.bind.annotation.RestController;
  * effective value comes from three configuration layers the transport has no business knowing about;
  * this class only validates the shape of the payload.
  *
+ * <p>Also the console side insight recording point, the M10 contract section 2.2: recording sits at
+ * the API boundary rather than inside the retrieval pipeline, so evaluation runs and gate reruns -
+ * which reuse the same pipeline - never appear in the miss report. The write is asynchronous and a
+ * failed retrieval records nothing. The M13 search metric shares this boundary and this reasoning.
+ *
  * @author owlzhangfq@gmail.com
  */
 @RestController
@@ -25,6 +38,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController {
 
     private final RetrievalService retrievalService;
+    private final SearchInsightService searchInsightService;
+    private final KbMetrics kbMetrics;
 
     /**
      * Runs one retrieval call against a knowledge base.
@@ -36,6 +51,21 @@ public class SearchController {
     @PostMapping("/api/v1/kb/{kbId}/search")
     public Result<SearchResponse> search(@PathVariable String kbId,
                                          @Valid @RequestBody SearchRequest request) {
-        return Result.success(SearchResponse.from(retrievalService.search(kbId, request.toCommand())));
+        long startedAt = System.currentTimeMillis();
+        SearchOutcome outcome = retrievalService.search(kbId, request.toCommand());
+        int resultCount = CollectionUtils.isEmpty(outcome.getNodes()) ? 0 : outcome.getNodes().size();
+        kbMetrics.recordSearch(InsightSource.CONSOLE, System.currentTimeMillis() - startedAt,
+                resultCount, outcome.getDegraded());
+        searchInsightService.recordAsync(SearchInsightService.InsightRecord.builder()
+                .source(InsightSource.CONSOLE)
+                .kbIds(List.of(kbId))
+                .query(request.query())
+                .resultCount(resultCount)
+                .topScore(CollectionUtils.isEmpty(outcome.getNodes())
+                        ? null : outcome.getNodes().get(0).getScore())
+                .degraded(outcome.getDegraded())
+                .requestId(RequestIdHolder.get())
+                .build());
+        return Result.success(SearchResponse.from(outcome));
     }
 }

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/SearchInsightController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/SearchInsightController.java
@@ -1,0 +1,106 @@
+package io.kbrag.api.controller;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.kbrag.api.dto.PageResponse;
+import io.kbrag.api.dto.SearchInsightResponse;
+import io.kbrag.api.dto.SearchInsightStatsResponse;
+import io.kbrag.app.insight.SearchInsightService;
+import io.kbrag.common.api.Result;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.entity.SearchInsight;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Search insight listing and content gap report of the console, the M10 contract section 2.2.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/v1/kb/{kbId}/search-insights")
+@RequiredArgsConstructor
+public class SearchInsightController {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 200;
+
+    private final SearchInsightService searchInsightService;
+
+    /**
+     * Pages the insight rows of one knowledge base, newest first.
+     *
+     * @param kbId    knowledge base business id
+     * @param zeroHit optional zero hit filter
+     * @param from    optional ISO lower bound of the call time
+     * @param to      optional ISO upper bound of the call time
+     * @param page    one based page number
+     * @param size    page size
+     * @return paged rows
+     */
+    @GetMapping
+    public Result<PageResponse<SearchInsightResponse>> list(
+            @PathVariable String kbId,
+            @RequestParam(name = "zero_hit", required = false) Boolean zeroHit,
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String to,
+            @RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) long page,
+            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) long size) {
+        IPage<SearchInsight> paged = searchInsightService.list(kbId, zeroHit,
+                parseTime(from, "from"), parseTime(to, "to"), normalizePage(page), normalizeSize(size));
+        return Result.success(PageResponse.from(paged, SearchInsightResponse::from));
+    }
+
+    /**
+     * Aggregates the content gap report of one knowledge base.
+     *
+     * @param kbId knowledge base business id
+     * @param from optional ISO lower bound, defaults to seven days back
+     * @param to   optional ISO upper bound
+     * @return totals plus the top zero hit query groups
+     */
+    @GetMapping("/stats")
+    public Result<SearchInsightStatsResponse> stats(
+            @PathVariable String kbId,
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String to) {
+        return Result.success(SearchInsightStatsResponse.from(
+                searchInsightService.stats(kbId, parseTime(from, "from"), parseTime(to, "to"))));
+    }
+
+    /**
+     * Parses an ISO local date time bound.
+     *
+     * @param value request literal
+     * @param field field name, for the rejection message
+     * @return timestamp, {@code null} when unfiltered
+     */
+    private LocalDateTime parseTime(String value, String field) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDateTime.parse(value.trim());
+        } catch (DateTimeParseException e) {
+            throw BizException.invalidParam(field + " 需为 ISO 格式的日期时间，例如 2026-07-26T00:00:00");
+        }
+    }
+
+    private long normalizePage(long page) {
+        return page < DEFAULT_PAGE ? DEFAULT_PAGE : page;
+    }
+
+    private long normalizeSize(long size) {
+        if (size < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/WebSourceController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/WebSourceController.java
@@ -1,0 +1,120 @@
+package io.kbrag.api.controller;
+
+import io.kbrag.api.dto.PageResponse;
+import io.kbrag.api.dto.RegisterWebSourceRequest;
+import io.kbrag.api.dto.UpdateWebSourceRequest;
+import io.kbrag.api.dto.WebSourceResponse;
+import io.kbrag.app.websource.WebSourceService;
+import io.kbrag.common.api.Result;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * URL import endpoints of the console, the M12 contract section 3.4: register a page, watch its
+ * sync outcomes, trigger a sync by hand, flip the switch, remove the registration.
+ *
+ * <p>Register and manual sync both run the fetch inline and return its outcome in the response -
+ * the operator who just typed a URL wants to know right now whether it worked, not after the next
+ * scheduled pass.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequiredArgsConstructor
+public class WebSourceController {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 200;
+
+    private final WebSourceService webSourceService;
+
+    /**
+     * Registers a URL and runs its first fetch immediately.
+     *
+     * @param kbId    knowledge base business id
+     * @param request page address and the optional sync switch, on by default
+     * @return registration carrying the outcome of the first fetch
+     */
+    @PostMapping("/api/v1/kb/{kbId}/web-sources")
+    public Result<WebSourceResponse> register(@PathVariable String kbId,
+                                              @Valid @RequestBody RegisterWebSourceRequest request) {
+        boolean syncEnabled = request.syncEnabled() == null || request.syncEnabled();
+        return Result.success(WebSourceResponse.from(
+                webSourceService.register(kbId, request.url().trim(), syncEnabled)));
+    }
+
+    /**
+     * Lists the registrations of a knowledge base, most recently registered first.
+     *
+     * @param kbId knowledge base business id
+     * @param page one based page number
+     * @param size page size
+     * @return paged registrations
+     */
+    @GetMapping("/api/v1/kb/{kbId}/web-sources")
+    public Result<PageResponse<WebSourceResponse>> list(
+            @PathVariable String kbId,
+            @RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) long page,
+            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) long size) {
+        return Result.success(PageResponse.from(
+                webSourceService.list(kbId, normalizePage(page), normalizeSize(size)),
+                WebSourceResponse::from));
+    }
+
+    /**
+     * Runs one sync of one source on demand.
+     *
+     * @param sourceId registration business id
+     * @return registration carrying the outcome of this fetch
+     */
+    @PostMapping("/api/v1/web-sources/{sourceId}/sync")
+    public Result<WebSourceResponse> sync(@PathVariable String sourceId) {
+        return Result.success(WebSourceResponse.from(webSourceService.syncNow(sourceId)));
+    }
+
+    /**
+     * Flips the scheduled-sync switch of one source.
+     *
+     * @param sourceId registration business id
+     * @param request  new switch value
+     * @return updated registration
+     */
+    @PutMapping("/api/v1/web-sources/{sourceId}")
+    public Result<WebSourceResponse> update(@PathVariable String sourceId,
+                                            @Valid @RequestBody UpdateWebSourceRequest request) {
+        return Result.success(WebSourceResponse.from(
+                webSourceService.updateSyncEnabled(sourceId, request.syncEnabled())));
+    }
+
+    /**
+     * Removes a registration; the document it fed stays in the knowledge base.
+     *
+     * @param sourceId registration business id
+     * @return empty success envelope
+     */
+    @DeleteMapping("/api/v1/web-sources/{sourceId}")
+    public Result<Void> remove(@PathVariable String sourceId) {
+        webSourceService.remove(sourceId);
+        return Result.success(null);
+    }
+
+    private long normalizePage(long page) {
+        return page < DEFAULT_PAGE ? DEFAULT_PAGE : page;
+    }
+
+    private long normalizeSize(long size) {
+        if (size < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ConvertFeedbackRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ConvertFeedbackRequest.java
@@ -1,0 +1,16 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Payload of {@code POST /api/v1/retrieval-feedback/{feedbackId}/convert}: the one thing a conversion
+ * needs that the feedback row does not already know is where the case should land.
+ *
+ * @param datasetId target evaluation data set
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ConvertFeedbackRequest(
+        @JsonProperty("dataset_id") @NotBlank(message = "must not be blank") String datasetId) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/DocumentResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/DocumentResponse.java
@@ -3,6 +3,9 @@ package io.kbrag.api.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kbrag.app.document.UploadOutcome;
 import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.enums.PublishStatus;
+
+import java.time.LocalDateTime;
 
 /**
  * Document view.
@@ -16,6 +19,11 @@ import io.kbrag.domain.entity.Document;
  * @param processStatus    processing state
  * @param configStale      {@code true} when the active version used an older configuration
  * @param failReason       classified failure cause
+ * @param publishStatus    editorial state, PUBLISHED for every document that predates M11
+ * @param reviewNote       latest rejection reason, {@code null} unless the state is REJECTED
+ * @param effectiveAt      ISO lower bound of the validity window, {@code null} means unbounded
+ * @param expiresAt        ISO upper bound of the validity window, {@code null} means unbounded
+ * @param trashedAt        ISO instant the document entered the recycle bin, {@code null} outside it
  * @param createdAt        ISO creation timestamp
  * @param versionId        version the upload produced, only present on the upload response
  * @param version          version number of that version, only present on the upload response
@@ -34,6 +42,11 @@ public record DocumentResponse(
         @JsonProperty("process_status") String processStatus,
         @JsonProperty("config_stale") boolean configStale,
         @JsonProperty("fail_reason") String failReason,
+        @JsonProperty("publish_status") String publishStatus,
+        @JsonProperty("review_note") String reviewNote,
+        @JsonProperty("effective_at") String effectiveAt,
+        @JsonProperty("expires_at") String expiresAt,
+        @JsonProperty("trashed_at") String trashedAt,
         @JsonProperty("created_at") String createdAt,
         @JsonProperty("version_id") String versionId,
         String version,
@@ -78,10 +91,21 @@ public record DocumentResponse(
                 entity.getProcessStatus() == null ? null : entity.getProcessStatus().name(),
                 entity.getConfigStale() != null && entity.getConfigStale() == STALE,
                 entity.getFailReason(),
+                // Rows written before the M11 migration carry a null column and are PUBLISHED by contract.
+                entity.getPublishStatus() == null
+                        ? PublishStatus.PUBLISHED.name() : entity.getPublishStatus().name(),
+                entity.getReviewNote(),
+                iso(entity.getEffectiveAt()),
+                iso(entity.getExpiresAt()),
+                iso(entity.getTrashedAt()),
                 entity.getCreatedAt() == null ? null : entity.getCreatedAt().toString(),
                 versionId,
                 version,
                 duplicated,
                 duplicateOfDocId);
+    }
+
+    private static String iso(LocalDateTime value) {
+        return value == null ? null : value.toString();
     }
 }

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/KnowledgeBaseResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/KnowledgeBaseResponse.java
@@ -21,6 +21,7 @@ import io.kbrag.domain.model.KbRetrievalConfig;
  * @param graphEnabled            graph route switch, inlined for the same reason the index configuration
  *                                is: the console renders it on the knowledge base card and a second
  *                                request per row would be N+1
+ * @param reviewRequired          {@code true} makes new documents start as DRAFT instead of PUBLISHED
  * @param createdAt               ISO creation timestamp
  *
  * @author owlzhangfq@gmail.com
@@ -32,7 +33,10 @@ public record KnowledgeBaseResponse(
         @JsonProperty("index_config") KbIndexConfig indexConfig,
         @JsonProperty("current_config_fingerprint") String currentConfigFingerprint,
         @JsonProperty("graph_enabled") boolean graphEnabled,
+        @JsonProperty("review_required") boolean reviewRequired,
         @JsonProperty("created_at") String createdAt) {
+
+    private static final int REVIEW_REQUIRED = 1;
 
     /**
      * Maps an entity onto its view.
@@ -51,6 +55,7 @@ public record KnowledgeBaseResponse(
                 indexConfig,
                 entity.getCurrentConfigFingerprint(),
                 retrievalConfig != null && retrievalConfig.graphEnabled(),
+                entity.getReviewRequired() != null && entity.getReviewRequired() == REVIEW_REQUIRED,
                 entity.getCreatedAt() == null ? null : entity.getCreatedAt().toString());
     }
 }

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RegisterWebSourceRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RegisterWebSourceRequest.java
@@ -1,0 +1,19 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Payload of {@code POST /api/v1/kb/{kbId}/web-sources}: registers one page URL for import.
+ *
+ * @param url         page address, http or https
+ * @param syncEnabled whether the scheduled pass should keep this page fresh, defaults to on
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record RegisterWebSourceRequest(
+        @NotBlank(message = "must not be blank") @Size(max = 2048, message = "must be at most 2048 characters")
+        String url,
+        @JsonProperty("sync_enabled") Boolean syncEnabled) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RejectDocumentRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RejectDocumentRequest.java
@@ -1,0 +1,17 @@
+package io.kbrag.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Payload of {@code POST /api/v1/documents/{docId}/reject}: a rejection without a reason gives the
+ * author nothing to revise, so the note is the one mandatory field.
+ *
+ * @param note rejection reason shown to the author
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record RejectDocumentRequest(
+        @NotBlank(message = "must not be blank") @Size(max = 512, message = "must be at most 512 characters")
+        String note) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RetrievalFeedbackResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RetrievalFeedbackResponse.java
@@ -1,0 +1,57 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kbrag.domain.entity.RetrievalFeedback;
+
+/**
+ * One feedback row of the console's feedback management view.
+ *
+ * <p>The raw query is returned to the console on purpose: the operator deciding whether to convert a
+ * feedback has to read the question that was actually asked, and this view sits behind the console's
+ * authentication like every other management screen.
+ *
+ * @param feedbackId      business identifier
+ * @param kbId            knowledge base the query ran against
+ * @param query           query the debug page ran
+ * @param chunkId         chunk the verdict concerns
+ * @param docId           owning document, {@code null} when the chunk was already deleted
+ * @param verdict         {@code GOOD} or {@code BAD}
+ * @param status          {@code NEW}, {@code CONVERTED} or {@code DISMISSED}
+ * @param convertedCaseId evaluation case created from this row, {@code null} until converted
+ * @param note            free form operator note
+ * @param createdAt       ISO submission timestamp
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record RetrievalFeedbackResponse(
+        @JsonProperty("feedback_id") String feedbackId,
+        @JsonProperty("kb_id") String kbId,
+        String query,
+        @JsonProperty("chunk_id") String chunkId,
+        @JsonProperty("doc_id") String docId,
+        String verdict,
+        String status,
+        @JsonProperty("converted_case_id") String convertedCaseId,
+        String note,
+        @JsonProperty("created_at") String createdAt) {
+
+    /**
+     * Maps a stored feedback row onto its response.
+     *
+     * @param row stored row
+     * @return response
+     */
+    public static RetrievalFeedbackResponse from(RetrievalFeedback row) {
+        return new RetrievalFeedbackResponse(
+                row.getFeedbackId(),
+                row.getKbId(),
+                row.getQuery(),
+                row.getChunkId(),
+                row.getDocId(),
+                row.getVerdict() == null ? null : row.getVerdict().name(),
+                row.getStatus() == null ? null : row.getStatus().name(),
+                row.getConvertedCaseId(),
+                row.getNote(),
+                row.getCreatedAt() == null ? null : row.getCreatedAt().toString());
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/SearchInsightResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/SearchInsightResponse.java
@@ -1,0 +1,66 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.entity.SearchInsight;
+
+import java.util.List;
+
+/**
+ * One insight row of the console's search insight view.
+ *
+ * @param insightId   business identifier
+ * @param kbId        knowledge base the retrieval ran against
+ * @param source      {@code CONSOLE} or {@code OPEN_API}
+ * @param queryDigest masked and truncated query
+ * @param resultCount nodes the call returned
+ * @param topScore    score of the first node, {@code null} on zero hits
+ * @param zeroHit     {@code true} when the call returned nothing
+ * @param degraded    degradation markers of the call
+ * @param requestId   correlation id
+ * @param createdAt   ISO call timestamp
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record SearchInsightResponse(
+        @JsonProperty("insight_id") String insightId,
+        @JsonProperty("kb_id") String kbId,
+        String source,
+        @JsonProperty("query_digest") String queryDigest,
+        @JsonProperty("result_count") Integer resultCount,
+        @JsonProperty("top_score") Double topScore,
+        @JsonProperty("zero_hit") Boolean zeroHit,
+        List<String> degraded,
+        @JsonProperty("request_id") String requestId,
+        @JsonProperty("created_at") String createdAt) {
+
+    /**
+     * Maps a stored insight row onto its response.
+     *
+     * @param row stored row
+     * @return response
+     */
+    public static SearchInsightResponse from(SearchInsight row) {
+        return new SearchInsightResponse(
+                row.getInsightId(),
+                row.getKbId(),
+                row.getSource() == null ? null : row.getSource().name(),
+                row.getQueryDigest(),
+                row.getResultCount(),
+                row.getTopScore(),
+                row.getZeroHit(),
+                stringList(row.getDegraded()),
+                row.getRequestId(),
+                row.getCreatedAt() == null ? null : row.getCreatedAt().toString());
+    }
+
+    private static List<String> stringList(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        List<String> parsed = JsonUtil.parse(json, new TypeReference<List<String>>() {
+        });
+        return parsed == null ? List.of() : parsed;
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/SearchInsightStatsResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/SearchInsightStatsResponse.java
@@ -1,0 +1,60 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kbrag.app.insight.SearchInsightService;
+
+import java.util.List;
+
+/**
+ * Content gap report of one knowledge base, the M10 contract section 2.2.
+ *
+ * @param total             recorded retrievals in the window
+ * @param zeroHitCount      retrievals that returned nothing
+ * @param zeroHitRate       {@code zeroHitCount / total}, 0 when the window is empty
+ * @param degradedCount     retrievals that carried at least one degradation marker
+ * @param topZeroHitQueries most frequent zero hit query groups, largest first
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record SearchInsightStatsResponse(
+        long total,
+        @JsonProperty("zero_hit_count") long zeroHitCount,
+        @JsonProperty("zero_hit_rate") double zeroHitRate,
+        @JsonProperty("degraded_count") long degradedCount,
+        @JsonProperty("top_zero_hit_queries") List<TopZeroHitQueryResponse> topZeroHitQueries) {
+
+    /**
+     * Maps the aggregated report onto the transport shape.
+     *
+     * @param stats aggregated report
+     * @return response
+     */
+    public static SearchInsightStatsResponse from(SearchInsightService.InsightStats stats) {
+        return new SearchInsightStatsResponse(
+                stats.total(),
+                stats.zeroHitCount(),
+                stats.zeroHitRate(),
+                stats.degradedCount(),
+                stats.topZeroHitQueries().stream().map(TopZeroHitQueryResponse::from).toList());
+    }
+
+    /**
+     * One zero hit query group of the report.
+     *
+     * @param queryDigest masked digest of the newest row of the group
+     * @param count       zero hit rows in the group
+     * @param lastAt      ISO time of the newest row of the group
+     */
+    public record TopZeroHitQueryResponse(
+            @JsonProperty("query_digest") String queryDigest,
+            long count,
+            @JsonProperty("last_at") String lastAt) {
+
+        private static TopZeroHitQueryResponse from(SearchInsightService.TopZeroHitQuery group) {
+            return new TopZeroHitQueryResponse(
+                    group.queryDigest(),
+                    group.count(),
+                    group.lastAt() == null ? null : group.lastAt().toString());
+        }
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateKbGovernanceRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateKbGovernanceRequest.java
@@ -1,0 +1,15 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Payload of {@code PUT /api/v1/kb/{kbId}/governance}: the review switch of a knowledge base.
+ *
+ * @param reviewRequired {@code true} makes future uploads start as DRAFT instead of PUBLISHED
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record UpdateKbGovernanceRequest(
+        @JsonProperty("review_required") @NotNull(message = "must not be null") Boolean reviewRequired) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateValidityRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateValidityRequest.java
@@ -1,0 +1,20 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Payload of {@code PUT /api/v1/documents/{docId}/validity}.
+ *
+ * <p>Both bounds are ISO local date time literals and both are optional: a {@code null} clears the
+ * bound, so submitting an empty payload removes the window entirely. The controller parses the
+ * literals so a malformed timestamp is rejected before the service is involved.
+ *
+ * @param effectiveAt lower bound, {@code null} clears it
+ * @param expiresAt   upper bound, {@code null} clears it
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record UpdateValidityRequest(
+        @JsonProperty("effective_at") String effectiveAt,
+        @JsonProperty("expires_at") String expiresAt) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateWebSourceRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateWebSourceRequest.java
@@ -1,0 +1,17 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Payload of {@code PUT /api/v1/web-sources/{sourceId}}: the sync switch is the only mutable
+ * attribute of a registration - changing the URL would change its identity, so that is a remove
+ * plus a new registration instead.
+ *
+ * @param syncEnabled {@code true} includes the source in the scheduled sync pass
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record UpdateWebSourceRequest(
+        @JsonProperty("sync_enabled") @NotNull(message = "must not be null") Boolean syncEnabled) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/WebSourceResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/WebSourceResponse.java
@@ -1,0 +1,61 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kbrag.domain.entity.WebSource;
+
+import java.time.LocalDateTime;
+
+/**
+ * Web source registration view.
+ *
+ * @param sourceId        business identifier
+ * @param kbId            knowledge base the fetched pages land in
+ * @param url             registered page address
+ * @param docId           document the fetches feed, {@code null} until the first successful fetch
+ * @param fileName        derived file name the document carries, {@code null} until the first fetch
+ * @param syncEnabled     whether the scheduled pass includes this source
+ * @param lastFetchStatus outcome of the last sync attempt, {@code null} before the first one
+ * @param lastFetchAt     ISO instant of the last sync attempt
+ * @param lastError       why the last sync failed or was skipped, {@code null} on success
+ * @param createdAt       ISO registration timestamp
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record WebSourceResponse(
+        @JsonProperty("source_id") String sourceId,
+        @JsonProperty("kb_id") String kbId,
+        String url,
+        @JsonProperty("doc_id") String docId,
+        @JsonProperty("file_name") String fileName,
+        @JsonProperty("sync_enabled") boolean syncEnabled,
+        @JsonProperty("last_fetch_status") String lastFetchStatus,
+        @JsonProperty("last_fetch_at") String lastFetchAt,
+        @JsonProperty("last_error") String lastError,
+        @JsonProperty("created_at") String createdAt) {
+
+    private static final int SYNC_ON = 1;
+
+    /**
+     * Maps an entity onto its view.
+     *
+     * @param entity registration entity
+     * @return view
+     */
+    public static WebSourceResponse from(WebSource entity) {
+        return new WebSourceResponse(
+                entity.getSourceId(),
+                entity.getKbId(),
+                entity.getUrl(),
+                entity.getDocId(),
+                entity.getFileName(),
+                entity.getSyncEnabled() != null && entity.getSyncEnabled() == SYNC_ON,
+                entity.getLastFetchStatus() == null ? null : entity.getLastFetchStatus().name(),
+                iso(entity.getLastFetchAt()),
+                entity.getLastError(),
+                iso(entity.getCreatedAt()));
+    }
+
+    private static String iso(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/filter/ApiKeyAuthFilter.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/filter/ApiKeyAuthFilter.java
@@ -1,5 +1,6 @@
 package io.kbrag.api.filter;
 
+import io.kbrag.app.metrics.KbMetrics;
 import io.kbrag.app.openapi.ApiAuditService;
 import io.kbrag.app.openapi.ApiKeyPrincipal;
 import io.kbrag.app.openapi.ApiKeyService;
@@ -57,6 +58,7 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
     private final ApiKeyService apiKeyService;
     private final ApiRateLimiter apiRateLimiter;
     private final ApiAuditService apiAuditService;
+    private final KbMetrics kbMetrics;
     private final KbProperties properties;
 
     @Override
@@ -134,11 +136,15 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
      * <p>A rate limited response also carries {@code Retry-After}, which is what lets a well behaved agent back
      * off by the amount the server actually wants rather than by a guess.
      *
+     * <p>The one funnel every rejection leaves through, so it is also where the M13 rejection counter sits -
+     * unlike the audit row it counts the credential failures too, since a counter needs no key id to be useful.
+     *
      * @param response outbound response
      * @param e        rejection
      */
     private void writeError(HttpServletResponse response, BizException e) throws IOException {
         ErrorCode errorCode = e.getErrorCode();
+        kbMetrics.recordOpenApiRejected(errorCode.name());
         log.info("open api call rejected, errorCode={}, reason={}", errorCode, e.getMessage());
         response.setStatus(errorCode.getHttpStatus());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/kb-rag-server/kb-api/src/main/resources/application.yml
+++ b/kb-rag-server/kb-api/src/main/resources/application.yml
@@ -155,7 +155,7 @@ kb:
     bootstrap-username: ${AUTH_BOOTSTRAP_USERNAME:admin}
   upload:
     max-file-size-mb: ${UPLOAD_MAX_FILE_SIZE_MB:100}
-    allowed-extensions: ${UPLOAD_ALLOWED_EXTENSIONS:pdf,docx,txt,md,xlsx,csv,png,jpg,jpeg,webp,bmp,gif}
+    allowed-extensions: ${UPLOAD_ALLOWED_EXTENSIONS:pdf,docx,txt,md,xlsx,csv,html,png,jpg,jpeg,webp,bmp,gif}
   doc:
     version:
       # Non active READY versions kept per document; the older ones are archived and lose their chunks,
@@ -217,6 +217,9 @@ kb:
     # and the concurrency is how many run at a time inside a batch.
     extract-batch-size: ${GRAPH_EXTRACT_BATCH_SIZE:10}
     extract-concurrency: ${GRAPH_EXTRACT_CONCURRENCY:2}
+    # Budget of one extraction answer. Deliberately not kb.chat.max-tokens: that one sizes a single line
+    # query rewrite, and running out mid JSON makes the parser reject an answer that was in fact fine.
+    extract-max-tokens: ${GRAPH_EXTRACT_MAX_TOKENS:2048}
   web:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:20002,http://127.0.0.1:20002}
   eval:
@@ -247,6 +250,34 @@ kb:
     audit-archive-prefix: ${AUDIT_ARCHIVE_PREFIX:audit/}
     # Width of the query_digest column; the digest is masked first and truncated to this afterwards.
     query-digest-max-length: ${AUDIT_QUERY_DIGEST_MAX_LENGTH:200}
+  insight:
+    # Off switches only the recording points; the report endpoints and the cleanup keep working
+    # over whatever rows already exist.
+    enabled: ${INSIGHT_ENABLED:true}
+    # Days an insight row stays queryable. Insight rows are statistics, not evidence, so unlike the
+    # audit trail they are deleted without an object storage archive.
+    retention-days: ${INSIGHT_RETENTION_DAYS:90}
+    cleanup-batch-size: ${INSIGHT_CLEANUP_BATCH_SIZE:5000}
+    cleanup-cron: ${INSIGHT_CLEANUP_CRON:0 45 3 * * *}
+  governance:
+    # Days a trashed document stays restorable. The purge is the same irreversible removal the old
+    # DELETE endpoint performed, so the window is the operator's undo horizon.
+    trash-retention-days: ${TRASH_RETENTION_DAYS:30}
+    # Documents per purge batch; each one clears chunks and both engine copies, hence the small bound.
+    trash-purge-batch-size: ${TRASH_PURGE_BATCH_SIZE:100}
+    trash-purge-cron: ${TRASH_PURGE_CRON:0 10 4 * * *}
+    trash-purge-enabled: ${TRASH_PURGE_ENABLED:true}
+  web-import:
+    # Per request budget of one page fetch, connect and read alike.
+    fetch-timeout-ms: ${WEB_IMPORT_FETCH_TIMEOUT_MS:10000}
+    # Body ceiling enforced while streaming, so a hostile Content-Length cannot lie its way past it.
+    max-page-size-mb: ${WEB_IMPORT_MAX_PAGE_SIZE_MB:10}
+    # Redirect hops followed by hand; every hop is re-validated against the SSRF guard.
+    max-redirects: ${WEB_IMPORT_MAX_REDIRECTS:3}
+    sync-cron: ${WEB_IMPORT_SYNC_CRON:0 30 2 * * *}
+    sync-enabled: ${WEB_IMPORT_SYNC_ENABLED:true}
+    # Sources per scheduled pass; fetches are slow network calls, so a pass drains a bounded slice.
+    sync-batch-size: ${WEB_IMPORT_SYNC_BATCH_SIZE:50}
   app:
     # Retired application versions per application whose index snapshot is kept. Every snapshot is a full copy
     # of the corpus of every linked knowledge base, so this is the rollback depth traded against disk.

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V12__retrieval_feedback_and_search_insight.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V12__retrieval_feedback_and_search_insight.sql
@@ -1,0 +1,62 @@
+-- M10: the retrieval quality loop. Feedback stops being a log line and becomes a managed row that
+-- can be converted into an evaluation case, and every online retrieval leaves an insight row so the
+-- console can answer "what are people searching for that the corpus cannot serve".
+
+CREATE TABLE t_kb_retrieval_feedback
+(
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
+    feedback_id       VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the console',
+    kb_id             VARCHAR(64)  NOT NULL COMMENT 'knowledge base the query ran against',
+    -- Stored raw on purpose, unlike the insight digest: converting a feedback into an evaluation
+    -- case replays the exact query, and a masked copy would create a case that never ran.
+    query             TEXT         NOT NULL COMMENT 'query the debug page ran, raw, replayed on conversion',
+    chunk_id          VARCHAR(64)  NOT NULL COMMENT 'chunk the verdict concerns',
+    doc_id            VARCHAR(64)           DEFAULT NULL COMMENT 'owning document, resolved server side, null when the chunk was already deleted',
+    verdict           VARCHAR(16)  NOT NULL COMMENT 'GOOD/BAD',
+    status            VARCHAR(16)  NOT NULL DEFAULT 'NEW' COMMENT 'NEW/CONVERTED/DISMISSED',
+    converted_case_id VARCHAR(64)           DEFAULT NULL COMMENT 'evaluation case created from this row, null until converted',
+    note              VARCHAR(512)          DEFAULT NULL COMMENT 'free form operator note',
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    lock_version      INT          NOT NULL DEFAULT 0,
+    deleted           TINYINT      NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_feedback_id (feedback_id),
+    KEY idx_kb_id (kb_id),
+    KEY idx_status (status),
+    -- The console lists the open feedback of one knowledge base, which is exactly this pair.
+    KEY idx_kb_status (kb_id, status)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_general_ci COMMENT ='good/bad verdicts on debug results, convertible into evaluation cases';
+
+CREATE TABLE t_kb_search_insight
+(
+    id           BIGINT      NOT NULL AUTO_INCREMENT,
+    insight_id   VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the console',
+    kb_id        VARCHAR(64) NOT NULL COMMENT 'knowledge base the retrieval ran against',
+    source       VARCHAR(16) NOT NULL COMMENT 'CONSOLE/OPEN_API, the boundary the call entered through',
+    -- Masked by the section 4.2 rules and then truncated, the exact t_kb_api_audit_log discipline:
+    -- an analytics table kept for 90 days must not become an unmasked copy of what users typed.
+    query_digest VARCHAR(200)         DEFAULT NULL COMMENT 'masked and truncated query, never the raw text',
+    query_hash   CHAR(64)    NOT NULL COMMENT 'SHA-256 of the normalized query, the grouping key of the miss report',
+    result_count INT         NOT NULL DEFAULT 0 COMMENT 'nodes the call returned',
+    top_score    DOUBLE               DEFAULT NULL COMMENT 'score of the first node, null on zero hits',
+    zero_hit     TINYINT     NOT NULL DEFAULT 0 COMMENT 'derived from result_count = 0, the column the report scans',
+    degraded     JSON                 DEFAULT NULL COMMENT 'degradation markers of this call',
+    request_id   VARCHAR(64)          DEFAULT NULL COMMENT 'correlation id, links the row to logs and audit',
+    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    lock_version INT         NOT NULL DEFAULT 0,
+    deleted      TINYINT     NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_insight_id (insight_id),
+    KEY idx_kb_id (kb_id),
+    KEY idx_query_hash (query_hash),
+    -- The zero hit report of one knowledge base over a time window, which is exactly this triple.
+    KEY idx_kb_zero_created (kb_id, zero_hit, created_at),
+    -- The retention pass walks the expired rows.
+    KEY idx_created_at (created_at)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_general_ci COMMENT ='one row per online retrieval, deleted after the retention window';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V13__document_governance.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V13__document_governance.sql
@@ -1,0 +1,17 @@
+-- M11: content governance. A document stops being retrievable the moment it is uploaded and
+-- becomes retrievable when governance says so: published, inside its validity window and not in
+-- the trash. Every existing row defaults to the permissive state, so upgrading changes nothing.
+
+ALTER TABLE t_kb_document
+    ADD COLUMN publish_status VARCHAR(16) NOT NULL DEFAULT 'PUBLISHED' COMMENT 'DRAFT/PENDING_REVIEW/PUBLISHED/REJECTED' AFTER process_status,
+    ADD COLUMN review_note    VARCHAR(512)         DEFAULT NULL COMMENT 'latest rejection reason, cleared on approval' AFTER publish_status,
+    ADD COLUMN effective_at   DATETIME             DEFAULT NULL COMMENT 'retrievable from this instant, null means no lower bound' AFTER review_note,
+    ADD COLUMN expires_at     DATETIME             DEFAULT NULL COMMENT 'retrievable before this instant, null means no upper bound' AFTER effective_at,
+    ADD COLUMN trashed        TINYINT      NOT NULL DEFAULT 0 COMMENT '1 while the document sits in the recycle bin' AFTER expires_at,
+    ADD COLUMN trashed_at     DATETIME             DEFAULT NULL COMMENT 'when the document entered the recycle bin, drives the purge pass' AFTER trashed,
+    ADD KEY idx_kb_publish (kb_id, publish_status),
+    ADD KEY idx_kb_trashed (kb_id, trashed),
+    ADD KEY idx_trashed_at (trashed_at);
+
+ALTER TABLE t_kb_knowledge_base
+    ADD COLUMN review_required TINYINT NOT NULL DEFAULT 0 COMMENT '1 makes a new document start as DRAFT instead of PUBLISHED' AFTER retrieval_config;

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V14__web_source.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V14__web_source.sql
@@ -1,0 +1,31 @@
+-- M12: URL import and incremental sync. A registered web source is the bridge between a URL and
+-- the document its fetches produce: the fetch itself funnels into the ordinary upload chain, so
+-- this table only records the binding, the sync switch and the outcome of the last fetch.
+
+CREATE TABLE t_kb_web_source
+(
+    id                BIGINT        NOT NULL AUTO_INCREMENT,
+    source_id         VARCHAR(64)   NOT NULL COMMENT 'business identifier exposed by the console',
+    kb_id             VARCHAR(64)   NOT NULL COMMENT 'knowledge base the fetched pages land in',
+    url               VARCHAR(2048) NOT NULL COMMENT 'registered page address, http or https',
+    -- The equality key: a VARCHAR(2048) cannot carry a unique index, the digest of it can.
+    url_hash          CHAR(64)      NOT NULL COMMENT 'SHA-256 of the url, the dedup and lookup key',
+    doc_id            VARCHAR(64)            DEFAULT NULL COMMENT 'document the fetches feed, null until the first success',
+    file_name         VARCHAR(255)           DEFAULT NULL COMMENT 'derived stable file name the upload chain sees',
+    sync_enabled      TINYINT       NOT NULL DEFAULT 1 COMMENT '1 includes the source in the scheduled sync pass',
+    last_content_hash CHAR(64)               DEFAULT NULL COMMENT 'SHA-256 of the last fetched body, the unchanged check',
+    last_fetch_at     DATETIME               DEFAULT NULL COMMENT 'when the last sync attempt ran',
+    last_fetch_status VARCHAR(16)            DEFAULT NULL COMMENT 'SUCCESS/UNCHANGED/SKIPPED/FAILED',
+    last_error        VARCHAR(512)           DEFAULT NULL COMMENT 'why the last sync failed or was skipped, null on success',
+    created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    lock_version      INT           NOT NULL DEFAULT 0,
+    deleted           TINYINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_source_id (source_id),
+    -- One registration per URL per knowledge base; other knowledge bases may register the same URL.
+    UNIQUE KEY uk_kb_url (kb_id, url_hash),
+    KEY idx_kb_id (kb_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_general_ci COMMENT ='registered web page sources feeding documents via URL import';

--- a/kb-rag-server/kb-app/pom.xml
+++ b/kb-rag-server/kb-app/pom.xml
@@ -32,6 +32,15 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <!--
+          Business metrics facade (M13). Only the core API is needed here; the Prometheus registry
+          lives in kb-api next to the actuator that exposes it. Version managed by the Spring Boot
+          bill of materials.
+        -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <!--
           Query rewrite cache. Version managed by the Spring Boot bill of materials, so the cache
           library stays aligned with whatever the framework already pulls in for its own caching
           support instead of introducing a second lineage.

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/alert/TaskFailureTracker.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/alert/TaskFailureTracker.java
@@ -1,5 +1,6 @@
 package io.kbrag.app.alert;
 
+import io.kbrag.app.metrics.KbMetrics;
 import io.kbrag.domain.enums.AlertType;
 import io.kbrag.domain.enums.TaskType;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <p>Counted in memory rather than queried from the task table: the signal is about what is happening
  * now, and reading a lifetime table would need a time window that the counter expresses more directly.
  *
+ * <p>Every completion also lands in the M13 task metric here: this class is the one funnel both the
+ * success and the failure path already pass through, so the counter cannot miss a task type.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
@@ -33,6 +37,7 @@ public class TaskFailureTracker {
 
     private final AlertConfigService alertConfigService;
     private final AlertService alertService;
+    private final KbMetrics kbMetrics;
 
     private final Map<TaskType, AtomicInteger> consecutiveFailures = new EnumMap<>(TaskType.class);
 
@@ -46,6 +51,7 @@ public class TaskFailureTracker {
         if (taskType == null) {
             return;
         }
+        kbMetrics.recordTaskCompleted(taskType, false);
         int failures = consecutiveFailures.computeIfAbsent(taskType, type -> new AtomicInteger())
                 .incrementAndGet();
         int threshold = alertConfigService.current().getTaskFailThreshold();
@@ -68,6 +74,7 @@ public class TaskFailureTracker {
         if (taskType == null) {
             return;
         }
+        kbMetrics.recordTaskCompleted(taskType, true);
         AtomicInteger counter = consecutiveFailures.get(taskType);
         if (counter != null) {
             counter.set(0);

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/document/DocumentService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/document/DocumentService.java
@@ -11,8 +11,10 @@ import io.kbrag.domain.entity.Annotation;
 import io.kbrag.domain.entity.Chunk;
 import io.kbrag.domain.entity.Document;
 import io.kbrag.domain.entity.DocumentVersion;
+import io.kbrag.domain.entity.KnowledgeBase;
 import io.kbrag.domain.enums.DocumentVersionStatus;
 import io.kbrag.domain.enums.ProcessStatus;
+import io.kbrag.domain.enums.PublishStatus;
 import io.kbrag.domain.mapper.AnnotationMapper;
 import io.kbrag.domain.mapper.ChunkMapper;
 import io.kbrag.domain.mapper.DocumentMapper;
@@ -62,6 +64,8 @@ public class DocumentService {
     private static final String CONTENT_TYPE_OCTET_STREAM = "application/octet-stream";
     private static final int NOT_STALE = 0;
     private static final int DISABLED = 0;
+    private static final int NOT_TRASHED = 0;
+    private static final int REVIEW_REQUIRED = 1;
 
     private final DocumentMapper documentMapper;
     private final DocumentVersionMapper documentVersionMapper;
@@ -87,27 +91,28 @@ public class DocumentService {
      */
     @Transactional(rollbackFor = Exception.class)
     public UploadOutcome upload(String kbId, String fileName, byte[] content) {
-        knowledgeBaseService.require(kbId);
+        KnowledgeBase knowledgeBase = knowledgeBaseService.require(kbId);
         String extension = uploadValidator.validate(fileName, content);
         String contentHash = HashUtil.sha256Hex(content);
         Document existing = findLogicalDocument(kbId, fileName);
         return existing == null
-                ? createDocument(kbId, fileName, extension, content, contentHash)
+                ? createDocument(knowledgeBase, fileName, extension, content, contentHash)
                 : addVersion(existing, extension, content, contentHash);
     }
 
     /**
      * Creates a document together with its first version.
      *
-     * @param kbId        target knowledge base
-     * @param fileName    original file name
-     * @param extension   validated lower case extension
-     * @param content     raw bytes
-     * @param contentHash digest of the raw bytes
+     * @param knowledgeBase target knowledge base, read for the governance switch
+     * @param fileName      original file name
+     * @param extension     validated lower case extension
+     * @param content       raw bytes
+     * @param contentHash   digest of the raw bytes
      * @return what the upload did
      */
-    private UploadOutcome createDocument(String kbId, String fileName, String extension, byte[] content,
-                                         String contentHash) {
+    private UploadOutcome createDocument(KnowledgeBase knowledgeBase, String fileName, String extension,
+                                         byte[] content, String contentHash) {
+        String kbId = knowledgeBase.getKbId();
         String docId = bizIdGenerator.documentId();
         String versionId = bizIdGenerator.documentVersionId();
 
@@ -118,6 +123,12 @@ public class DocumentService {
         document.setFileExt(extension);
         document.setFileSize((long) content.length);
         document.setProcessStatus(ProcessStatus.UPLOADED);
+        // Admission is decided once at creation. Later versions inherit the state: the review gates what
+        // the document is, not each revision - revisions are governed by the M4a version machinery.
+        document.setPublishStatus(knowledgeBase.getReviewRequired() != null
+                && knowledgeBase.getReviewRequired() == REVIEW_REQUIRED
+                ? PublishStatus.DRAFT : PublishStatus.PUBLISHED);
+        document.setTrashed(NOT_TRASHED);
         document.setConfigStale(NOT_STALE);
         documentMapper.insert(document);
 
@@ -223,7 +234,8 @@ public class DocumentService {
      *
      * <p>Chat imports are excluded by requiring an empty source key: a conversation carries its own
      * logical identity and its display name is not unique, so matching on the name would merge unrelated
-     * conversations into one document.
+     * conversations into one document. A trashed document is excluded too: appending a version to it
+     * would resurrect content the operator threw away, so the upload starts a fresh document instead.
      *
      * @param kbId     knowledge base business id
      * @param fileName original file name
@@ -233,6 +245,7 @@ public class DocumentService {
         return documentMapper.selectOne(new LambdaQueryWrapper<Document>()
                 .eq(Document::getKbId, kbId)
                 .eq(Document::getFileName, fileName)
+                .eq(Document::getTrashed, NOT_TRASHED)
                 .isNull(Document::getSourceKey)
                 .orderByDesc(Document::getId)
                 .last("limit 1"));
@@ -305,6 +318,9 @@ public class DocumentService {
     public IPage<Document> list(String kbId, ProcessStatus processStatus, long page, long size) {
         LambdaQueryWrapper<Document> wrapper = new LambdaQueryWrapper<Document>()
                 .eq(Document::getKbId, kbId)
+                // Trashed documents live in the recycle bin listing only; showing them here would make
+                // "deleted" and "present" indistinguishable in the console.
+                .eq(Document::getTrashed, NOT_TRASHED)
                 .orderByDesc(Document::getId);
         if (processStatus != null) {
             wrapper.eq(Document::getProcessStatus, processStatus);

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalDatasetService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalDatasetService.java
@@ -270,6 +270,29 @@ public class EvalDatasetService {
     @Transactional(rollbackFor = Exception.class)
     public EvalCase collectFromRetrieval(String datasetId, String query, List<ChatMessage> messages,
                                          List<String> chunkIds, AnchorType anchorOverride) {
+        return collectFromRetrieval(datasetId, query, messages, chunkIds, anchorOverride,
+                CaseSource.DEBUG_PAGE);
+    }
+
+    /**
+     * Collects a case from recalled chunks with an explicit provenance, the M10 contract section 2.1.
+     *
+     * <p>Exists because the feedback conversion runs the exact collection path of the debug page but
+     * must not claim to be it: {@code source} is the one column an analyst filters by when judging
+     * where the cases of a data set came from.
+     *
+     * @param datasetId       data set business id
+     * @param query           query the retrieval ran
+     * @param messages        conversation history, may be empty
+     * @param chunkIds        recalled chunks selected as evidence
+     * @param anchorOverride  forces {@code DOCUMENT} anchoring, {@code null} lets an image chunk decide
+     * @param source          how the case entered the data set
+     * @return created case
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public EvalCase collectFromRetrieval(String datasetId, String query, List<ChatMessage> messages,
+                                         List<String> chunkIds, AnchorType anchorOverride,
+                                         CaseSource source) {
         if (CollectionUtils.isEmpty(chunkIds)) {
             throw BizException.invalidParam("chunk_ids must not be empty");
         }
@@ -299,7 +322,7 @@ public class EvalDatasetService {
         EvalCase evalCase = new EvalCase();
         evalCase.setCaseId(bizIdGenerator.evalCaseId());
         evalCase.setDatasetId(datasetId);
-        applyCommand(evalCase, command, CaseSource.DEBUG_PAGE);
+        applyCommand(evalCase, command, source);
         evalCaseMapper.insert(evalCase);
         bumpRevision(dataset, 1);
         log.info("evaluation case collected from retrieval, caseId={}, datasetId={}, anchorType={}",

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/feedback/RetrievalFeedbackService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/feedback/RetrievalFeedbackService.java
@@ -1,0 +1,194 @@
+package io.kbrag.app.feedback;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.kbrag.app.eval.EvalDatasetService;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.entity.EvalCase;
+import io.kbrag.domain.entity.RetrievalFeedback;
+import io.kbrag.domain.enums.CaseSource;
+import io.kbrag.domain.enums.FeedbackStatus;
+import io.kbrag.domain.enums.FeedbackVerdict;
+import io.kbrag.domain.mapper.ChunkMapper;
+import io.kbrag.domain.mapper.RetrievalFeedbackMapper;
+import io.kbrag.domain.service.BizIdGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Persists and manages the good/bad verdicts of the debug page, requirement section 4.5 "distilled
+ * into evaluation material" and the M10 contract section 2.1.
+ *
+ * <p><b>A feedback is an event, not a state.</b> Submitting the same verdict twice records two rows on
+ * purpose: each click is one observation, and deduplicating them would make five operators agreeing
+ * look identical to one.
+ *
+ * <p><b>Only {@code GOOD} converts.</b> A conversion creates a case whose evidence is the chunk the
+ * verdict pointed at; a {@code BAD} verdict states that this chunk is <em>not</em> evidence, so a case
+ * built from it would assert the opposite of what the operator said. The value of {@code BAD} lives in
+ * the statistics and the insight report instead.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RetrievalFeedbackService {
+
+    private final RetrievalFeedbackMapper retrievalFeedbackMapper;
+    private final ChunkMapper chunkMapper;
+    private final EvalDatasetService evalDatasetService;
+    private final BizIdGenerator bizIdGenerator;
+
+    /**
+     * Records one verdict.
+     *
+     * <p>The owning document is resolved server side from the chunk. A missing chunk does not reject
+     * the feedback - the signal may arrive after the chunk was deleted, and the query text is still a
+     * fact worth keeping - the row simply carries no {@code doc_id}.
+     *
+     * @param kbId    knowledge base the query ran against
+     * @param query   query the debug page ran, stored raw for a later conversion
+     * @param chunkId chunk the verdict concerns
+     * @param verdict operator verdict
+     * @return persisted row, {@code status=NEW}
+     */
+    public RetrievalFeedback record(String kbId, String query, String chunkId, FeedbackVerdict verdict) {
+        RetrievalFeedback feedback = new RetrievalFeedback();
+        feedback.setFeedbackId(bizIdGenerator.retrievalFeedbackId());
+        feedback.setKbId(kbId);
+        feedback.setQuery(query);
+        feedback.setChunkId(chunkId);
+        feedback.setDocId(resolveDocId(chunkId));
+        feedback.setVerdict(verdict);
+        feedback.setStatus(FeedbackStatus.NEW);
+        retrievalFeedbackMapper.insert(feedback);
+        log.info("retrieval feedback recorded, feedbackId={}, kbId={}, verdict={}",
+                feedback.getFeedbackId(), kbId, verdict);
+        return feedback;
+    }
+
+    /**
+     * Pages the feedback of one knowledge base, newest first.
+     *
+     * @param kbId    knowledge base business id
+     * @param verdict optional verdict filter
+     * @param status  optional status filter
+     * @param page    one based page number
+     * @param size    page size
+     * @return paged rows
+     */
+    public IPage<RetrievalFeedback> list(String kbId, FeedbackVerdict verdict, FeedbackStatus status,
+                                         long page, long size) {
+        LambdaQueryWrapper<RetrievalFeedback> wrapper = new LambdaQueryWrapper<RetrievalFeedback>()
+                .eq(RetrievalFeedback::getKbId, kbId);
+        if (verdict != null) {
+            wrapper.eq(RetrievalFeedback::getVerdict, verdict);
+        }
+        if (status != null) {
+            wrapper.eq(RetrievalFeedback::getStatus, status);
+        }
+        return retrievalFeedbackMapper.selectPage(new Page<>(page, size),
+                wrapper.orderByDesc(RetrievalFeedback::getId));
+    }
+
+    /**
+     * Converts one {@code GOOD} feedback into an evaluation case, the closing move of the loop.
+     *
+     * <p>Delegates to the exact collection path of the debug page so a converted case is structurally
+     * indistinguishable from a hand collected one, differing only in its {@code source=FEEDBACK}
+     * provenance. A deleted chunk fails the conversion with a clear message rather than silently
+     * producing a case without evidence.
+     *
+     * @param feedbackId feedback business id, must be {@code NEW} and {@code GOOD}
+     * @param datasetId  target evaluation data set
+     * @return the same row, {@code status=CONVERTED} with the case id filled in
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public RetrievalFeedback convert(String feedbackId, String datasetId) {
+        RetrievalFeedback feedback = require(feedbackId);
+        requireNew(feedback);
+        if (feedback.getVerdict() == FeedbackVerdict.BAD) {
+            throw BizException.invalidParam("BAD 反馈不能转为评测用例：它声明该分片不是证据，其价值在洞察统计");
+        }
+        // Checked here rather than left to the collector: its "some selected chunks no longer exist"
+        // is phrased for an operator holding a chunk list, and letting it pass through would also
+        // let a missing data set masquerade as a missing chunk.
+        if (chunkOf(feedback.getChunkId()) == null) {
+            throw BizException.invalidParam("反馈引用的分片已不存在，无法转为评测用例");
+        }
+        EvalCase evalCase = evalDatasetService.collectFromRetrieval(datasetId, feedback.getQuery(), null,
+                List.of(feedback.getChunkId()), null, CaseSource.FEEDBACK);
+        feedback.setStatus(FeedbackStatus.CONVERTED);
+        feedback.setConvertedCaseId(evalCase.getCaseId());
+        retrievalFeedbackMapper.updateById(feedback);
+        log.info("retrieval feedback converted, feedbackId={}, caseId={}, datasetId={}",
+                feedbackId, evalCase.getCaseId(), datasetId);
+        return feedback;
+    }
+
+    /**
+     * Dismisses one feedback, the terminal "seen, not worth a case" decision.
+     *
+     * @param feedbackId feedback business id, must be {@code NEW}
+     * @return the same row, {@code status=DISMISSED}
+     */
+    public RetrievalFeedback dismiss(String feedbackId) {
+        RetrievalFeedback feedback = require(feedbackId);
+        requireNew(feedback);
+        feedback.setStatus(FeedbackStatus.DISMISSED);
+        retrievalFeedbackMapper.updateById(feedback);
+        log.info("retrieval feedback dismissed, feedbackId={}", feedbackId);
+        return feedback;
+    }
+
+    /**
+     * Loads a feedback row or fails.
+     *
+     * @param feedbackId feedback business id
+     * @return feedback row
+     */
+    public RetrievalFeedback require(String feedbackId) {
+        RetrievalFeedback feedback = retrievalFeedbackMapper.selectOne(
+                new LambdaQueryWrapper<RetrievalFeedback>()
+                        .eq(RetrievalFeedback::getFeedbackId, feedbackId)
+                        .last("limit 1"));
+        if (feedback == null) {
+            throw BizException.notFound("retrieval feedback not found");
+        }
+        return feedback;
+    }
+
+    /**
+     * Guards the one legal transition source: both non {@code NEW} states are terminal, and repeating
+     * an operation on them must fail loudly rather than silently succeed twice.
+     *
+     * @param feedback row about to change state
+     */
+    private void requireNew(RetrievalFeedback feedback) {
+        if (feedback.getStatus() != FeedbackStatus.NEW) {
+            throw BizException.invalidParam("反馈已处于终态 " + feedback.getStatus() + "，不能再变更");
+        }
+    }
+
+    private String resolveDocId(String chunkId) {
+        Chunk chunk = chunkOf(chunkId);
+        if (chunk == null) {
+            log.info("feedback chunk no longer exists, recorded without doc id, chunkId={}", chunkId);
+            return null;
+        }
+        return chunk.getDocId();
+    }
+
+    private Chunk chunkOf(String chunkId) {
+        return chunkMapper.selectOne(new LambdaQueryWrapper<Chunk>()
+                .eq(Chunk::getChunkId, chunkId)
+                .last("limit 1"));
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/governance/DocumentGovernanceService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/governance/DocumentGovernanceService.java
@@ -1,0 +1,333 @@
+package io.kbrag.app.governance;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.kbrag.app.document.DocumentService;
+import io.kbrag.app.index.ActiveVersionResolver;
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.KnowledgeBase;
+import io.kbrag.domain.enums.PublishStatus;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.KnowledgeBaseMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Content governance of documents, the M11 contract section 2.2: the review state machine, the
+ * validity window and the recycle bin.
+ *
+ * <p><b>Every operation here is a database row flip plus one cache invalidation.</b> Nothing is ever
+ * written into a search engine: the {@link ActiveVersionResolver} is the single gate all three
+ * governance axes pass through, so publishing, expiring and trashing cost the same regardless of
+ * corpus size, and restoring from the trash is instant because the engine copies never left.
+ *
+ * <p><b>The one irreversible operation is the purge.</b> It delegates to the pre-M11 hard delete
+ * chain and is reachable only from inside the trash - two explicit steps before content is truly
+ * gone, which is the entire point of having a recycle bin.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DocumentGovernanceService {
+
+    /** Value of {@code trashed} inside the recycle bin. */
+    private static final int TRASHED = 1;
+
+    /** Value of {@code trashed} outside the recycle bin. */
+    private static final int NOT_TRASHED = 0;
+
+    private final DocumentMapper documentMapper;
+    private final KnowledgeBaseMapper knowledgeBaseMapper;
+    private final DocumentService documentService;
+    private final KnowledgeBaseService knowledgeBaseService;
+    private final ActiveVersionResolver activeVersionResolver;
+    private final KbProperties properties;
+
+    /**
+     * Submits a draft or a rejected document for review.
+     *
+     * @param docId document business id
+     * @return updated document
+     */
+    public Document submitReview(String docId) {
+        Document document = requireOutsideTrash(docId);
+        PublishStatus status = statusOf(document);
+        if (status != PublishStatus.DRAFT && status != PublishStatus.REJECTED) {
+            throw BizException.invalidParam("当前发布状态 " + status + " 不能提交审核，仅草稿或被驳回的文档可提交");
+        }
+        document.setPublishStatus(PublishStatus.PENDING_REVIEW);
+        documentMapper.updateById(document);
+        activeVersionResolver.invalidate(document.getKbId());
+        log.info("document submitted for review, docId={}, kbId={}", docId, document.getKbId());
+        return document;
+    }
+
+    /**
+     * Approves a pending document, admitting it to retrieval.
+     *
+     * @param docId document business id
+     * @return updated document
+     */
+    public Document approve(String docId) {
+        Document document = requirePending(docId);
+        // The rejection note describes a verdict this approval supersedes, so it goes with it.
+        documentMapper.update(null, new LambdaUpdateWrapper<Document>()
+                .eq(Document::getId, document.getId())
+                .set(Document::getPublishStatus, PublishStatus.PUBLISHED)
+                .set(Document::getReviewNote, null));
+        document.setPublishStatus(PublishStatus.PUBLISHED);
+        document.setReviewNote(null);
+        activeVersionResolver.invalidate(document.getKbId());
+        log.info("document approved, docId={}, kbId={}", docId, document.getKbId());
+        return document;
+    }
+
+    /**
+     * Rejects a pending document with a reason the author will see.
+     *
+     * @param docId document business id
+     * @param note  rejection reason, mandatory
+     * @return updated document
+     */
+    public Document reject(String docId, String note) {
+        Document document = requirePending(docId);
+        document.setPublishStatus(PublishStatus.REJECTED);
+        document.setReviewNote(note);
+        documentMapper.updateById(document);
+        activeVersionResolver.invalidate(document.getKbId());
+        log.info("document rejected, docId={}, kbId={}", docId, document.getKbId());
+        return document;
+    }
+
+    /**
+     * Sets or clears the validity window of a document.
+     *
+     * <p>An {@code expires_at} in the past is deliberately allowed: "take this offline right now" is
+     * the most common reason an operator opens the dialog at all.
+     *
+     * @param docId       document business id
+     * @param effectiveAt lower bound, {@code null} clears it
+     * @param expiresAt   upper bound, {@code null} clears it
+     * @return updated document
+     */
+    public Document updateValidity(String docId, LocalDateTime effectiveAt, LocalDateTime expiresAt) {
+        if (effectiveAt != null && expiresAt != null && !effectiveAt.isBefore(expiresAt)) {
+            throw BizException.invalidParam("生效时间必须早于失效时间");
+        }
+        Document document = requireOutsideTrash(docId);
+        documentMapper.update(null, new LambdaUpdateWrapper<Document>()
+                .eq(Document::getId, document.getId())
+                .set(Document::getEffectiveAt, effectiveAt)
+                .set(Document::getExpiresAt, expiresAt));
+        document.setEffectiveAt(effectiveAt);
+        document.setExpiresAt(expiresAt);
+        activeVersionResolver.invalidate(document.getKbId());
+        log.info("document validity updated, docId={}, kbId={}, effectiveAt={}, expiresAt={}",
+                docId, document.getKbId(), effectiveAt, expiresAt);
+        return document;
+    }
+
+    /**
+     * Moves a document into the recycle bin, out of retrieval but restorable.
+     *
+     * <p>Chunks, versions and both engine copies stay untouched - the visibility set alone keeps the
+     * document out of every recall, which is what makes {@link #restore(String)} an instant flag flip.
+     *
+     * @param docId document business id
+     */
+    public void trash(String docId) {
+        Document document = documentService.require(docId);
+        if (inTrash(document)) {
+            throw BizException.invalidParam("文档已在回收站中");
+        }
+        document.setTrashed(TRASHED);
+        document.setTrashedAt(LocalDateTime.now());
+        documentMapper.updateById(document);
+        activeVersionResolver.invalidate(document.getKbId());
+        log.info("document trashed, docId={}, kbId={}", docId, document.getKbId());
+    }
+
+    /**
+     * Restores a trashed document to exactly the state it was deleted in.
+     *
+     * @param docId document business id
+     * @return updated document
+     */
+    public Document restore(String docId) {
+        Document document = requireInTrash(docId);
+        documentMapper.update(null, new LambdaUpdateWrapper<Document>()
+                .eq(Document::getId, document.getId())
+                .set(Document::getTrashed, NOT_TRASHED)
+                .set(Document::getTrashedAt, null));
+        document.setTrashed(NOT_TRASHED);
+        document.setTrashedAt(null);
+        activeVersionResolver.invalidate(document.getKbId());
+        log.info("document restored from trash, docId={}, kbId={}", docId, document.getKbId());
+        return document;
+    }
+
+    /**
+     * Irreversibly removes a trashed document through the pre-M11 hard delete chain.
+     *
+     * <p>Only a trashed document may be purged: requiring the trash step first is the two-step
+     * confirmation that keeps a mistyped identifier from destroying content.
+     *
+     * @param docId document business id
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public void purge(String docId) {
+        Document document = requireInTrash(docId);
+        documentService.delete(docId);
+        activeVersionResolver.invalidate(document.getKbId());
+        log.info("document purged from trash, docId={}, kbId={}", docId, document.getKbId());
+    }
+
+    /**
+     * Lists the recycle bin of a knowledge base, most recently trashed first.
+     *
+     * @param kbId knowledge base business id
+     * @param page one based page number
+     * @param size page size
+     * @return page of trashed documents
+     */
+    public IPage<Document> listTrash(String kbId, long page, long size) {
+        return documentMapper.selectPage(new Page<>(page, size), new LambdaQueryWrapper<Document>()
+                .eq(Document::getKbId, kbId)
+                .eq(Document::getTrashed, TRASHED)
+                .orderByDesc(Document::getTrashedAt)
+                .orderByDesc(Document::getId));
+    }
+
+    /**
+     * Flips the review switch of a knowledge base.
+     *
+     * <p>Only future uploads read the switch; documents already present keep their state, because a
+     * policy change is not a verdict about content that was admitted under the old policy.
+     *
+     * @param kbId           knowledge base business id
+     * @param reviewRequired {@code true} makes new documents start as DRAFT
+     * @return updated knowledge base
+     */
+    public KnowledgeBase updateGovernance(String kbId, boolean reviewRequired) {
+        KnowledgeBase knowledgeBase = knowledgeBaseService.require(kbId);
+        knowledgeBase.setReviewRequired(reviewRequired ? 1 : 0);
+        knowledgeBaseMapper.updateById(knowledgeBase);
+        log.info("knowledge base governance updated, kbId={}, reviewRequired={}", kbId, reviewRequired);
+        return knowledgeBase;
+    }
+
+    /**
+     * Daily purge pass over the trash.
+     *
+     * <p>Failures are logged and never rethrown: the scheduler has no caller to report to, and a
+     * skipped pass only defers the disk reclaim to the next one.
+     */
+    @Scheduled(cron = "${kb.governance.trash-purge-cron:0 10 4 * * *}")
+    public void scheduledPurge() {
+        if (!properties.getGovernance().isTrashPurgeEnabled()) {
+            return;
+        }
+        try {
+            int purged = purgeExpired();
+            if (purged > 0) {
+                log.info("trash purge pass finished, purgedDocuments={}", purged);
+            }
+        } catch (Exception e) {
+            log.error("trash purge pass failed, errorCode={}", ErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+
+    /**
+     * Purges every document trashed before the retention horizon, one bounded batch at a time.
+     *
+     * <p>Each document is purged in its own transaction: one failing document must not roll back the
+     * neighbours already cleaned, and the failure is logged so the next pass retries it.
+     *
+     * @return documents purged by this pass
+     */
+    public int purgeExpired() {
+        int batchSize = Math.max(1, properties.getGovernance().getTrashPurgeBatchSize());
+        LocalDateTime horizon = LocalDate.now()
+                .minusDays(properties.getGovernance().getTrashRetentionDays())
+                .atStartOfDay();
+        int purgedTotal = 0;
+        while (true) {
+            List<Document> batch = documentMapper.selectList(new LambdaQueryWrapper<Document>()
+                    .eq(Document::getTrashed, TRASHED)
+                    .lt(Document::getTrashedAt, horizon)
+                    .orderByAsc(Document::getId)
+                    .last("limit " + batchSize));
+            if (CollectionUtils.isEmpty(batch)) {
+                return purgedTotal;
+            }
+            int failed = 0;
+            for (Document document : batch) {
+                try {
+                    documentService.delete(document.getDocId());
+                    activeVersionResolver.invalidate(document.getKbId());
+                    purgedTotal++;
+                } catch (Exception e) {
+                    failed++;
+                    log.error("trash purge of one document failed, errorCode={}, docId={}",
+                            ErrorCode.INTERNAL_ERROR, document.getDocId(), e);
+                }
+            }
+            if (failed == batch.size()) {
+                // Every document of the batch failed: the next iteration would reselect and refail the
+                // same rows forever, so the pass stops and the next scheduled one tries again.
+                return purgedTotal;
+            }
+        }
+    }
+
+    private Document requirePending(String docId) {
+        Document document = requireOutsideTrash(docId);
+        if (statusOf(document) != PublishStatus.PENDING_REVIEW) {
+            throw BizException.invalidParam("当前发布状态 " + statusOf(document) + " 不在待审核中，无法执行审核操作");
+        }
+        return document;
+    }
+
+    private Document requireOutsideTrash(String docId) {
+        Document document = documentService.require(docId);
+        if (inTrash(document)) {
+            throw BizException.invalidParam("文档在回收站中，请先恢复后再操作");
+        }
+        return document;
+    }
+
+    private Document requireInTrash(String docId) {
+        Document document = documentService.require(docId);
+        if (!inTrash(document)) {
+            throw BizException.invalidParam("文档不在回收站中");
+        }
+        return document;
+    }
+
+    private boolean inTrash(Document document) {
+        return document.getTrashed() != null && document.getTrashed() == TRASHED;
+    }
+
+    /**
+     * Publication state of a row, PUBLISHED when the column predates M11 and is still {@code null}.
+     */
+    private PublishStatus statusOf(Document document) {
+        return document.getPublishStatus() == null ? PublishStatus.PUBLISHED : document.getPublishStatus();
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/graph/GraphExtractionService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/graph/GraphExtractionService.java
@@ -22,8 +22,8 @@ import io.kbrag.domain.port.ChatProvider;
 import io.kbrag.domain.port.GraphStore;
 import io.kbrag.domain.service.BizIdGenerator;
 import io.kbrag.domain.service.GraphExtractionParser;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -65,7 +65,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class GraphExtractionService {
 
     /**
@@ -107,6 +106,33 @@ public class GraphExtractionService {
     private final GraphExtractionParser extractionParser;
     private final BizIdGenerator bizIdGenerator;
     private final KbProperties properties;
+
+    /**
+     * Wired explicitly rather than through Lombok so the extraction provider can be qualified: the
+     * primary {@code chatProvider} carries the single line rewrite budget, which truncates an extraction
+     * answer mid JSON.
+     */
+    public GraphExtractionService(KnowledgeBaseService knowledgeBaseService,
+                                  ActiveVersionResolver activeVersionResolver,
+                                  ChunkMapper chunkMapper,
+                                  DocumentVersionMapper documentVersionMapper,
+                                  KbTaskMapper kbTaskMapper,
+                                  GraphStore graphStore,
+                                  @Qualifier("graphExtractionChatProvider") ChatProvider chatProvider,
+                                  GraphExtractionParser extractionParser,
+                                  BizIdGenerator bizIdGenerator,
+                                  KbProperties properties) {
+        this.knowledgeBaseService = knowledgeBaseService;
+        this.activeVersionResolver = activeVersionResolver;
+        this.chunkMapper = chunkMapper;
+        this.documentVersionMapper = documentVersionMapper;
+        this.kbTaskMapper = kbTaskMapper;
+        this.graphStore = graphStore;
+        this.chatProvider = chatProvider;
+        this.extractionParser = extractionParser;
+        this.bizIdGenerator = bizIdGenerator;
+        this.properties = properties;
+    }
 
     /**
      * Opens or reuses the graph extraction task of a knowledge base, on the caller's thread.

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/ActiveVersionResolver.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/ActiveVersionResolver.java
@@ -5,11 +5,13 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.enums.PublishStatus;
 import io.kbrag.domain.mapper.DocumentMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -30,11 +32,19 @@ import java.util.List;
  * it must never be completed from here - that is the very substitution requirement section 4.7 forbids, the
  * one that made a rollback recall nothing.
  *
+ * <p><b>The single governance gate (M11 contract section 2.1).</b> Publication state, validity window and the
+ * recycle bin are all row predicates of this one query, never columns in a search engine: a governance change
+ * flips the database row and invalidates this cache, and no index is rebuilt. A window that opens or closes
+ * with nobody operating the console takes effect when the cache entry expires, which is the accepted delay.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
 @Service
 public class ActiveVersionResolver {
+
+    /** Value of {@code trashed} outside the recycle bin. */
+    private static final int NOT_TRASHED = 0;
 
     private final DocumentMapper documentMapper;
     private final Cache<String, List<String>> cache;
@@ -72,9 +82,14 @@ public class ActiveVersionResolver {
     }
 
     private List<String> load(String kbId) {
+        LocalDateTime now = LocalDateTime.now();
         List<Document> documents = documentMapper.selectList(new LambdaQueryWrapper<Document>()
                 .eq(Document::getKbId, kbId)
-                .isNotNull(Document::getCurrentVersionId));
+                .isNotNull(Document::getCurrentVersionId)
+                .eq(Document::getTrashed, NOT_TRASHED)
+                .eq(Document::getPublishStatus, PublishStatus.PUBLISHED)
+                .and(w -> w.isNull(Document::getEffectiveAt).or().le(Document::getEffectiveAt, now))
+                .and(w -> w.isNull(Document::getExpiresAt).or().gt(Document::getExpiresAt, now)));
         return documents.stream().map(Document::getCurrentVersionId).toList();
     }
 }

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/insight/SearchInsightService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/insight/SearchInsightService.java
@@ -1,0 +1,330 @@
+package io.kbrag.app.insight;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.kbrag.app.config.AsyncConfig;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.util.HashUtil;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.SearchInsight;
+import io.kbrag.domain.enums.InsightSource;
+import io.kbrag.domain.mapper.SearchInsightMapper;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.QueryDigestFactory;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Records and reports the search insight rows, the M10 contract section 2.2: one row per online
+ * retrieval, aggregated into the "what are people searching for that the corpus cannot serve" report.
+ *
+ * <p><b>Recorded at the API boundary, never inside {@code RetrievalService}.</b> Evaluation runs and
+ * the release gate reuse the same retrieval pipeline; a hook inside the pipeline would pollute the
+ * report with offline traffic that no user ever typed. The two boundaries that call
+ * {@link #recordAsync(InsightRecord)} are the console debug search and the open API.
+ *
+ * <p><b>Written after the call, off the call's thread.</b> The exact {@code ApiAuditService}
+ * discipline: an insight row is bookkeeping about a search that already answered, so the write is
+ * asynchronous and its failure is logged, never rethrown.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchInsightService {
+
+    /** Rows of the top zero hit query group listing. */
+    private static final int TOP_QUERY_LIMIT = 10;
+
+    /** Days the statistics window covers when the caller names no bounds. */
+    private static final int DEFAULT_STATS_WINDOW_DAYS = 7;
+
+    /** Collapses runs of whitespace during query normalization. */
+    private static final String WHITESPACE_RUN = "\\s+";
+
+    /** Single space the whitespace runs collapse into. */
+    private static final String SINGLE_SPACE = " ";
+
+    private final SearchInsightMapper searchInsightMapper;
+    private final QueryDigestFactory queryDigestFactory;
+    private final BizIdGenerator bizIdGenerator;
+    private final KbProperties properties;
+
+    /**
+     * Queues one insight row per searched knowledge base.
+     *
+     * @param record everything known about the finished retrieval
+     */
+    @Async(AsyncConfig.AUDIT_EXECUTOR)
+    public void recordAsync(InsightRecord record) {
+        try {
+            record(record);
+        } catch (Exception e) {
+            log.error("search insight rows not written, errorCode={}, source={}",
+                    ErrorCode.INTERNAL_ERROR, record.getSource(), e);
+        }
+    }
+
+    /**
+     * Writes one insight row per searched knowledge base.
+     *
+     * <p>A multi knowledge base open API call produces one row per base rather than one row total:
+     * the report is read per knowledge base, and a call that searched three bases is three chances
+     * to discover a content gap. The counts describe the whole call, which the {@code request_id}
+     * shared by the sibling rows makes visible.
+     *
+     * @param record everything known about the finished retrieval
+     * @return persisted rows, empty when recording is disabled or no base was searched
+     */
+    public List<SearchInsight> record(InsightRecord record) {
+        if (!properties.getInsight().isEnabled() || CollectionUtils.isEmpty(record.getKbIds())) {
+            return List.of();
+        }
+        String digest = queryDigestFactory.digest(record.getQuery(),
+                properties.getOpenApi().getQueryDigestMaxLength());
+        String hash = queryHashOf(record.getQuery());
+        int resultCount = record.getResultCount() == null ? 0 : record.getResultCount();
+        String degraded = CollectionUtils.isEmpty(record.getDegraded())
+                ? null : JsonUtil.toJson(record.getDegraded());
+        List<SearchInsight> rows = new ArrayList<>(record.getKbIds().size());
+        for (String kbId : record.getKbIds()) {
+            SearchInsight row = new SearchInsight();
+            row.setInsightId(bizIdGenerator.searchInsightId());
+            row.setKbId(kbId);
+            row.setSource(record.getSource());
+            row.setQueryDigest(digest);
+            row.setQueryHash(hash);
+            row.setResultCount(resultCount);
+            row.setTopScore(record.getTopScore());
+            row.setZeroHit(resultCount == 0);
+            row.setDegraded(degraded);
+            row.setRequestId(record.getRequestId());
+            searchInsightMapper.insert(row);
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    /**
+     * Grouping key of the miss report: SHA-256 of the trimmed, lower cased query with every
+     * whitespace run collapsed to one space.
+     *
+     * <p>Exactly the equivalences a human applies when reading two queries aloud - case and spacing -
+     * and nothing more. Stemming or synonym folding would merge questions a content author must see
+     * apart.
+     *
+     * @param query raw query, {@code null} treated as empty
+     * @return lower case hexadecimal hash
+     */
+    public String queryHashOf(String query) {
+        String normalized = query == null ? "" : query.trim().toLowerCase()
+                .replaceAll(WHITESPACE_RUN, SINGLE_SPACE);
+        return HashUtil.sha256Hex(normalized);
+    }
+
+    /**
+     * Pages the insight rows of one knowledge base, newest first.
+     *
+     * @param kbId    knowledge base business id
+     * @param zeroHit optional zero hit filter
+     * @param from    optional inclusive lower bound of the call time
+     * @param to      optional inclusive upper bound of the call time
+     * @param page    one based page number
+     * @param size    page size
+     * @return paged rows
+     */
+    public IPage<SearchInsight> list(String kbId, Boolean zeroHit, LocalDateTime from, LocalDateTime to,
+                                     long page, long size) {
+        return searchInsightMapper.selectPage(new Page<>(page, size),
+                filter(kbId, zeroHit, from, to).orderByDesc(SearchInsight::getId));
+    }
+
+    /**
+     * Aggregates the content gap report of one knowledge base, the M10 contract section 2.2.
+     *
+     * <p>Computed over the filtered rows rather than kept as running counters, the same reasoning as
+     * the audit statistics: the table already holds every fact, and a second incrementally maintained
+     * set of totals would be one more thing that can disagree with it.
+     *
+     * @param kbId knowledge base business id
+     * @param from optional inclusive lower bound, defaults to seven days back
+     * @param to   optional inclusive upper bound
+     * @return totals plus the top zero hit query groups
+     */
+    public InsightStats stats(String kbId, LocalDateTime from, LocalDateTime to) {
+        LocalDateTime effectiveFrom = from != null ? from
+                : LocalDate.now().minusDays(DEFAULT_STATS_WINDOW_DAYS).atStartOfDay();
+        List<SearchInsight> rows = searchInsightMapper.selectList(
+                filter(kbId, null, effectiveFrom, to).orderByAsc(SearchInsight::getId));
+        if (CollectionUtils.isEmpty(rows)) {
+            return new InsightStats(0L, 0L, 0.0d, 0L, List.of());
+        }
+        long zeroHits = 0;
+        long degradedCalls = 0;
+        Map<String, TopQueryAccumulator> groups = new LinkedHashMap<>();
+        for (SearchInsight row : rows) {
+            if (Boolean.TRUE.equals(row.getZeroHit())) {
+                zeroHits++;
+                groups.computeIfAbsent(row.getQueryHash(), key -> new TopQueryAccumulator())
+                        .absorb(row);
+            }
+            if (row.getDegraded() != null && !row.getDegraded().isBlank()) {
+                degradedCalls++;
+            }
+        }
+        List<TopZeroHitQuery> top = groups.values().stream()
+                .sorted(Comparator.comparingLong(TopQueryAccumulator::getCount).reversed())
+                .limit(TOP_QUERY_LIMIT)
+                .map(TopQueryAccumulator::toView)
+                .toList();
+        return new InsightStats(rows.size(), zeroHits, (double) zeroHits / rows.size(),
+                degradedCalls, top);
+    }
+
+    /**
+     * Daily retention pass.
+     *
+     * <p>Failures are logged and never rethrown: the scheduler has no caller to report to, and one
+     * skipped pass costs table size until the next one, which is not a correctness problem.
+     */
+    @Scheduled(cron = "${kb.insight.cleanup-cron:0 45 3 * * *}")
+    public void scheduledCleanup() {
+        try {
+            int purged = purgeExpired();
+            if (purged > 0) {
+                log.info("search insight cleanup pass finished, purgedRows={}", purged);
+            }
+        } catch (Exception e) {
+            log.error("search insight cleanup pass failed, errorCode={}", ErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+
+    /**
+     * Removes every row older than the retention window, one bounded batch at a time.
+     *
+     * @return rows removed by this pass
+     */
+    public int purgeExpired() {
+        int batchSize = Math.max(1, properties.getInsight().getCleanupBatchSize());
+        LocalDateTime horizon = LocalDate.now()
+                .minusDays(properties.getInsight().getRetentionDays())
+                .atStartOfDay();
+        int purgedTotal = 0;
+        while (true) {
+            int purged = searchInsightMapper.purgeExpired(horizon, batchSize);
+            purgedTotal += purged;
+            if (purged < batchSize) {
+                return purgedTotal;
+            }
+        }
+    }
+
+    private LambdaQueryWrapper<SearchInsight> filter(String kbId, Boolean zeroHit,
+                                                     LocalDateTime from, LocalDateTime to) {
+        LambdaQueryWrapper<SearchInsight> wrapper = new LambdaQueryWrapper<SearchInsight>()
+                .eq(SearchInsight::getKbId, kbId);
+        if (zeroHit != null) {
+            wrapper.eq(SearchInsight::getZeroHit, zeroHit);
+        }
+        if (from != null) {
+            wrapper.ge(SearchInsight::getCreatedAt, from);
+        }
+        if (to != null) {
+            wrapper.le(SearchInsight::getCreatedAt, to);
+        }
+        return wrapper;
+    }
+
+    /**
+     * Everything one recording point knows about a finished retrieval.
+     */
+    @Getter
+    @Builder
+    @ToString(exclude = "query")
+    public static class InsightRecord {
+
+        /** API boundary the call entered through. */
+        private final InsightSource source;
+
+        /** Knowledge bases the call searched, one row each. */
+        private final List<String> kbIds;
+
+        /** Raw query; digested and hashed before anything is stored. */
+        private final String query;
+
+        /** Nodes the call returned. */
+        private final Integer resultCount;
+
+        /** Score of the first node, {@code null} on zero hits. */
+        private final Double topScore;
+
+        /** Degradation markers of the call. */
+        private final List<String> degraded;
+
+        /** Correlation id of the call. */
+        private final String requestId;
+    }
+
+    /**
+     * Content gap report of one knowledge base over one window.
+     *
+     * @param total            recorded retrievals
+     * @param zeroHitCount     retrievals that returned nothing
+     * @param zeroHitRate      {@code zeroHitCount / total}, 0 when the window is empty
+     * @param degradedCount    retrievals that carried at least one degradation marker
+     * @param topZeroHitQueries most frequent zero hit query groups, largest first
+     */
+    public record InsightStats(long total, long zeroHitCount, double zeroHitRate, long degradedCount,
+                               List<TopZeroHitQuery> topZeroHitQueries) {
+    }
+
+    /**
+     * One zero hit query group of the report.
+     *
+     * @param queryDigest masked digest of the newest row of the group
+     * @param count       zero hit rows in the group
+     * @param lastAt      time of the newest row of the group
+     */
+    public record TopZeroHitQuery(String queryDigest, long count, LocalDateTime lastAt) {
+    }
+
+    /**
+     * Running aggregate of one query hash group; rows arrive oldest first, so the last absorbed row
+     * is the newest and its digest is the one the report shows.
+     */
+    @Getter
+    private static class TopQueryAccumulator {
+
+        private String queryDigest;
+        private long count;
+        private LocalDateTime lastAt;
+
+        private void absorb(SearchInsight row) {
+            queryDigest = row.getQueryDigest();
+            lastAt = row.getCreatedAt();
+            count++;
+        }
+
+        private TopZeroHitQuery toView() {
+            return new TopZeroHitQuery(queryDigest, count, lastAt);
+        }
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/metrics/KbMetrics.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/metrics/KbMetrics.java
@@ -1,0 +1,132 @@
+package io.kbrag.app.metrics;
+
+import io.kbrag.domain.enums.InsightSource;
+import io.kbrag.domain.enums.TaskType;
+import io.kbrag.domain.enums.WebSourceFetchStatus;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Business metrics facade, the M13 contract section 3.1.
+ *
+ * <p><b>One method per business fact, no registry leaking into callers.</b> The instrumented
+ * services state what happened - a search finished, a task completed, a call was rejected - and
+ * this class alone decides metric names, tag keys and tag values. That keeps the naming scheme in
+ * one file and keeps an unbounded label (a kb id, a key id, a raw query) from ever becoming a tag:
+ * every value below comes from a bounded enum or a boolean.
+ *
+ * <p><b>Recording never disturbs the business path.</b> Micrometer counters and timers are in
+ * memory operations that do not fail; a {@code null} enum from a defensive caller drops the sample
+ * instead of throwing, because losing one data point is cheaper than failing the call it describes.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class KbMetrics {
+
+    /** Timer of one online retrieval, the same two API boundaries the M10 insight records. */
+    static final String SEARCH = "kb.search";
+
+    /** Counter of one finished asynchronous task. */
+    static final String TASK_COMPLETED = "kb.task.completed";
+
+    /** Counter of one open API call the filter rejected before any controller ran. */
+    static final String OPENAPI_REJECTED = "kb.openapi.rejected";
+
+    /** Counter of one web source sync outcome, the M12 four state result. */
+    static final String WEBSOURCE_SYNC = "kb.websource.sync";
+
+    static final String TAG_SOURCE = "source";
+    static final String TAG_ZERO_HIT = "zero_hit";
+    static final String TAG_DEGRADED = "degraded";
+    static final String TAG_TYPE = "type";
+    static final String TAG_STATUS = "status";
+    static final String TAG_ERROR_CODE = "error_code";
+
+    static final String STATUS_SUCCESS = "success";
+    static final String STATUS_FAILED = "failed";
+
+    private final MeterRegistry registry;
+
+    public KbMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * Records one online retrieval.
+     *
+     * @param source    API boundary the call entered through
+     * @param latencyMs wall time of the retrieval stage in milliseconds
+     * @param resultCount nodes the call returned
+     * @param degraded  degradation markers of the call, empty or {@code null} on a clean run
+     */
+    public void recordSearch(InsightSource source, long latencyMs, int resultCount, List<String> degraded) {
+        if (source == null) {
+            return;
+        }
+        Timer.builder(SEARCH)
+                .tag(TAG_SOURCE, lower(source.name()))
+                .tag(TAG_ZERO_HIT, String.valueOf(resultCount == 0))
+                .tag(TAG_DEGRADED, String.valueOf(CollectionUtils.isNotEmpty(degraded)))
+                .register(registry)
+                .record(latencyMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Records one finished asynchronous task.
+     *
+     * @param taskType task category
+     * @param success  {@code true} for a successful completion
+     */
+    public void recordTaskCompleted(TaskType taskType, boolean success) {
+        if (taskType == null) {
+            return;
+        }
+        Counter.builder(TASK_COMPLETED)
+                .tag(TAG_TYPE, lower(taskType.name()))
+                .tag(TAG_STATUS, success ? STATUS_SUCCESS : STATUS_FAILED)
+                .register(registry)
+                .increment();
+    }
+
+    /**
+     * Records one open API call rejected by the authentication filter.
+     *
+     * @param errorCode classified rejection cause, a bounded {@code ErrorCode} name
+     */
+    public void recordOpenApiRejected(String errorCode) {
+        if (errorCode == null || errorCode.isBlank()) {
+            return;
+        }
+        Counter.builder(OPENAPI_REJECTED)
+                .tag(TAG_ERROR_CODE, errorCode)
+                .register(registry)
+                .increment();
+    }
+
+    /**
+     * Records the outcome of one web source sync.
+     *
+     * @param status four state outcome written onto the registration row
+     */
+    public void recordWebSourceSync(WebSourceFetchStatus status) {
+        if (status == null) {
+            return;
+        }
+        Counter.builder(WEBSOURCE_SYNC)
+                .tag(TAG_STATUS, lower(status.name()))
+                .register(registry)
+                .increment();
+    }
+
+    private String lower(String name) {
+        return name.toLowerCase(Locale.ROOT);
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/metrics/TaskBacklogMetrics.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/metrics/TaskBacklogMetrics.java
@@ -1,0 +1,70 @@
+package io.kbrag.app.metrics;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.domain.entity.KbTask;
+import io.kbrag.domain.enums.TaskStatus;
+import io.kbrag.domain.mapper.KbTaskMapper;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+/**
+ * Task backlog gauges, the M13 contract section 3.2.
+ *
+ * <p><b>Queried on scrape, not kept as running counters.</b> The task table already holds the
+ * truth and {@code idx_status} makes the two counts index-only lookups; a second incrementally
+ * maintained number would be one more thing that can disagree with it. A Prometheus scrape happens
+ * every few seconds at worst, which is nothing next to the writes the pipeline itself performs.
+ *
+ * <p><b>A failing database must not fail the scrape.</b> The count falls back to {@code NaN},
+ * which Prometheus treats as "no sample this round" - the metrics endpoint stays up precisely when
+ * an operator needs it to diagnose the outage.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+public class TaskBacklogMetrics {
+
+    /** Gauge of tasks sitting in one lifecycle state. */
+    static final String TASK_BACKLOG = "kb.task.backlog";
+
+    static final String TAG_STATUS = "status";
+
+    private final KbTaskMapper kbTaskMapper;
+
+    public TaskBacklogMetrics(MeterRegistry registry, KbTaskMapper kbTaskMapper) {
+        this.kbTaskMapper = kbTaskMapper;
+        // Only the states that mean outstanding work: a SUCCESS/FAILED row is history, not backlog.
+        register(registry, TaskStatus.PENDING);
+        register(registry, TaskStatus.RUNNING);
+    }
+
+    private void register(MeterRegistry registry, TaskStatus status) {
+        Gauge.builder(TASK_BACKLOG, this, metrics -> metrics.count(status))
+                .tag(TAG_STATUS, status.name().toLowerCase(Locale.ROOT))
+                .register(registry);
+    }
+
+    /**
+     * Live count of the tasks in one state, {@code NaN} when the database cannot answer.
+     *
+     * @param status lifecycle state
+     * @return row count or {@code NaN}
+     */
+    double count(TaskStatus status) {
+        try {
+            Long count = kbTaskMapper.selectCount(new LambdaQueryWrapper<KbTask>()
+                    .eq(KbTask::getStatus, status));
+            return count == null ? 0 : count;
+        } catch (Exception e) {
+            log.error("task backlog gauge query failed, errorCode={}, status={}",
+                    ErrorCode.INTERNAL_ERROR, status, e);
+            return Double.NaN;
+        }
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/openapi/KnowledgeApiService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/openapi/KnowledgeApiService.java
@@ -3,6 +3,8 @@ package io.kbrag.app.openapi;
 import io.kbrag.app.appcenter.AppService;
 import io.kbrag.app.appcenter.AppVersionService;
 import io.kbrag.app.config.AsyncConfig;
+import io.kbrag.app.insight.SearchInsightService;
+import io.kbrag.app.metrics.KbMetrics;
 import io.kbrag.app.retrieval.ImageQueryService;
 import io.kbrag.app.retrieval.RetrievalCommand;
 import io.kbrag.app.retrieval.RetrievalIndexOverride;
@@ -14,6 +16,7 @@ import io.kbrag.common.context.RequestIdHolder;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.domain.entity.AppVersion;
 import io.kbrag.domain.enums.AppVersionStatus;
+import io.kbrag.domain.enums.InsightSource;
 import io.kbrag.domain.enums.TargetStage;
 import io.kbrag.domain.model.AppConfigSnapshot;
 import io.kbrag.domain.model.AppIndexSnapshot;
@@ -71,7 +74,9 @@ public class KnowledgeApiService {
     private final ContentBudgetTrimmer contentBudgetTrimmer;
     private final RequestOverridePolicy requestOverridePolicy;
     private final ApiAuditService apiAuditService;
+    private final SearchInsightService searchInsightService;
     private final ImageQueryService imageQueryService;
+    private final KbMetrics kbMetrics;
 
     /**
      * Runs one open search call.
@@ -87,6 +92,7 @@ public class KnowledgeApiService {
             ResolvedTarget target = resolve(principal, command);
             call = enrich(command);
             KnowledgeCallResult result = retrieve(target, call);
+            insight(call, result, startedAt);
             audit(principal, call.command(), target, result, startedAt, ApiAuditService.ENDPOINT_SEARCH);
             return result;
         } catch (BizException e) {
@@ -109,6 +115,7 @@ public class KnowledgeApiService {
             ResolvedTarget target = resolve(principal, command);
             call = enrich(command);
             KnowledgeCallResult retrieved = retrieve(target, call);
+            insight(call, retrieved, startedAt);
             String answer = generate(target, call.command(), retrieved.getNodes());
             KnowledgeCallResult result = withAnswer(retrieved, answer);
             audit(principal, call.command(), target, result, startedAt, ApiAuditService.ENDPOINT_CHAT);
@@ -138,6 +145,7 @@ public class KnowledgeApiService {
             ResolvedTarget target = resolve(principal, command);
             call = enrich(command);
             KnowledgeCallResult retrieved = retrieve(target, call);
+            insight(call, retrieved, startedAt);
             StringBuilder answer = new StringBuilder();
             streamGenerate(target, call.command(), retrieved.getNodes(), delta -> {
                 answer.append(delta);
@@ -557,6 +565,39 @@ public class KnowledgeApiService {
                 .latencyMs((int) (System.currentTimeMillis() - startedAt))
                 .overrideKeys(requestOverridePolicy.appliedKeys(command.getPresentedOverrideKeys()))
                 .errorCode(e.getErrorCode().name())
+                .requestId(RequestIdHolder.get())
+                .build());
+    }
+
+    /**
+     * The open API insight recording point, the M10 contract section 2.2.
+     *
+     * <p>Sits after a successful retrieval only: a rejected call never searched anything, so it belongs
+     * to the audit trail and not to the content gap report. The enriched query is what gets digested -
+     * the same choice the audit row makes - because it is the text the ranking actually came from.
+     * Chat calls record the counts of their retrieval stage; the generated answer changes nothing about
+     * whether the corpus could serve the question.
+     *
+     * <p>Also the open API sampling point of the M13 search metric, which shares the insight's boundary
+     * reasoning and adds what the insight row does not carry: the wall time since the call entered. For a
+     * chat call that is the retrieval stage only, since this runs before the generation starts.
+     *
+     * @param call      call parameters with the image text folded into the query
+     * @param result    retrieval outcome of the call
+     * @param startedAt epoch milliseconds the call entered the service at
+     */
+    private void insight(EnrichedCall call, KnowledgeCallResult result, long startedAt) {
+        List<RetrievalNodeView> nodes = result.getNodes();
+        int resultCount = CollectionUtils.isEmpty(nodes) ? 0 : nodes.size();
+        kbMetrics.recordSearch(InsightSource.OPEN_API, System.currentTimeMillis() - startedAt,
+                resultCount, result.getDegraded());
+        searchInsightService.recordAsync(SearchInsightService.InsightRecord.builder()
+                .source(InsightSource.OPEN_API)
+                .kbIds(result.routedKbIds())
+                .query(call.command().getQuery())
+                .resultCount(resultCount)
+                .topScore(CollectionUtils.isEmpty(nodes) ? null : nodes.get(0).getScore())
+                .degraded(result.getDegraded())
                 .requestId(RequestIdHolder.get())
                 .build());
     }

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/websource/WebSourceService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/websource/WebSourceService.java
@@ -1,0 +1,323 @@
+package io.kbrag.app.websource;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.kbrag.app.document.DocumentService;
+import io.kbrag.app.document.UploadOutcome;
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.app.metrics.KbMetrics;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.common.util.HashUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.WebSource;
+import io.kbrag.domain.enums.WebSourceFetchStatus;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.WebSourceMapper;
+import io.kbrag.domain.port.WebPageFetcher;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.UrlGuard;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * URL import and incremental sync, the M12 contract section 3.4.
+ *
+ * <p><b>Everything a fetch produces goes through {@link DocumentService#upload}.</b> The derived
+ * file name is stable per URL, so a re-fetch lands on the "same name adds a version" path, and the
+ * content-hash short circuit inside the upload chain means an unchanged page never creates a
+ * version. Governance, retention and the index pipeline all apply to web content for free because
+ * there is no second intake path to keep honest.
+ *
+ * <p><b>One sync never throws.</b> Its outcome - SUCCESS, UNCHANGED, SKIPPED or FAILED - is written
+ * onto the registration row where both the operator and the next pass can read it; a page that is
+ * down today is simply retried tomorrow.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WebSourceService {
+
+    /** Value of {@code trashed} inside the recycle bin. */
+    private static final int TRASHED = 1;
+
+    /** {@code sync_enabled} value that includes a source in the scheduled pass. */
+    private static final int SYNC_ON = 1;
+
+    /** {@code sync_enabled} value that excludes a source from the scheduled pass. */
+    private static final int SYNC_OFF = 0;
+
+    /** Column limit of {@code last_error}; longer causes are truncated, not lost to an SQL error. */
+    private static final int MAX_ERROR_LENGTH = 512;
+
+    /** Upper bound of the derived file name, kept well under the 500 char column. */
+    private static final int MAX_FILE_NAME_LENGTH = 200;
+
+    /** URL hash prefix appended to the file name so two URLs with alike paths never merge. */
+    private static final int FILE_NAME_HASH_LENGTH = 8;
+
+    private final WebSourceMapper webSourceMapper;
+    private final DocumentMapper documentMapper;
+    private final DocumentService documentService;
+    private final KnowledgeBaseService knowledgeBaseService;
+    private final UrlGuard urlGuard;
+    private final WebPageFetcher webPageFetcher;
+    private final BizIdGenerator bizIdGenerator;
+    private final KbProperties properties;
+    private final KbMetrics kbMetrics;
+
+    /**
+     * Registers a URL and immediately runs its first sync.
+     *
+     * <p>The registration survives a failed first fetch on purpose: the operator registered the
+     * page, not the luck of this minute, and the row carries the failure for them to see.
+     *
+     * @param kbId        knowledge base business id
+     * @param url         page address, validated against the SSRF guard
+     * @param syncEnabled whether the scheduled pass should include this source
+     * @return registration row including the outcome of the first fetch
+     */
+    public WebSource register(String kbId, String url, boolean syncEnabled) {
+        knowledgeBaseService.require(kbId);
+        String normalized = urlGuard.validate(url).toString();
+        String urlHash = HashUtil.sha256Hex(normalized);
+        Long existing = webSourceMapper.selectCount(new LambdaQueryWrapper<WebSource>()
+                .eq(WebSource::getKbId, kbId)
+                .eq(WebSource::getUrlHash, urlHash));
+        if (existing != null && existing > 0) {
+            throw BizException.invalidParam("该 URL 已在此知识库登记，请勿重复添加");
+        }
+        WebSource source = new WebSource();
+        source.setSourceId(bizIdGenerator.webSourceId());
+        source.setKbId(kbId);
+        source.setUrl(normalized);
+        source.setUrlHash(urlHash);
+        source.setSyncEnabled(syncEnabled ? SYNC_ON : SYNC_OFF);
+        webSourceMapper.insert(source);
+        log.info("web source registered, sourceId={}, kbId={}, url={}", source.getSourceId(), kbId, normalized);
+        sync(source);
+        return source;
+    }
+
+    /**
+     * Lists the registrations of a knowledge base, most recently registered first.
+     *
+     * @param kbId knowledge base business id
+     * @param page one based page number
+     * @param size page size
+     * @return page of registrations
+     */
+    public IPage<WebSource> list(String kbId, long page, long size) {
+        return webSourceMapper.selectPage(new Page<>(page, size), new LambdaQueryWrapper<WebSource>()
+                .eq(WebSource::getKbId, kbId)
+                .orderByDesc(WebSource::getId));
+    }
+
+    /**
+     * Runs one sync of one source on demand.
+     *
+     * @param sourceId registration business id
+     * @return registration row carrying the outcome
+     */
+    public WebSource syncNow(String sourceId) {
+        WebSource source = require(sourceId);
+        sync(source);
+        return source;
+    }
+
+    /**
+     * Flips the scheduled-sync switch of one source.
+     *
+     * @param sourceId registration business id
+     * @param enabled  {@code true} includes the source in the scheduled pass
+     * @return updated registration row
+     */
+    public WebSource updateSyncEnabled(String sourceId, boolean enabled) {
+        WebSource source = require(sourceId);
+        source.setSyncEnabled(enabled ? SYNC_ON : SYNC_OFF);
+        webSourceMapper.updateById(source);
+        log.info("web source sync switch updated, sourceId={}, enabled={}", sourceId, enabled);
+        return source;
+    }
+
+    /**
+     * Removes a registration; the document it fed stays untouched.
+     *
+     * <p>Hard delete, not the soft flag: a soft-deleted row would hold {@code uk_kb_url} hostage
+     * and make the same URL unregisterable forever.
+     *
+     * @param sourceId registration business id
+     */
+    public void remove(String sourceId) {
+        WebSource source = require(sourceId);
+        webSourceMapper.hardDeleteById(source.getId());
+        log.info("web source removed, sourceId={}, kbId={}, docId={}",
+                sourceId, source.getKbId(), source.getDocId());
+    }
+
+    /**
+     * Nightly sync pass over every source whose switch is on.
+     *
+     * <p>Failures are logged and never rethrown: the scheduler has no caller to report to, and
+     * {@link #sync} already confines each source's failure to its own row.
+     */
+    @Scheduled(cron = "${kb.web-import.sync-cron:0 30 2 * * *}")
+    public void scheduledSync() {
+        if (!properties.getWebImport().isSyncEnabled()) {
+            return;
+        }
+        try {
+            int synced = syncEnabledSources();
+            if (synced > 0) {
+                log.info("web source sync pass finished, sources={}", synced);
+            }
+        } catch (Exception e) {
+            log.error("web source sync pass failed, errorCode={}", ErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+
+    /**
+     * Syncs one bounded batch of enabled sources, oldest registration first.
+     *
+     * <p>A single batch per pass is intentional: page fetches are slow network calls, and an
+     * operator who registered thousands of URLs should see them drain over passes rather than one
+     * pass monopolising the scheduler thread for hours.
+     *
+     * @return sources attempted by this pass
+     */
+    public int syncEnabledSources() {
+        int batchSize = Math.max(1, properties.getWebImport().getSyncBatchSize());
+        List<WebSource> batch = webSourceMapper.selectList(new LambdaQueryWrapper<WebSource>()
+                .eq(WebSource::getSyncEnabled, SYNC_ON)
+                .orderByAsc(WebSource::getId)
+                .last("limit " + batchSize));
+        if (CollectionUtils.isEmpty(batch)) {
+            return 0;
+        }
+        for (WebSource source : batch) {
+            sync(source);
+        }
+        return batch.size();
+    }
+
+    /**
+     * Runs one sync of one source and records its outcome on the row. Never throws.
+     *
+     * <p>The five steps of the contract: re-validate the URL (DNS may have moved since
+     * registration), fetch, short-circuit on an unchanged body, skip while the bound document sits
+     * in the recycle bin, otherwise feed the body to the upload chain and rebind.
+     *
+     * @param source registration row, mutated in place with the outcome
+     */
+    public void sync(WebSource source) {
+        source.setLastFetchAt(LocalDateTime.now());
+        try {
+            URI uri = urlGuard.validate(source.getUrl());
+            WebPageFetcher.FetchedPage page = webPageFetcher.fetch(uri.toString());
+            String contentHash = HashUtil.sha256Hex(page.body());
+            if (contentHash.equals(source.getLastContentHash())) {
+                record(source, WebSourceFetchStatus.UNCHANGED, null);
+                return;
+            }
+            Document bound = findBoundDocument(source);
+            if (bound != null && inTrash(bound)) {
+                // Writing a version into a trashed document would silently resurrect content the
+                // operator chose to remove; the page waits until they restore or purge it.
+                record(source, WebSourceFetchStatus.SKIPPED, "绑定的文档在回收站中，本次同步已跳过");
+                return;
+            }
+            String fileName = source.getFileName() != null
+                    ? source.getFileName()
+                    : deriveFileName(uri, source.getUrlHash(), page.extension());
+            UploadOutcome outcome = documentService.upload(source.getKbId(), fileName, page.body());
+            // A purge breaks the binding; the upload above then created a fresh document and the
+            // registration follows it, which is the weak-binding semantics of the contract.
+            source.setDocId(outcome.document().getDocId());
+            source.setFileName(fileName);
+            source.setLastContentHash(contentHash);
+            record(source, WebSourceFetchStatus.SUCCESS, null);
+            log.info("web source synced, sourceId={}, docId={}, version={}, duplicated={}",
+                    source.getSourceId(), source.getDocId(), outcome.version(), outcome.duplicated());
+        } catch (Exception e) {
+            log.warn("web source sync failed, sourceId={}, url={}, error={}",
+                    source.getSourceId(), source.getUrl(), e.getMessage());
+            record(source, WebSourceFetchStatus.FAILED, e.getMessage());
+        }
+    }
+
+    private void record(WebSource source, WebSourceFetchStatus status, String error) {
+        source.setLastFetchStatus(status);
+        source.setLastError(truncate(error));
+        webSourceMapper.updateById(source);
+        // The one funnel every outcome passes, which is what makes it the M13 sync counter's spot.
+        kbMetrics.recordWebSourceSync(status);
+    }
+
+    private WebSource require(String sourceId) {
+        WebSource source = webSourceMapper.selectOne(new LambdaQueryWrapper<WebSource>()
+                .eq(WebSource::getSourceId, sourceId));
+        if (source == null) {
+            throw BizException.notFound("URL 登记不存在：" + sourceId);
+        }
+        return source;
+    }
+
+    /**
+     * Bound document of a source, {@code null} when never bound or when a purge removed it.
+     */
+    private Document findBoundDocument(WebSource source) {
+        if (source.getDocId() == null) {
+            return null;
+        }
+        return documentMapper.selectOne(new LambdaQueryWrapper<Document>()
+                .eq(Document::getDocId, source.getDocId()));
+    }
+
+    private boolean inTrash(Document document) {
+        return document.getTrashed() != null && document.getTrashed() == TRASHED;
+    }
+
+    /**
+     * Derives the stable file name a URL uploads under: host, a slug of the path and a hash prefix
+     * that keeps two different URLs with alike paths from merging into one document.
+     */
+    static String deriveFileName(URI uri, String urlHash, String extension) {
+        String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
+        String slug = slugOf(uri.getRawPath());
+        String base = slug.isEmpty() ? host : host + "-" + slug;
+        String suffix = "-" + urlHash.substring(0, FILE_NAME_HASH_LENGTH) + "." + extension;
+        int room = MAX_FILE_NAME_LENGTH - suffix.length();
+        if (base.length() > room) {
+            base = base.substring(0, room);
+        }
+        return base + suffix;
+    }
+
+    /** Lower-cases a URL path and collapses every non-alphanumeric run into a single dash. */
+    private static String slugOf(String path) {
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
+        String slug = path.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "-");
+        return slug.replaceAll("^-+|-+$", "");
+    }
+
+    private String truncate(String message) {
+        if (message == null) {
+            return null;
+        }
+        return message.length() <= MAX_ERROR_LENGTH ? message : message.substring(0, MAX_ERROR_LENGTH);
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/alert/AlertServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/alert/AlertServiceTest.java
@@ -1,5 +1,6 @@
 package io.kbrag.app.alert;
 
+import io.kbrag.app.metrics.KbMetrics;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.enums.AlertType;
@@ -7,6 +8,7 @@ import io.kbrag.domain.enums.TaskType;
 import io.kbrag.domain.mapper.ChunkIndexSyncMapper;
 import io.kbrag.domain.model.AlertConfig;
 import io.kbrag.domain.port.WebhookNotifier;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -161,7 +163,8 @@ class AlertServiceTest {
 
     @Test
     void shouldRaiseTaskFailuresOnlyOnceTheThresholdIsReached() {
-        TaskFailureTracker tracker = new TaskFailureTracker(alertConfigService, alertService);
+        TaskFailureTracker tracker = new TaskFailureTracker(alertConfigService, alertService,
+                new KbMetrics(new SimpleMeterRegistry()));
 
         tracker.recordFailure(TaskType.INDEX, "engine unreachable");
         tracker.recordFailure(TaskType.INDEX, "engine unreachable");
@@ -174,7 +177,8 @@ class AlertServiceTest {
 
     @Test
     void shouldResetTheFailureRunOnASuccess() {
-        TaskFailureTracker tracker = new TaskFailureTracker(alertConfigService, alertService);
+        TaskFailureTracker tracker = new TaskFailureTracker(alertConfigService, alertService,
+                new KbMetrics(new SimpleMeterRegistry()));
 
         tracker.recordFailure(TaskType.INDEX, "transient");
         tracker.recordFailure(TaskType.INDEX, "transient");
@@ -188,7 +192,8 @@ class AlertServiceTest {
 
     @Test
     void shouldCountFailureRunsPerTaskType() {
-        TaskFailureTracker tracker = new TaskFailureTracker(alertConfigService, alertService);
+        TaskFailureTracker tracker = new TaskFailureTracker(alertConfigService, alertService,
+                new KbMetrics(new SimpleMeterRegistry()));
 
         tracker.recordFailure(TaskType.INDEX, "one");
         tracker.recordFailure(TaskType.INDEX, "two");

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/document/DocumentServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/document/DocumentServiceTest.java
@@ -1,0 +1,130 @@
+package io.kbrag.app.document;
+
+import io.kbrag.app.index.IndexPipelineService;
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.app.support.MybatisLambdaCache;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.DocumentVersion;
+import io.kbrag.domain.entity.KnowledgeBase;
+import io.kbrag.domain.enums.PublishStatus;
+import io.kbrag.domain.mapper.AnnotationMapper;
+import io.kbrag.domain.mapper.ChunkMapper;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.DocumentVersionMapper;
+import io.kbrag.domain.port.EmbeddingProvider;
+import io.kbrag.domain.port.ObjectStorage;
+import io.kbrag.domain.port.VisionProvider;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.DocumentVersionPlanner;
+import io.kbrag.domain.service.VersionFingerprintFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the governance side of the intake: the initial publication state is decided once, by the
+ * review switch of the knowledge base at creation time, and later versions inherit it.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class DocumentServiceTest {
+
+    private static final String KB_ID = "kb_1";
+    private static final String DOC_ID = "doc_1";
+    private static final String VERSION_ID = "dv_1";
+    private static final String FILE_NAME = "guide.txt";
+    private static final byte[] CONTENT = "hello".getBytes(StandardCharsets.UTF_8);
+
+    private DocumentMapper documentMapper;
+    private DocumentVersionMapper documentVersionMapper;
+    private KnowledgeBaseService knowledgeBaseService;
+    private DocumentVersionPlanner versionPlanner;
+    private DocumentService service;
+
+    @BeforeEach
+    void setUp() {
+        MybatisLambdaCache.register(Document.class, DocumentVersion.class);
+        documentMapper = mock(DocumentMapper.class);
+        documentVersionMapper = mock(DocumentVersionMapper.class);
+        knowledgeBaseService = mock(KnowledgeBaseService.class);
+        versionPlanner = mock(DocumentVersionPlanner.class);
+        UploadValidator uploadValidator = mock(UploadValidator.class);
+        BizIdGenerator bizIdGenerator = mock(BizIdGenerator.class);
+        service = new DocumentService(documentMapper, documentVersionMapper,
+                mock(ChunkMapper.class), mock(AnnotationMapper.class), mock(ObjectStorage.class),
+                bizIdGenerator, uploadValidator, knowledgeBaseService,
+                mock(IndexPipelineService.class), versionPlanner,
+                mock(VersionFingerprintFactory.class), mock(EmbeddingProvider.class),
+                mock(VisionProvider.class));
+
+        when(uploadValidator.validate(anyString(), any())).thenReturn("txt");
+        when(bizIdGenerator.documentId()).thenReturn(DOC_ID);
+        when(bizIdGenerator.documentVersionId()).thenReturn(VERSION_ID);
+        when(versionPlanner.plan(any(), any())).thenReturn(new DocumentVersionPlanner.VersionPlan(
+                false, "1", null, DocumentVersionPlanner.Reuse.none()));
+        when(documentVersionMapper.selectList(any())).thenReturn(List.of());
+    }
+
+    @Test
+    void shouldPublishANewDocumentWhenTheKnowledgeBaseNeedsNoReview() {
+        when(knowledgeBaseService.require(KB_ID)).thenReturn(knowledgeBase(0));
+
+        service.upload(KB_ID, FILE_NAME, CONTENT);
+
+        Document inserted = capturedInsert();
+        assertEquals(PublishStatus.PUBLISHED, inserted.getPublishStatus());
+        assertEquals(0, inserted.getTrashed());
+    }
+
+    @Test
+    void shouldStartANewDocumentAsADraftUnderAReviewRequiringKnowledgeBase() {
+        when(knowledgeBaseService.require(KB_ID)).thenReturn(knowledgeBase(1));
+
+        service.upload(KB_ID, FILE_NAME, CONTENT);
+
+        assertEquals(PublishStatus.DRAFT, capturedInsert().getPublishStatus());
+    }
+
+    @Test
+    void shouldNotResetThePublicationStateWhenAVersionIsAdded() {
+        // The review gates what the document is, not each revision: a re-upload of a draft must not
+        // silently publish it, and a re-upload of a published document must not pull it offline.
+        when(knowledgeBaseService.require(KB_ID)).thenReturn(knowledgeBase(1));
+        Document existing = new Document();
+        existing.setDocId(DOC_ID);
+        existing.setKbId(KB_ID);
+        existing.setFileName(FILE_NAME);
+        existing.setPublishStatus(PublishStatus.DRAFT);
+        existing.setTrashed(0);
+        when(documentMapper.selectOne(any())).thenReturn(existing);
+
+        service.upload(KB_ID, FILE_NAME, CONTENT);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(documentMapper).updateById(captor.capture());
+        assertEquals(PublishStatus.DRAFT, captor.getValue().getPublishStatus());
+    }
+
+    private Document capturedInsert() {
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(documentMapper).insert(captor.capture());
+        return captor.getValue();
+    }
+
+    private KnowledgeBase knowledgeBase(int reviewRequired) {
+        KnowledgeBase knowledgeBase = new KnowledgeBase();
+        knowledgeBase.setKbId(KB_ID);
+        knowledgeBase.setReviewRequired(reviewRequired);
+        return knowledgeBase;
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/feedback/RetrievalFeedbackServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/feedback/RetrievalFeedbackServiceTest.java
@@ -1,0 +1,176 @@
+package io.kbrag.app.feedback;
+
+import io.kbrag.app.eval.EvalDatasetService;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.entity.EvalCase;
+import io.kbrag.domain.entity.RetrievalFeedback;
+import io.kbrag.domain.enums.CaseSource;
+import io.kbrag.domain.enums.FeedbackStatus;
+import io.kbrag.domain.enums.FeedbackVerdict;
+import io.kbrag.domain.mapper.ChunkMapper;
+import io.kbrag.domain.mapper.RetrievalFeedbackMapper;
+import io.kbrag.domain.service.BizIdGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the feedback loop of the M10 contract section 2.1: a verdict is an event that always lands,
+ * the owning document is resolved server side, and the only legal transitions are
+ * {@code NEW -> CONVERTED} for a {@code GOOD} verdict and {@code NEW -> DISMISSED} for any.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class RetrievalFeedbackServiceTest {
+
+    private static final String FEEDBACK_ID = "rfb_1";
+    private static final String KB_ID = "kb_1";
+    private static final String QUERY = "如何重置密码";
+    private static final String CHUNK_ID = "ck_1";
+    private static final String DOC_ID = "doc_1";
+    private static final String DATASET_ID = "ds_1";
+    private static final String CASE_ID = "case_1";
+
+    private RetrievalFeedbackMapper retrievalFeedbackMapper;
+    private ChunkMapper chunkMapper;
+    private EvalDatasetService evalDatasetService;
+    private RetrievalFeedbackService service;
+
+    @BeforeEach
+    void setUp() {
+        retrievalFeedbackMapper = mock(RetrievalFeedbackMapper.class);
+        chunkMapper = mock(ChunkMapper.class);
+        evalDatasetService = mock(EvalDatasetService.class);
+        BizIdGenerator bizIdGenerator = mock(BizIdGenerator.class);
+        when(bizIdGenerator.retrievalFeedbackId()).thenReturn(FEEDBACK_ID);
+        service = new RetrievalFeedbackService(retrievalFeedbackMapper, chunkMapper,
+                evalDatasetService, bizIdGenerator);
+    }
+
+    @Test
+    void shouldResolveTheOwningDocumentServerSide() {
+        when(chunkMapper.selectOne(any())).thenReturn(chunk());
+
+        RetrievalFeedback stored = service.record(KB_ID, QUERY, CHUNK_ID, FeedbackVerdict.GOOD);
+
+        verify(retrievalFeedbackMapper).insert(any(RetrievalFeedback.class));
+        assertEquals(FEEDBACK_ID, stored.getFeedbackId());
+        assertEquals(DOC_ID, stored.getDocId());
+        assertEquals(FeedbackVerdict.GOOD, stored.getVerdict());
+        assertEquals(FeedbackStatus.NEW, stored.getStatus());
+    }
+
+    @Test
+    void shouldAcceptFeedbackWhoseChunkWasAlreadyDeleted() {
+        when(chunkMapper.selectOne(any())).thenReturn(null);
+
+        RetrievalFeedback stored = service.record(KB_ID, QUERY, CHUNK_ID, FeedbackVerdict.BAD);
+
+        // The signal may arrive after the chunk is gone; the query is still a fact worth keeping.
+        verify(retrievalFeedbackMapper).insert(any(RetrievalFeedback.class));
+        assertNull(stored.getDocId());
+    }
+
+    @Test
+    void shouldConvertAGoodFeedbackThroughTheDebugPagePath() {
+        when(retrievalFeedbackMapper.selectOne(any())).thenReturn(feedback(FeedbackVerdict.GOOD, FeedbackStatus.NEW));
+        when(chunkMapper.selectOne(any())).thenReturn(chunk());
+        EvalCase evalCase = new EvalCase();
+        evalCase.setCaseId(CASE_ID);
+        when(evalDatasetService.collectFromRetrieval(eq(DATASET_ID), eq(QUERY), isNull(),
+                eq(List.of(CHUNK_ID)), isNull(), eq(CaseSource.FEEDBACK))).thenReturn(evalCase);
+
+        RetrievalFeedback converted = service.convert(FEEDBACK_ID, DATASET_ID);
+
+        ArgumentCaptor<RetrievalFeedback> captor = ArgumentCaptor.forClass(RetrievalFeedback.class);
+        verify(retrievalFeedbackMapper).updateById(captor.capture());
+        assertEquals(FeedbackStatus.CONVERTED, captor.getValue().getStatus());
+        assertEquals(CASE_ID, captor.getValue().getConvertedCaseId());
+        assertEquals(CASE_ID, converted.getConvertedCaseId());
+    }
+
+    @Test
+    void shouldRefuseToConvertABadVerdict() {
+        when(retrievalFeedbackMapper.selectOne(any())).thenReturn(feedback(FeedbackVerdict.BAD, FeedbackStatus.NEW));
+
+        assertThrows(BizException.class, () -> service.convert(FEEDBACK_ID, DATASET_ID));
+
+        verify(evalDatasetService, never()).collectFromRetrieval(anyString(), anyString(), any(),
+                anyList(), any(), any());
+    }
+
+    @Test
+    void shouldRefuseToConvertWhenTheChunkNoLongerExists() {
+        when(retrievalFeedbackMapper.selectOne(any())).thenReturn(feedback(FeedbackVerdict.GOOD, FeedbackStatus.NEW));
+        when(chunkMapper.selectOne(any())).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.convert(FEEDBACK_ID, DATASET_ID));
+
+        verify(evalDatasetService, never()).collectFromRetrieval(anyString(), anyString(), any(),
+                anyList(), any(), any());
+    }
+
+    @Test
+    void shouldDismissANewFeedback() {
+        when(retrievalFeedbackMapper.selectOne(any())).thenReturn(feedback(FeedbackVerdict.BAD, FeedbackStatus.NEW));
+
+        RetrievalFeedback dismissed = service.dismiss(FEEDBACK_ID);
+
+        verify(retrievalFeedbackMapper).updateById(any(RetrievalFeedback.class));
+        assertEquals(FeedbackStatus.DISMISSED, dismissed.getStatus());
+    }
+
+    @Test
+    void shouldTreatBothNonNewStatesAsTerminal() {
+        when(retrievalFeedbackMapper.selectOne(any()))
+                .thenReturn(feedback(FeedbackVerdict.GOOD, FeedbackStatus.CONVERTED));
+        assertThrows(BizException.class, () -> service.convert(FEEDBACK_ID, DATASET_ID));
+        assertThrows(BizException.class, () -> service.dismiss(FEEDBACK_ID));
+
+        when(retrievalFeedbackMapper.selectOne(any()))
+                .thenReturn(feedback(FeedbackVerdict.GOOD, FeedbackStatus.DISMISSED));
+        assertThrows(BizException.class, () -> service.convert(FEEDBACK_ID, DATASET_ID));
+        assertThrows(BizException.class, () -> service.dismiss(FEEDBACK_ID));
+    }
+
+    @Test
+    void shouldFailLoudlyWhenTheFeedbackIsUnknown() {
+        when(retrievalFeedbackMapper.selectOne(any())).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.dismiss(FEEDBACK_ID));
+    }
+
+    private RetrievalFeedback feedback(FeedbackVerdict verdict, FeedbackStatus status) {
+        RetrievalFeedback feedback = new RetrievalFeedback();
+        feedback.setFeedbackId(FEEDBACK_ID);
+        feedback.setKbId(KB_ID);
+        feedback.setQuery(QUERY);
+        feedback.setChunkId(CHUNK_ID);
+        feedback.setVerdict(verdict);
+        feedback.setStatus(status);
+        return feedback;
+    }
+
+    private Chunk chunk() {
+        Chunk chunk = new Chunk();
+        chunk.setChunkId(CHUNK_ID);
+        chunk.setDocId(DOC_ID);
+        return chunk;
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/governance/DocumentGovernanceServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/governance/DocumentGovernanceServiceTest.java
@@ -1,0 +1,361 @@
+package io.kbrag.app.governance;
+
+import io.kbrag.app.document.DocumentService;
+import io.kbrag.app.index.ActiveVersionResolver;
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.app.support.MybatisLambdaCache;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.KnowledgeBase;
+import io.kbrag.domain.enums.PublishStatus;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.KnowledgeBaseMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the governance state machine, the validity window, the recycle bin and the scheduled purge
+ * of the M11 contract: every mutation must both flip the row and drop the visibility cache, because
+ * the cache is the only place governance takes effect.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class DocumentGovernanceServiceTest {
+
+    private static final String DOC_ID = "doc_1";
+    private static final String OTHER_DOC_ID = "doc_2";
+    private static final String KB_ID = "kb_1";
+
+    private DocumentMapper documentMapper;
+    private KnowledgeBaseMapper knowledgeBaseMapper;
+    private DocumentService documentService;
+    private KnowledgeBaseService knowledgeBaseService;
+    private ActiveVersionResolver activeVersionResolver;
+    private KbProperties properties;
+    private DocumentGovernanceService service;
+
+    @BeforeEach
+    void setUp() {
+        MybatisLambdaCache.register(Document.class, KnowledgeBase.class);
+        documentMapper = mock(DocumentMapper.class);
+        knowledgeBaseMapper = mock(KnowledgeBaseMapper.class);
+        documentService = mock(DocumentService.class);
+        knowledgeBaseService = mock(KnowledgeBaseService.class);
+        activeVersionResolver = mock(ActiveVersionResolver.class);
+        properties = new KbProperties();
+        service = new DocumentGovernanceService(documentMapper, knowledgeBaseMapper, documentService,
+                knowledgeBaseService, activeVersionResolver, properties);
+    }
+
+    @Test
+    void shouldSubmitADraftForReview() {
+        given(document(PublishStatus.DRAFT));
+
+        Document updated = service.submitReview(DOC_ID);
+
+        assertEquals(PublishStatus.PENDING_REVIEW, updated.getPublishStatus());
+        verify(documentMapper).updateById(updated);
+        verify(activeVersionResolver).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldLetARejectedDocumentBeResubmitted() {
+        given(document(PublishStatus.REJECTED));
+
+        assertEquals(PublishStatus.PENDING_REVIEW, service.submitReview(DOC_ID).getPublishStatus());
+    }
+
+    @Test
+    void shouldRefuseToSubmitAPublishedDocument() {
+        given(document(PublishStatus.PUBLISHED));
+
+        assertThrows(BizException.class, () -> service.submitReview(DOC_ID));
+        verify(documentMapper, never()).updateById(any(Document.class));
+    }
+
+    @Test
+    void shouldTreatARowPredatingTheMigrationAsPublished() {
+        // Rows written before V13 carry a null column; the contract says they are PUBLISHED, so they
+        // must be refused exactly like an explicit PUBLISHED.
+        given(document(null));
+
+        assertThrows(BizException.class, () -> service.submitReview(DOC_ID));
+    }
+
+    @Test
+    void shouldApproveAPendingDocumentAndClearTheOldRejectionNote() {
+        Document document = given(document(PublishStatus.PENDING_REVIEW));
+        document.setReviewNote("previous verdict");
+        AtomicReference<String> sqlSet = captureUpdateSqlSet();
+
+        Document updated = service.approve(DOC_ID);
+
+        assertEquals(PublishStatus.PUBLISHED, updated.getPublishStatus());
+        assertNull(updated.getReviewNote());
+        // The note of the superseded rejection must be written as null, which updateById would skip.
+        assertTrue(sqlSet.get().contains("review_note"));
+        verify(activeVersionResolver).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldRefuseToApproveADocumentNobodySubmitted() {
+        given(document(PublishStatus.DRAFT));
+
+        assertThrows(BizException.class, () -> service.approve(DOC_ID));
+    }
+
+    @Test
+    void shouldRejectAPendingDocumentWithTheNote() {
+        given(document(PublishStatus.PENDING_REVIEW));
+
+        Document updated = service.reject(DOC_ID, "needs a source");
+
+        assertEquals(PublishStatus.REJECTED, updated.getPublishStatus());
+        assertEquals("needs a source", updated.getReviewNote());
+        verify(documentMapper).updateById(updated);
+        verify(activeVersionResolver).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldRefuseToRejectAPublishedDocument() {
+        // PUBLISHED is terminal: taking content offline is an expiry or a trash operation, never a
+        // review rollback.
+        given(document(PublishStatus.PUBLISHED));
+
+        assertThrows(BizException.class, () -> service.reject(DOC_ID, "note"));
+    }
+
+    @Test
+    void shouldSetTheValidityWindow() {
+        given(document(PublishStatus.PUBLISHED));
+        AtomicReference<String> sqlSet = captureUpdateSqlSet();
+        LocalDateTime from = LocalDateTime.of(2026, 1, 1, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2026, 12, 31, 0, 0);
+
+        Document updated = service.updateValidity(DOC_ID, from, to);
+
+        assertEquals(from, updated.getEffectiveAt());
+        assertEquals(to, updated.getExpiresAt());
+        assertTrue(sqlSet.get().contains("effective_at"));
+        assertTrue(sqlSet.get().contains("expires_at"));
+        verify(activeVersionResolver).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldClearTheWindowWhenBothBoundsAreAbsent() {
+        Document document = given(document(PublishStatus.PUBLISHED));
+        document.setEffectiveAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        document.setExpiresAt(LocalDateTime.of(2026, 12, 31, 0, 0));
+        captureUpdateSqlSet();
+
+        Document updated = service.updateValidity(DOC_ID, null, null);
+
+        assertNull(updated.getEffectiveAt());
+        assertNull(updated.getExpiresAt());
+        verify(activeVersionResolver).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldRefuseAWindowThatNeverOpens() {
+        LocalDateTime instant = LocalDateTime.of(2026, 6, 1, 0, 0);
+
+        assertThrows(BizException.class, () -> service.updateValidity(DOC_ID, instant, instant));
+        verify(documentMapper, never()).update(any(), any());
+    }
+
+    @Test
+    void shouldRefuseGovernanceOperationsInsideTheTrash() {
+        Document document = given(document(PublishStatus.DRAFT));
+        document.setTrashed(1);
+
+        assertThrows(BizException.class, () -> service.submitReview(DOC_ID));
+        assertThrows(BizException.class, () -> service.updateValidity(DOC_ID, null, null));
+    }
+
+    @Test
+    void shouldMoveADocumentIntoTheTrash() {
+        Document document = given(document(PublishStatus.PUBLISHED));
+
+        service.trash(DOC_ID);
+
+        assertEquals(1, document.getTrashed());
+        assertNotNull(document.getTrashedAt());
+        verify(documentMapper).updateById(document);
+        verify(activeVersionResolver).invalidate(KB_ID);
+        // The trash keeps chunks, versions and engine copies; only the purge may destroy them.
+        verify(documentService, never()).delete(any());
+    }
+
+    @Test
+    void shouldRefuseToTrashADocumentTwice() {
+        Document document = given(document(PublishStatus.PUBLISHED));
+        document.setTrashed(1);
+
+        assertThrows(BizException.class, () -> service.trash(DOC_ID));
+    }
+
+    @Test
+    void shouldRestoreATrashedDocument() {
+        Document document = given(document(PublishStatus.PUBLISHED));
+        document.setTrashed(1);
+        document.setTrashedAt(LocalDateTime.now());
+        AtomicReference<String> sqlSet = captureUpdateSqlSet();
+
+        Document updated = service.restore(DOC_ID);
+
+        assertEquals(0, updated.getTrashed());
+        assertNull(updated.getTrashedAt());
+        // The timestamp must be written as null or the purge pass would still see the old one.
+        assertTrue(sqlSet.get().contains("trashed_at"));
+        verify(activeVersionResolver).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldRefuseToRestoreADocumentThatIsNotTrashed() {
+        given(document(PublishStatus.PUBLISHED));
+
+        assertThrows(BizException.class, () -> service.restore(DOC_ID));
+    }
+
+    @Test
+    void shouldPurgeOnlyFromInsideTheTrash() {
+        given(document(PublishStatus.PUBLISHED));
+
+        assertThrows(BizException.class, () -> service.purge(DOC_ID));
+        verify(documentService, never()).delete(any());
+    }
+
+    @Test
+    void shouldPurgeThroughTheHardDeleteChain() {
+        Document document = given(document(PublishStatus.PUBLISHED));
+        document.setTrashed(1);
+
+        service.purge(DOC_ID);
+
+        verify(documentService).delete(DOC_ID);
+        verify(activeVersionResolver).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldFlipTheReviewSwitchOfAKnowledgeBase() {
+        KnowledgeBase knowledgeBase = new KnowledgeBase();
+        knowledgeBase.setKbId(KB_ID);
+        when(knowledgeBaseService.require(KB_ID)).thenReturn(knowledgeBase);
+
+        KnowledgeBase updated = service.updateGovernance(KB_ID, true);
+
+        assertEquals(1, updated.getReviewRequired());
+        verify(knowledgeBaseMapper).updateById(knowledgeBase);
+    }
+
+    @Test
+    void shouldPurgeExpiredTrashInBatches() {
+        properties.getGovernance().setTrashPurgeBatchSize(2);
+        when(documentMapper.selectList(any()))
+                .thenReturn(List.of(trashedDocument(DOC_ID), trashedDocument(OTHER_DOC_ID)))
+                .thenReturn(List.of());
+
+        assertEquals(2, service.purgeExpired());
+
+        verify(documentService).delete(DOC_ID);
+        verify(documentService).delete(OTHER_DOC_ID);
+        verify(activeVersionResolver, times(2)).invalidate(KB_ID);
+    }
+
+    @Test
+    void shouldContinuePastOneFailingDocument() {
+        when(documentMapper.selectList(any()))
+                .thenReturn(List.of(trashedDocument(DOC_ID), trashedDocument(OTHER_DOC_ID)))
+                .thenReturn(List.of());
+        doThrow(new IllegalStateException("engine down")).when(documentService).delete(DOC_ID);
+
+        assertEquals(1, service.purgeExpired());
+
+        verify(documentService).delete(OTHER_DOC_ID);
+    }
+
+    @Test
+    void shouldStopWhenAWholeBatchFails() {
+        // Purging deletes the rows it selected; if none were deleted the next iteration would reselect
+        // and refail the same rows forever.
+        when(documentMapper.selectList(any())).thenReturn(List.of(trashedDocument(DOC_ID)));
+        doThrow(new IllegalStateException("engine down")).when(documentService).delete(DOC_ID);
+
+        assertEquals(0, service.purgeExpired());
+
+        verify(documentMapper, times(1)).selectList(any());
+    }
+
+    @Test
+    void shouldSkipTheScheduledPassWhenDisabled() {
+        properties.getGovernance().setTrashPurgeEnabled(false);
+
+        service.scheduledPurge();
+
+        verify(documentMapper, never()).selectList(any());
+    }
+
+    @Test
+    void shouldSwallowAFailureOfTheScheduledPass() {
+        when(documentMapper.selectList(any())).thenThrow(new IllegalStateException("db down"));
+
+        assertDoesNotThrow(() -> service.scheduledPurge());
+    }
+
+    private Document given(Document document) {
+        when(documentService.require(DOC_ID)).thenReturn(document);
+        return document;
+    }
+
+    private Document document(PublishStatus status) {
+        Document document = new Document();
+        document.setId(1L);
+        document.setDocId(DOC_ID);
+        document.setKbId(KB_ID);
+        document.setPublishStatus(status);
+        document.setTrashed(0);
+        return document;
+    }
+
+    private Document trashedDocument(String docId) {
+        Document document = new Document();
+        document.setDocId(docId);
+        document.setKbId(KB_ID);
+        document.setTrashed(1);
+        document.setTrashedAt(LocalDateTime.now().minusDays(60));
+        return document;
+    }
+
+    /**
+     * Records the SET clause of the next wrapper based update, the only place a null write is visible.
+     */
+    private AtomicReference<String> captureUpdateSqlSet() {
+        AtomicReference<String> sqlSet = new AtomicReference<>();
+        when(documentMapper.update(any(), any())).thenAnswer(invocation -> {
+            com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper<Document> wrapper =
+                    invocation.getArgument(1);
+            sqlSet.set(wrapper.getSqlSet());
+            return 1;
+        });
+        return sqlSet;
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/index/ActiveVersionResolverTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/index/ActiveVersionResolverTest.java
@@ -1,5 +1,6 @@
 package io.kbrag.app.index;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import io.kbrag.app.support.MybatisLambdaCache;
 import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.entity.Document;
@@ -9,10 +10,12 @@ import io.kbrag.domain.mapper.DocumentVersionMapper;
 import io.kbrag.domain.enums.ProcessStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -104,6 +107,26 @@ class ActiveVersionResolverTest {
         // The invalidation is wired into the activation rather than left to the caller, so no activation path
         // can forget it.
         assertEquals(List.of(SECOND_VERSION), resolver.activeVersionIds(KB_ID));
+    }
+
+    @Test
+    void shouldFilterTheSetThroughTheGovernanceGate() {
+        // The resolver is the single place governance takes effect: the trash flag, the review state
+        // and both bounds of the validity window must all be part of the row filter, or a governed
+        // document would keep serving queries.
+        when(documentMapper.selectList(any())).thenReturn(List.of(document(FIRST_VERSION)));
+        resolver.activeVersionIds(KB_ID);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<LambdaQueryWrapper<Document>> captor =
+                ArgumentCaptor.forClass((Class) LambdaQueryWrapper.class);
+        verify(documentMapper).selectList(captor.capture());
+
+        String where = captor.getValue().getSqlSegment();
+        assertTrue(where.contains("trashed"));
+        assertTrue(where.contains("publish_status"));
+        assertTrue(where.contains("effective_at IS NULL OR effective_at <="));
+        assertTrue(where.contains("expires_at IS NULL OR expires_at >"));
     }
 
     private Document document(String currentVersionId) {

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/insight/SearchInsightServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/insight/SearchInsightServiceTest.java
@@ -1,0 +1,200 @@
+package io.kbrag.app.insight;
+
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.SearchInsight;
+import io.kbrag.domain.enums.InsightSource;
+import io.kbrag.domain.mapper.SearchInsightMapper;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.QueryDigestFactory;
+import io.kbrag.domain.service.TextDesensitizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the insight row of the M10 contract section 2.2: one row per searched knowledge base, the
+ * query stored only as masked digest plus normalized hash, and the report derived from the rows
+ * rather than kept as separate counters.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class SearchInsightServiceTest {
+
+    private static final String INSIGHT_ID = "si_1";
+    private static final String KB_A = "kb_a";
+    private static final String KB_B = "kb_b";
+
+    private SearchInsightMapper searchInsightMapper;
+    private KbProperties properties;
+    private SearchInsightService service;
+
+    @BeforeEach
+    void setUp() {
+        searchInsightMapper = mock(SearchInsightMapper.class);
+        BizIdGenerator bizIdGenerator = mock(BizIdGenerator.class);
+        when(bizIdGenerator.searchInsightId()).thenReturn(INSIGHT_ID);
+        properties = new KbProperties();
+        service = new SearchInsightService(searchInsightMapper,
+                new QueryDigestFactory(new TextDesensitizer()), bizIdGenerator, properties);
+    }
+
+    @Test
+    void shouldWriteOneRowPerSearchedKnowledgeBase() {
+        List<SearchInsight> rows = service.record(SearchInsightService.InsightRecord.builder()
+                .source(InsightSource.OPEN_API)
+                .kbIds(List.of(KB_A, KB_B))
+                .query("产品报价")
+                .resultCount(3)
+                .topScore(0.87d)
+                .requestId("req_1")
+                .build());
+
+        verify(searchInsightMapper, times(2)).insert(any(SearchInsight.class));
+        assertEquals(2, rows.size());
+        assertEquals(KB_A, rows.get(0).getKbId());
+        assertEquals(KB_B, rows.get(1).getKbId());
+        // The sibling rows describe the same call, which the shared request id makes visible.
+        assertEquals("req_1", rows.get(0).getRequestId());
+        assertEquals("req_1", rows.get(1).getRequestId());
+        assertEquals(rows.get(0).getQueryHash(), rows.get(1).getQueryHash());
+    }
+
+    @Test
+    void shouldMaskTheQueryAndDeriveZeroHitBeforeStoring() {
+        service.record(SearchInsightService.InsightRecord.builder()
+                .source(InsightSource.CONSOLE)
+                .kbIds(List.of(KB_A))
+                .query("电话 13812345678 的保单")
+                .resultCount(0)
+                .degraded(List.of("rerank_timeout"))
+                .build());
+
+        SearchInsight stored = captured();
+        assertFalse(stored.getQueryDigest().contains("13812345678"));
+        assertTrue(stored.getQueryDigest().contains("138****5678"));
+        assertEquals(service.queryHashOf("电话 13812345678 的保单"), stored.getQueryHash());
+        // zero_hit is derived, never supplied: the one fact it encodes is result_count == 0.
+        assertTrue(stored.getZeroHit());
+        assertNull(stored.getTopScore());
+        assertEquals(JsonUtil.toJson(List.of("rerank_timeout")), stored.getDegraded());
+        assertEquals(InsightSource.CONSOLE, stored.getSource());
+    }
+
+    @Test
+    void shouldTreatCaseAndSpacingAsTheSameQueryAndNothingElse() {
+        assertEquals(service.queryHashOf("How  To Reset"), service.queryHashOf(" how to reset "));
+        assertEquals(service.queryHashOf(null), service.queryHashOf("  "));
+        // Word boundaries carry meaning, so removing a space is a different query.
+        assertNotEquals(service.queryHashOf("resetpassword"), service.queryHashOf("reset password"));
+    }
+
+    @Test
+    void shouldShortCircuitWhenRecordingIsDisabledOrNothingWasSearched() {
+        properties.getInsight().setEnabled(false);
+        assertTrue(service.record(SearchInsightService.InsightRecord.builder()
+                .source(InsightSource.CONSOLE)
+                .kbIds(List.of(KB_A))
+                .query("q")
+                .resultCount(1)
+                .build()).isEmpty());
+
+        properties.getInsight().setEnabled(true);
+        assertTrue(service.record(SearchInsightService.InsightRecord.builder()
+                .source(InsightSource.OPEN_API)
+                .kbIds(List.of())
+                .query("q")
+                .resultCount(1)
+                .build()).isEmpty());
+
+        verify(searchInsightMapper, never()).insert(any(SearchInsight.class));
+    }
+
+    @Test
+    void shouldAggregateTheReportAndShowTheNewestDigestOfEachGroup() {
+        // Rows arrive oldest first, exactly the order the service requests.
+        when(searchInsightMapper.selectList(any())).thenReturn(List.of(
+                zeroHitRow("h1", "old digest", LocalDateTime.of(2026, 7, 1, 10, 0)),
+                zeroHitRow("h1", "mid digest", LocalDateTime.of(2026, 7, 2, 10, 0)),
+                hitRow(JsonUtil.toJson(List.of("rerank_timeout"))),
+                zeroHitRow("h2", "other digest", LocalDateTime.of(2026, 7, 3, 10, 0)),
+                zeroHitRow("h1", "new digest", LocalDateTime.of(2026, 7, 4, 10, 0))));
+
+        SearchInsightService.InsightStats stats = service.stats(KB_A, null, null);
+
+        assertEquals(5L, stats.total());
+        assertEquals(4L, stats.zeroHitCount());
+        assertEquals(0.8d, stats.zeroHitRate(), 1e-9d);
+        assertEquals(1L, stats.degradedCount());
+        assertEquals(2, stats.topZeroHitQueries().size());
+        SearchInsightService.TopZeroHitQuery top = stats.topZeroHitQueries().get(0);
+        assertEquals(3L, top.count());
+        // The digest shown is the one of the newest row of the group, so the report reads current.
+        assertEquals("new digest", top.queryDigest());
+        assertEquals(LocalDateTime.of(2026, 7, 4, 10, 0), top.lastAt());
+        assertEquals(1L, stats.topZeroHitQueries().get(1).count());
+    }
+
+    @Test
+    void shouldReportZeroTotalsForAnEmptyWindow() {
+        when(searchInsightMapper.selectList(any())).thenReturn(List.of());
+
+        SearchInsightService.InsightStats stats = service.stats(KB_A, null, null);
+
+        assertEquals(0L, stats.total());
+        assertEquals(0.0d, stats.zeroHitRate(), 1e-9d);
+        assertTrue(stats.topZeroHitQueries().isEmpty());
+    }
+
+    @Test
+    void shouldPurgeInBoundedBatchesUntilTheBatchComesBackShort() {
+        properties.getInsight().setCleanupBatchSize(2);
+        when(searchInsightMapper.purgeExpired(any(LocalDateTime.class), anyInt()))
+                .thenReturn(2, 2, 1);
+
+        assertEquals(5, service.purgeExpired());
+
+        verify(searchInsightMapper, times(3)).purgeExpired(any(LocalDateTime.class), anyInt());
+    }
+
+    private SearchInsight zeroHitRow(String hash, String digest, LocalDateTime createdAt) {
+        SearchInsight row = new SearchInsight();
+        row.setQueryHash(hash);
+        row.setQueryDigest(digest);
+        row.setZeroHit(true);
+        row.setResultCount(0);
+        row.setCreatedAt(createdAt);
+        return row;
+    }
+
+    private SearchInsight hitRow(String degraded) {
+        SearchInsight row = new SearchInsight();
+        row.setQueryHash("hit");
+        row.setZeroHit(false);
+        row.setResultCount(5);
+        row.setDegraded(degraded);
+        return row;
+    }
+
+    private SearchInsight captured() {
+        ArgumentCaptor<SearchInsight> captor = ArgumentCaptor.forClass(SearchInsight.class);
+        verify(searchInsightMapper).insert(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/metrics/KbMetricsTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/metrics/KbMetricsTest.java
@@ -1,0 +1,103 @@
+package io.kbrag.app.metrics;
+
+import io.kbrag.domain.enums.InsightSource;
+import io.kbrag.domain.enums.TaskType;
+import io.kbrag.domain.enums.WebSourceFetchStatus;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the metrics facade of the M13 contract section 3.1: every record method must land in the
+ * registry under the exact name and bounded tag values, the two search booleans must map from the
+ * caller's raw facts, and a {@code null} enum must drop the sample instead of throwing - the one
+ * defensive promise that keeps recording off the business failure path.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class KbMetricsTest {
+
+    private SimpleMeterRegistry registry;
+    private KbMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        metrics = new KbMetrics(registry);
+    }
+
+    @Test
+    void shouldTimeASearchUnderItsBoundaryAndOutcomeTags() {
+        metrics.recordSearch(InsightSource.CONSOLE, 120, 3, null);
+
+        assertEquals(1, registry.get(KbMetrics.SEARCH)
+                .tag(KbMetrics.TAG_SOURCE, "console")
+                .tag(KbMetrics.TAG_ZERO_HIT, "false")
+                .tag(KbMetrics.TAG_DEGRADED, "false")
+                .timer().count());
+        assertEquals(120, registry.get(KbMetrics.SEARCH).timer().totalTime(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void shouldMapAnEmptyResultAndADegradationMarkerOntoTheBooleanTags() {
+        metrics.recordSearch(InsightSource.OPEN_API, 5, 0, List.of("VECTOR_UNAVAILABLE"));
+
+        assertEquals(1, registry.get(KbMetrics.SEARCH)
+                .tag(KbMetrics.TAG_SOURCE, "open_api")
+                .tag(KbMetrics.TAG_ZERO_HIT, "true")
+                .tag(KbMetrics.TAG_DEGRADED, "true")
+                .timer().count());
+    }
+
+    @Test
+    void shouldCountATaskCompletionUnderItsTypeAndStatus() {
+        metrics.recordTaskCompleted(TaskType.INDEX, true);
+        metrics.recordTaskCompleted(TaskType.PARSE, false);
+
+        assertEquals(1, registry.get(KbMetrics.TASK_COMPLETED)
+                .tag(KbMetrics.TAG_TYPE, "index")
+                .tag(KbMetrics.TAG_STATUS, KbMetrics.STATUS_SUCCESS)
+                .counter().count());
+        assertEquals(1, registry.get(KbMetrics.TASK_COMPLETED)
+                .tag(KbMetrics.TAG_TYPE, "parse")
+                .tag(KbMetrics.TAG_STATUS, KbMetrics.STATUS_FAILED)
+                .counter().count());
+    }
+
+    @Test
+    void shouldCountAnOpenApiRejectionUnderItsErrorCode() {
+        metrics.recordOpenApiRejected("INVALID_API_KEY");
+        metrics.recordOpenApiRejected("INVALID_API_KEY");
+
+        assertEquals(2, registry.get(KbMetrics.OPENAPI_REJECTED)
+                .tag(KbMetrics.TAG_ERROR_CODE, "INVALID_API_KEY")
+                .counter().count());
+    }
+
+    @Test
+    void shouldCountAWebSourceSyncUnderItsLowerCasedState() {
+        metrics.recordWebSourceSync(WebSourceFetchStatus.UNCHANGED);
+
+        assertEquals(1, registry.get(KbMetrics.WEBSOURCE_SYNC)
+                .tag(KbMetrics.TAG_STATUS, "unchanged")
+                .counter().count());
+    }
+
+    @Test
+    void shouldDropTheSampleInsteadOfThrowingOnANullInput() {
+        assertDoesNotThrow(() -> metrics.recordSearch(null, 10, 1, null));
+        assertDoesNotThrow(() -> metrics.recordTaskCompleted(null, true));
+        assertDoesNotThrow(() -> metrics.recordOpenApiRejected(null));
+        assertDoesNotThrow(() -> metrics.recordOpenApiRejected(" "));
+        assertDoesNotThrow(() -> metrics.recordWebSourceSync(null));
+
+        assertTrue(registry.getMeters().isEmpty());
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/metrics/TaskBacklogMetricsTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/metrics/TaskBacklogMetricsTest.java
@@ -1,0 +1,66 @@
+package io.kbrag.app.metrics;
+
+import io.kbrag.app.support.MybatisLambdaCache;
+import io.kbrag.domain.entity.KbTask;
+import io.kbrag.domain.enums.TaskStatus;
+import io.kbrag.domain.mapper.KbTaskMapper;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the backlog gauges of the M13 contract section 3.2: the two outstanding states must be
+ * registered and answer with the live row count on read, and a database that cannot answer must
+ * turn into {@code NaN} - never into an exception that would take the scrape down with it.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class TaskBacklogMetricsTest {
+
+    private KbTaskMapper kbTaskMapper;
+    private SimpleMeterRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        MybatisLambdaCache.register(KbTask.class);
+        kbTaskMapper = mock(KbTaskMapper.class);
+        registry = new SimpleMeterRegistry();
+        new TaskBacklogMetrics(registry, kbTaskMapper);
+    }
+
+    @Test
+    void shouldRegisterOneGaugePerOutstandingStateAndReadTheLiveCount() {
+        when(kbTaskMapper.selectCount(any())).thenReturn(7L);
+
+        assertEquals(2, registry.get(TaskBacklogMetrics.TASK_BACKLOG).gauges().size());
+        assertEquals(7, gauge(TaskStatus.PENDING).value());
+        assertEquals(7, gauge(TaskStatus.RUNNING).value());
+    }
+
+    @Test
+    void shouldTreatANullCountAsZero() {
+        when(kbTaskMapper.selectCount(any())).thenReturn(null);
+
+        assertEquals(0, gauge(TaskStatus.PENDING).value());
+    }
+
+    @Test
+    void shouldAnswerNaNInsteadOfFailingTheScrapeWhenTheDatabaseIsDown() {
+        when(kbTaskMapper.selectCount(any())).thenThrow(new IllegalStateException("db down"));
+
+        assertTrue(Double.isNaN(gauge(TaskStatus.PENDING).value()));
+    }
+
+    private Gauge gauge(TaskStatus status) {
+        return registry.get(TaskBacklogMetrics.TASK_BACKLOG)
+                .tag(TaskBacklogMetrics.TAG_STATUS, status.name().toLowerCase())
+                .gauge();
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/openapi/KnowledgeApiServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/openapi/KnowledgeApiServiceTest.java
@@ -2,6 +2,8 @@ package io.kbrag.app.openapi;
 
 import io.kbrag.app.appcenter.AppService;
 import io.kbrag.app.appcenter.AppVersionService;
+import io.kbrag.app.insight.SearchInsightService;
+import io.kbrag.app.metrics.KbMetrics;
 import io.kbrag.app.retrieval.AppliedInfo;
 import io.kbrag.app.retrieval.ImageQueryService;
 import io.kbrag.app.retrieval.RetrievalCommand;
@@ -30,6 +32,7 @@ import io.kbrag.domain.port.VisionProvider;
 import io.kbrag.domain.service.ChatPromptAssembler;
 import io.kbrag.domain.service.ContentBudgetTrimmer;
 import io.kbrag.domain.service.RequestOverridePolicy;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -76,6 +79,7 @@ class KnowledgeApiServiceTest {
     private ChatProvider chatProvider;
     private ApiAuditService apiAuditService;
     private VisionProvider visionProvider;
+    private SimpleMeterRegistry meterRegistry;
     private KnowledgeApiService service;
 
     @BeforeEach
@@ -89,9 +93,11 @@ class KnowledgeApiServiceTest {
         when(appService.require(APP_ID)).thenReturn(new App());
         when(chatProviderFactory.forModel(any())).thenReturn(chatProvider);
         visionProvider = mock(VisionProvider.class);
+        meterRegistry = new SimpleMeterRegistry();
         service = new KnowledgeApiService(appService, appVersionService, retrievalService, chatProviderFactory,
                 new ChatPromptAssembler(), new ContentBudgetTrimmer(), new RequestOverridePolicy(),
-                apiAuditService, new ImageQueryService(visionProvider, new KbProperties()));
+                apiAuditService, mock(SearchInsightService.class),
+                new ImageQueryService(visionProvider, new KbProperties()), new KbMetrics(meterRegistry));
     }
 
     @Test
@@ -109,6 +115,8 @@ class KnowledgeApiServiceTest {
         assertEquals("weighted", issued.getFusionMode());
         assertEquals(Boolean.TRUE, issued.getRerankEnabled());
         assertEquals(Boolean.FALSE, issued.getRewriteEnabled());
+        // The M13 search timer sits on the same insight point every open flow passes.
+        assertEquals(1, meterRegistry.get("kb.search").tag("source", "open_api").timer().count());
     }
 
     @Test

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/websource/WebSourceServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/websource/WebSourceServiceTest.java
@@ -1,0 +1,281 @@
+package io.kbrag.app.websource;
+
+import io.kbrag.app.document.DocumentService;
+import io.kbrag.app.document.UploadOutcome;
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.app.metrics.KbMetrics;
+import io.kbrag.app.support.MybatisLambdaCache;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.common.util.HashUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.WebSource;
+import io.kbrag.domain.enums.WebSourceFetchStatus;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.WebSourceMapper;
+import io.kbrag.domain.port.WebPageFetcher;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.UrlGuard;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the sync state machine of the M12 contract: everything a fetch produces must go through
+ * the one upload chain, an unchanged page must write nothing, a trashed document must stay
+ * untouched, a purged one must be rebuilt and rebound, and no sync failure may ever escape onto
+ * the scheduler thread or the register call.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class WebSourceServiceTest {
+
+    private static final String KB_ID = "kb_1";
+    private static final String SOURCE_ID = "ws_1";
+    private static final String URL = "https://example.com/docs/guide";
+    private static final byte[] BODY = "<html><body>guide</body></html>".getBytes(StandardCharsets.UTF_8);
+
+    private WebSourceMapper webSourceMapper;
+    private DocumentMapper documentMapper;
+    private DocumentService documentService;
+    private KnowledgeBaseService knowledgeBaseService;
+    private UrlGuard urlGuard;
+    private WebPageFetcher webPageFetcher;
+    private BizIdGenerator bizIdGenerator;
+    private KbProperties properties;
+    private SimpleMeterRegistry meterRegistry;
+    private WebSourceService service;
+
+    @BeforeEach
+    void setUp() {
+        MybatisLambdaCache.register(WebSource.class, Document.class);
+        webSourceMapper = mock(WebSourceMapper.class);
+        documentMapper = mock(DocumentMapper.class);
+        documentService = mock(DocumentService.class);
+        knowledgeBaseService = mock(KnowledgeBaseService.class);
+        urlGuard = mock(UrlGuard.class);
+        webPageFetcher = mock(WebPageFetcher.class);
+        bizIdGenerator = mock(BizIdGenerator.class);
+        properties = new KbProperties();
+        meterRegistry = new SimpleMeterRegistry();
+        service = new WebSourceService(webSourceMapper, documentMapper, documentService,
+                knowledgeBaseService, urlGuard, webPageFetcher, bizIdGenerator, properties,
+                new KbMetrics(meterRegistry));
+        when(urlGuard.validate(anyString())).thenAnswer(invocation ->
+                URI.create(invocation.getArgument(0, String.class)));
+        when(bizIdGenerator.webSourceId()).thenReturn(SOURCE_ID);
+    }
+
+    @Test
+    void shouldRegisterAndRunTheFirstFetchThroughTheUploadChain() {
+        when(webSourceMapper.selectCount(any())).thenReturn(0L);
+        when(webPageFetcher.fetch(URL)).thenReturn(page());
+        when(documentService.upload(eq(KB_ID), anyString(), eq(BODY))).thenReturn(outcome("doc_1"));
+
+        WebSource source = service.register(KB_ID, URL, true);
+
+        verify(webSourceMapper).insert(source);
+        assertEquals(WebSourceFetchStatus.SUCCESS, source.getLastFetchStatus());
+        assertEquals("doc_1", source.getDocId());
+        assertEquals(HashUtil.sha256Hex(BODY), source.getLastContentHash());
+        // The derived name is host plus path slug plus a hash prefix, under the upload extension.
+        assertTrue(source.getFileName().startsWith("example.com-docs-guide-"));
+        assertTrue(source.getFileName().endsWith(".html"));
+        assertNull(source.getLastError());
+        // The M13 sync counter rides the same record funnel, so a success must show up there too.
+        assertEquals(1, meterRegistry.get("kb.websource.sync").tag("status", "success").counter().count());
+    }
+
+    @Test
+    void shouldRejectADuplicateUrlWithinTheSameKnowledgeBase() {
+        when(webSourceMapper.selectCount(any())).thenReturn(1L);
+
+        assertThrows(BizException.class, () -> service.register(KB_ID, URL, true));
+        verify(webSourceMapper, never()).insert(any(WebSource.class));
+    }
+
+    @Test
+    void shouldKeepTheRegistrationWhenTheFirstFetchFails() {
+        // The operator registered the page, not the luck of this minute: the row must survive and
+        // carry the failure for them to read.
+        when(webSourceMapper.selectCount(any())).thenReturn(0L);
+        when(webPageFetcher.fetch(URL)).thenThrow(new IllegalStateException("connection refused"));
+
+        WebSource source = assertDoesNotThrow(() -> service.register(KB_ID, URL, true));
+
+        verify(webSourceMapper).insert(source);
+        assertEquals(WebSourceFetchStatus.FAILED, source.getLastFetchStatus());
+        assertEquals("connection refused", source.getLastError());
+        verify(documentService, never()).upload(any(), any(), any());
+    }
+
+    @Test
+    void shouldWriteNothingWhenThePageIsUnchanged() {
+        WebSource source = boundSource();
+        source.setLastContentHash(HashUtil.sha256Hex(BODY));
+        when(webPageFetcher.fetch(URL)).thenReturn(page());
+
+        service.sync(source);
+
+        assertEquals(WebSourceFetchStatus.UNCHANGED, source.getLastFetchStatus());
+        assertNull(source.getLastError());
+        verify(documentService, never()).upload(any(), any(), any());
+        verify(webSourceMapper).updateById(source);
+    }
+
+    @Test
+    void shouldSkipWhileTheBoundDocumentSitsInTheTrash() {
+        // Feeding a version into a trashed document would silently resurrect removed content.
+        WebSource source = boundSource();
+        when(webPageFetcher.fetch(URL)).thenReturn(page());
+        when(documentMapper.selectOne(any())).thenReturn(trashedDocument());
+
+        service.sync(source);
+
+        assertEquals(WebSourceFetchStatus.SKIPPED, source.getLastFetchStatus());
+        assertNotNull(source.getLastError());
+        verify(documentService, never()).upload(any(), any(), any());
+    }
+
+    @Test
+    void shouldRebindAfterAPurgeRemovedTheDocument() {
+        // The purge broke the binding; the next sync recreates the document under the same stable
+        // file name and the registration follows it.
+        WebSource source = boundSource();
+        when(webPageFetcher.fetch(URL)).thenReturn(page());
+        when(documentMapper.selectOne(any())).thenReturn(null);
+        when(documentService.upload(KB_ID, source.getFileName(), BODY)).thenReturn(outcome("doc_new"));
+
+        service.sync(source);
+
+        assertEquals(WebSourceFetchStatus.SUCCESS, source.getLastFetchStatus());
+        assertEquals("doc_new", source.getDocId());
+        verify(documentService).upload(KB_ID, "example.com-docs-guide-abcd1234.html", BODY);
+    }
+
+    @Test
+    void shouldRecordAFailureTruncatedAndNeverRethrow() {
+        WebSource source = boundSource();
+        when(webPageFetcher.fetch(URL)).thenThrow(new IllegalStateException("x".repeat(600)));
+
+        assertDoesNotThrow(() -> service.sync(source));
+
+        assertEquals(WebSourceFetchStatus.FAILED, source.getLastFetchStatus());
+        // The cause must fit the 512 char column instead of failing the status write itself.
+        assertEquals(512, source.getLastError().length());
+        verify(webSourceMapper).updateById(source);
+    }
+
+    @Test
+    void shouldSkipTheScheduledPassWhenDisabled() {
+        properties.getWebImport().setSyncEnabled(false);
+
+        service.scheduledSync();
+
+        verify(webSourceMapper, never()).selectList(any());
+    }
+
+    @Test
+    void shouldSyncOneBoundedBatchAndContinuePastAFailingSource() {
+        properties.getWebImport().setSyncBatchSize(2);
+        WebSource failing = boundSource();
+        WebSource healthy = boundSource();
+        healthy.setSourceId("ws_2");
+        healthy.setUrl(URL + "/second");
+        when(webSourceMapper.selectList(any())).thenReturn(List.of(failing, healthy));
+        when(webPageFetcher.fetch(URL)).thenThrow(new IllegalStateException("down"));
+        when(webPageFetcher.fetch(URL + "/second")).thenReturn(page());
+        when(documentMapper.selectOne(any())).thenReturn(null);
+        when(documentService.upload(any(), any(), any())).thenReturn(outcome("doc_2"));
+
+        assertEquals(2, service.syncEnabledSources());
+
+        assertEquals(WebSourceFetchStatus.FAILED, failing.getLastFetchStatus());
+        assertEquals(WebSourceFetchStatus.SUCCESS, healthy.getLastFetchStatus());
+    }
+
+    @Test
+    void shouldSwallowAFailureOfTheScheduledPass() {
+        when(webSourceMapper.selectList(any())).thenThrow(new IllegalStateException("db down"));
+
+        assertDoesNotThrow(() -> service.scheduledSync());
+    }
+
+    @Test
+    void shouldRemoveTheRegistrationPhysically() {
+        // A soft delete would hold uk_kb_url hostage and make the URL unregisterable forever.
+        WebSource source = boundSource();
+        source.setId(7L);
+        when(webSourceMapper.selectOne(any())).thenReturn(source);
+
+        service.remove(SOURCE_ID);
+
+        verify(webSourceMapper).hardDeleteById(7L);
+        verify(webSourceMapper, never()).deleteById(any(Long.class));
+    }
+
+    @Test
+    void shouldDeriveAStableBoundedFileName() {
+        String urlHash = HashUtil.sha256Hex(URL);
+        String name = WebSourceService.deriveFileName(URI.create(URL), urlHash, "html");
+
+        assertEquals("example.com-docs-guide-" + urlHash.substring(0, 8) + ".html", name);
+        // A root URL keeps just the host.
+        assertTrue(WebSourceService.deriveFileName(URI.create("https://example.com/"), urlHash, "html")
+                .startsWith("example.com-"));
+        // A pathological path is truncated but the disambiguating hash suffix always survives.
+        String longName = WebSourceService.deriveFileName(
+                URI.create("https://example.com/" + "a/".repeat(300)), urlHash, "html");
+        assertEquals(200, longName.length());
+        assertTrue(longName.endsWith("-" + urlHash.substring(0, 8) + ".html"));
+    }
+
+    private WebSource boundSource() {
+        WebSource source = new WebSource();
+        source.setSourceId(SOURCE_ID);
+        source.setKbId(KB_ID);
+        source.setUrl(URL);
+        source.setUrlHash(HashUtil.sha256Hex(URL));
+        source.setDocId("doc_1");
+        source.setFileName("example.com-docs-guide-abcd1234.html");
+        source.setSyncEnabled(1);
+        return source;
+    }
+
+    private Document trashedDocument() {
+        Document document = new Document();
+        document.setDocId("doc_1");
+        document.setKbId(KB_ID);
+        document.setTrashed(1);
+        return document;
+    }
+
+    private WebPageFetcher.FetchedPage page() {
+        return new WebPageFetcher.FetchedPage(BODY, "html");
+    }
+
+    private UploadOutcome outcome(String docId) {
+        Document document = new Document();
+        document.setDocId(docId);
+        document.setKbId(KB_ID);
+        return new UploadOutcome(document, "dv_1", "v1", false, null);
+    }
+}

--- a/kb-rag-server/kb-common/src/main/java/io/kbrag/common/constant/KbConstants.java
+++ b/kb-rag-server/kb-common/src/main/java/io/kbrag/common/constant/KbConstants.java
@@ -64,6 +64,15 @@ public final class KbConstants {
     /** Business id prefix of a chat import mapping profile row. */
     public static final String SOURCE_MAPPING_ID_PREFIX = "smp";
 
+    /** Business id prefix of a retrieval feedback row. */
+    public static final String RETRIEVAL_FEEDBACK_ID_PREFIX = "rfb";
+
+    /** Business id prefix of a search insight row. */
+    public static final String SEARCH_INSIGHT_ID_PREFIX = "si";
+
+    /** Business id prefix of a registered web source row. */
+    public static final String WEB_SOURCE_ID_PREFIX = "ws";
+
     /**
      * Fixed prefix of every open API key plaintext, requirement section 4.8 "kb-sk-{prefix}{random}".
      *

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
@@ -96,8 +96,68 @@ public class KbProperties {
     /** Open API policy: rate limit default, audit retention and archiving. */
     private OpenApi openApi = new OpenApi();
 
+    /** Search insight policy: recording switch and retention, the M10 contract section 2.3. */
+    private Insight insight = new Insight();
+
     /** Application release policy: index snapshot timeout and retention. */
     private App app = new App();
+
+    /** Content governance policy: recycle bin retention, the M11 contract section 2.3. */
+    private Governance governance = new Governance();
+
+    /** URL import policy: fetch limits and the scheduled sync pass, the M12 contract section 3.5. */
+    private WebImport webImport = new WebImport();
+
+    /**
+     * Content governance policy, the M11 contract section 2.3.
+     */
+    @Getter
+    @Setter
+    @ToString
+    public static class Governance {
+
+        /** Days a trashed document stays restorable before the purge pass removes it for good. */
+        private int trashRetentionDays = 30;
+
+        /**
+         * Documents one purge batch removes. A purge clears chunks and both engine copies per document,
+         * so the bound is a document count, much smaller than the row-count bounds of the log cleanups.
+         */
+        private int trashPurgeBatchSize = 100;
+
+        /** Cron expression of the daily purge pass. */
+        private String trashPurgeCron = "0 10 4 * * *";
+
+        /** {@code false} disables the purge pass; trashed documents then stay restorable forever. */
+        private boolean trashPurgeEnabled = true;
+    }
+
+    /**
+     * URL import policy, the M12 contract section 3.5.
+     */
+    @Getter
+    @Setter
+    @ToString
+    public static class WebImport {
+
+        /** Connect and read timeout of one page fetch. */
+        private int fetchTimeoutMs = 10000;
+
+        /** Largest page body accepted, counted while streaming - Content-Length is not trusted. */
+        private int maxPageSizeMb = 10;
+
+        /** Redirect hops the fetcher follows manually, re-validating each target against SSRF. */
+        private int maxRedirects = 3;
+
+        /** Cron expression of the nightly incremental sync pass. */
+        private String syncCron = "0 30 2 * * *";
+
+        /** {@code false} disables the scheduled pass; manual sync stays available. */
+        private boolean syncEnabled = true;
+
+        /** Sources one scheduled pass re-fetches; fetching is slow outbound I/O, hence a count bound. */
+        private int syncBatchSize = 50;
+    }
 
     /**
      * Application release policy, requirement section 4.7 "index snapshot".
@@ -769,6 +829,16 @@ public class KbProperties {
         private int extractConcurrency = 2;
 
         /**
+         * Generation budget of one extraction call.
+         *
+         * <p>Separate from {@code kb.chat.max-tokens} because that one sizes a single line query rewrite:
+         * an extraction answer is a JSON object holding every entity and relation of the passage, and a
+         * budget that runs out mid object yields truncated JSON the parser can only reject - the chunk is
+         * then silently counted as skipped. A table heavy passage routinely needs several hundred tokens.
+         */
+        private int extractMaxTokens = 2048;
+
+        /**
          * Tells whether the deployment runs a graph at all.
          *
          * @return {@code true} when a Bolt URI is configured
@@ -874,5 +944,32 @@ public class KbProperties {
 
         /** Width of the {@code query_digest} column; the digest is truncated to it after masking. */
         private int queryDigestMaxLength = 200;
+    }
+
+    /**
+     * Search insight policy, the M10 contract section 2.3.
+     */
+    @Getter
+    @Setter
+    @ToString
+    public static class Insight {
+
+        /**
+         * {@code false} short circuits the recording points entirely; the report endpoints still
+         * serve whatever history exists. Used by tests and deployments that do not want the table.
+         */
+        private boolean enabled = true;
+
+        /** Days an insight row stays before the cleanup removes it. Never archived, unlike audit. */
+        private int retentionDays = 90;
+
+        /**
+         * Rows one cleanup batch deletes. Bounded so a retention pass never holds a long transaction
+         * over a table the request path keeps inserting into.
+         */
+        private int cleanupBatchSize = 5000;
+
+        /** Cron expression of the daily cleanup pass. */
+        private String cleanupCron = "0 45 3 * * *";
     }
 }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/Document.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/Document.java
@@ -3,9 +3,12 @@ package io.kbrag.domain.entity;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableName;
 import io.kbrag.domain.enums.ProcessStatus;
+import io.kbrag.domain.enums.PublishStatus;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 /**
  * Document master record. Holds the pointer to the currently active version.
@@ -47,6 +50,30 @@ public class Document extends BaseEntity {
     /** Single valued processing state. */
     @TableField("process_status")
     private ProcessStatus processStatus;
+
+    /** Editorial state, orthogonal to the processing state (M11 governance). */
+    @TableField("publish_status")
+    private PublishStatus publishStatus;
+
+    /** Latest rejection reason, cleared on approval. */
+    @TableField("review_note")
+    private String reviewNote;
+
+    /** Instant the document becomes retrievable, {@code null} for no lower bound. */
+    @TableField("effective_at")
+    private LocalDateTime effectiveAt;
+
+    /** Instant the document stops being retrievable, {@code null} for no upper bound. */
+    @TableField("expires_at")
+    private LocalDateTime expiresAt;
+
+    /** {@code 1} while the document sits in the recycle bin, out of retrieval but restorable. */
+    @TableField("trashed")
+    private Integer trashed;
+
+    /** When the document entered the recycle bin, drives the retention purge. */
+    @TableField("trashed_at")
+    private LocalDateTime trashedAt;
 
     /** Set when the knowledge base configuration fingerprint no longer matches the active version. */
     @TableField("config_stale")

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/KnowledgeBase.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/KnowledgeBase.java
@@ -42,4 +42,8 @@ public class KnowledgeBase extends BaseEntity {
     /** Knowledge base level retrieval defaults serialised as JSON, overridden by request parameters. */
     @TableField("retrieval_config")
     private String retrievalConfig;
+
+    /** {@code 1} makes a freshly created document start as DRAFT instead of PUBLISHED (M11 governance). */
+    @TableField("review_required")
+    private Integer reviewRequired;
 }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/RetrievalFeedback.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/RetrievalFeedback.java
@@ -1,0 +1,67 @@
+package io.kbrag.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.kbrag.domain.enums.FeedbackStatus;
+import io.kbrag.domain.enums.FeedbackVerdict;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * One good/bad verdict on a debug page retrieval result, requirement section 4.5 "distilled into
+ * evaluation material".
+ *
+ * <p>{@link #query} is stored raw, unlike the insight digest: converting this row into an evaluation
+ * case replays the exact query, and a masked copy would create a case that never actually ran.
+ *
+ * <p>{@link #docId} is resolved server side from the chunk and may be {@code null}: feedback can
+ * arrive after the chunk was deleted, and rejecting it then would lose the one signal the operator
+ * still wanted recorded.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Setter
+@ToString(callSuper = true, exclude = "query")
+@TableName("t_kb_retrieval_feedback")
+public class RetrievalFeedback extends BaseEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Business identifier exposed by the console. */
+    @TableField("feedback_id")
+    private String feedbackId;
+
+    /** Knowledge base the query ran against. */
+    @TableField("kb_id")
+    private String kbId;
+
+    /** Query the debug page ran, raw, replayed on conversion. */
+    @TableField("query")
+    private String query;
+
+    /** Chunk the verdict concerns. */
+    @TableField("chunk_id")
+    private String chunkId;
+
+    /** Owning document, {@code null} when the chunk was already deleted. */
+    @TableField("doc_id")
+    private String docId;
+
+    /** Operator verdict. */
+    @TableField("verdict")
+    private FeedbackVerdict verdict;
+
+    /** Lifecycle state, {@code NEW} until an operator converts or dismisses the row. */
+    @TableField("status")
+    private FeedbackStatus status;
+
+    /** Evaluation case created from this row, {@code null} until converted. */
+    @TableField("converted_case_id")
+    private String convertedCaseId;
+
+    /** Free form operator note. */
+    @TableField("note")
+    private String note;
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/SearchInsight.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/SearchInsight.java
@@ -1,0 +1,71 @@
+package io.kbrag.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.kbrag.domain.enums.InsightSource;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * One online retrieval as the miss report sees it, the M10 contract section 1.
+ *
+ * <p>Stores a digest and a hash, never the raw query. {@link #queryDigest} is masked by the section
+ * 4.2 rules and truncated - the exact {@code t_kb_api_audit_log} discipline - because an analytics
+ * table kept for 90 days must not become an unmasked copy of what users typed. {@link #queryHash}
+ * is the SHA-256 of the normalized query and exists so equal questions group together without
+ * comparing text: {@code "How To Reset"} and {@code "how  to reset"} are one gap, not two.
+ *
+ * <p>{@link #zeroHit} is derived from {@link #resultCount} at write time. Redundant on purpose: the
+ * report scans this column with an index instead of evaluating {@code result_count = 0} per row.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Setter
+@ToString(callSuper = true)
+@TableName("t_kb_search_insight")
+public class SearchInsight extends BaseEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Business identifier exposed by the console. */
+    @TableField("insight_id")
+    private String insightId;
+
+    /** Knowledge base the retrieval ran against. */
+    @TableField("kb_id")
+    private String kbId;
+
+    /** API boundary the call entered through. */
+    @TableField("source")
+    private InsightSource source;
+
+    /** Masked and truncated query, never the raw text. */
+    @TableField("query_digest")
+    private String queryDigest;
+
+    /** SHA-256 of the normalized query, the grouping key of the miss report. */
+    @TableField("query_hash")
+    private String queryHash;
+
+    /** Nodes the call returned. */
+    @TableField("result_count")
+    private Integer resultCount;
+
+    /** Score of the first node, {@code null} on zero hits. */
+    @TableField("top_score")
+    private Double topScore;
+
+    /** Derived {@code result_count = 0} flag, the column the report scans. */
+    @TableField("zero_hit")
+    private Boolean zeroHit;
+
+    /** JSON array of degradation markers of this call. */
+    @TableField("degraded")
+    private String degraded;
+
+    /** Correlation id, links the row to logs and audit. */
+    @TableField("request_id")
+    private String requestId;
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/WebSource.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/WebSource.java
@@ -1,0 +1,73 @@
+package io.kbrag.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.kbrag.domain.enums.WebSourceFetchStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+/**
+ * A registered web page source, the M12 contract section 1: the binding between a URL and the
+ * document its fetches produce, plus the sync switch and the outcome of the last fetch.
+ *
+ * <p>The binding is deliberately weak. Removing the registration leaves the document alone, and
+ * trashing the document leaves the registration alone - the two lifecycles meet only inside a sync
+ * pass, which reads both sides and decides what one fetch may do.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Setter
+@ToString(callSuper = true)
+@TableName("t_kb_web_source")
+public class WebSource extends BaseEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Business identifier exposed through the API. */
+    @TableField("source_id")
+    private String sourceId;
+
+    /** Knowledge base the fetched pages land in. */
+    @TableField("kb_id")
+    private String kbId;
+
+    /** Registered page address, http or https. */
+    @TableField("url")
+    private String url;
+
+    /** SHA-256 of the URL; the equality key a VARCHAR(2048) column cannot be. */
+    @TableField("url_hash")
+    private String urlHash;
+
+    /** Document the fetches feed, {@code null} until the first successful fetch. */
+    @TableField("doc_id")
+    private String docId;
+
+    /** Derived stable file name the upload chain sees, {@code null} until the first fetch. */
+    @TableField("file_name")
+    private String fileName;
+
+    /** {@code 1} includes the source in the scheduled sync pass. */
+    @TableField("sync_enabled")
+    private Integer syncEnabled;
+
+    /** SHA-256 of the last fetched body, the unchanged check of an incremental sync. */
+    @TableField("last_content_hash")
+    private String lastContentHash;
+
+    /** When the last sync attempt ran, success or not. */
+    @TableField("last_fetch_at")
+    private LocalDateTime lastFetchAt;
+
+    /** Outcome of the last sync attempt. */
+    @TableField("last_fetch_status")
+    private WebSourceFetchStatus lastFetchStatus;
+
+    /** Why the last sync failed or was skipped, {@code null} on success. */
+    @TableField("last_error")
+    private String lastError;
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/CaseSource.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/CaseSource.java
@@ -14,5 +14,8 @@ public enum CaseSource {
     DEBUG_PAGE,
 
     /** Brought in by the demo data set importer. */
-    IMPORTED
+    IMPORTED,
+
+    /** Converted from a persisted retrieval feedback row, the M10 contract section 2.1. */
+    FEEDBACK
 }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/FeedbackStatus.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/FeedbackStatus.java
@@ -1,0 +1,38 @@
+package io.kbrag.domain.enums;
+
+/**
+ * Lifecycle of one feedback row: {@code NEW} is the only state an operator can act on, and both
+ * outcomes are terminal - a converted feedback lives on as its evaluation case, a dismissed one is
+ * kept only so the statistics stay honest.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum FeedbackStatus {
+
+    /** Recorded and waiting for an operator decision. */
+    NEW,
+
+    /** Turned into an evaluation case, terminal. */
+    CONVERTED,
+
+    /** Judged not worth a case, terminal. */
+    DISMISSED;
+
+    /**
+     * Resolves a status from its request literal, case insensitively.
+     *
+     * @param value request literal, {@code null} or blank yields {@code null}
+     * @return matching status, {@code null} when nothing matches
+     */
+    public static FeedbackStatus from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        for (FeedbackStatus status : values()) {
+            if (status.name().equalsIgnoreCase(value.trim())) {
+                return status;
+            }
+        }
+        return null;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/FeedbackVerdict.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/FeedbackVerdict.java
@@ -1,0 +1,33 @@
+package io.kbrag.domain.enums;
+
+/**
+ * Operator verdict on one debug page retrieval result, requirement section 4.5.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum FeedbackVerdict {
+
+    /** The chunk answered the query, candidate evidence for an evaluation case. */
+    GOOD,
+
+    /** The chunk did not answer the query; feeds the miss statistics, never a case. */
+    BAD;
+
+    /**
+     * Resolves a verdict from its request literal, case insensitively.
+     *
+     * @param value request literal, {@code null} or blank yields {@code null}
+     * @return matching verdict, {@code null} when nothing matches
+     */
+    public static FeedbackVerdict from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        for (FeedbackVerdict verdict : values()) {
+            if (verdict.name().equalsIgnoreCase(value.trim())) {
+                return verdict;
+            }
+        }
+        return null;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/InsightSource.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/InsightSource.java
@@ -1,0 +1,19 @@
+package io.kbrag.domain.enums;
+
+/**
+ * API boundary a recorded retrieval entered through.
+ *
+ * <p>Deliberately not "who ran it": evaluation runs and the release gate reuse the same retrieval
+ * pipeline but never pass an API boundary, which is what keeps offline traffic out of the insight
+ * report without a filter column.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum InsightSource {
+
+    /** Console debug page search. */
+    CONSOLE,
+
+    /** Open API search or chat retrieval stage. */
+    OPEN_API
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/PublishStatus.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/PublishStatus.java
@@ -1,0 +1,26 @@
+package io.kbrag.domain.enums;
+
+/**
+ * Editorial state of a document, orthogonal to {@link ProcessStatus}: the pipeline decides whether
+ * the corpus <em>can</em> serve the document, this state decides whether it <em>may</em>.
+ *
+ * <p>Transitions: {@code DRAFT | REJECTED -> PENDING_REVIEW -> PUBLISHED | REJECTED}. PUBLISHED is
+ * terminal - taking a published document out of retrieval is an expiry or a trash operation, not a
+ * review rollback, so the review trail never contradicts what readers already saw.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum PublishStatus {
+
+    /** Uploaded under a review requiring knowledge base, waiting for the author to submit. */
+    DRAFT,
+
+    /** Submitted, waiting for a reviewer's verdict. */
+    PENDING_REVIEW,
+
+    /** Admitted to retrieval. Terminal. Also the implicit state of every document that predates M11. */
+    PUBLISHED,
+
+    /** Turned down with a note; the author may revise and resubmit. */
+    REJECTED
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/WebSourceFetchStatus.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/WebSourceFetchStatus.java
@@ -1,0 +1,25 @@
+package io.kbrag.domain.enums;
+
+/**
+ * Outcome of one sync attempt of a registered web source, the M12 contract section 3.4.
+ *
+ * <p>UNCHANGED and SKIPPED are successes of a kind - the fetch pipeline worked and decided that
+ * writing anything would be wrong - and they are distinct states because the operator reacts
+ * differently to "the page did not change" and "your document sits in the recycle bin".
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum WebSourceFetchStatus {
+
+    /** The page was fetched and fed into the upload chain. */
+    SUCCESS,
+
+    /** The page was fetched but its content hash matches the previous fetch; nothing was written. */
+    UNCHANGED,
+
+    /** The fetch was not attempted or its result discarded, for a reason recorded in last_error. */
+    SKIPPED,
+
+    /** The fetch or the intake failed, for a reason recorded in last_error. */
+    FAILED
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/RetrievalFeedbackMapper.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/RetrievalFeedbackMapper.java
@@ -1,0 +1,14 @@
+package io.kbrag.domain.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.kbrag.domain.entity.RetrievalFeedback;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * Data access for t_kb_retrieval_feedback.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Mapper
+public interface RetrievalFeedbackMapper extends BaseMapper<RetrievalFeedback> {
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/SearchInsightMapper.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/SearchInsightMapper.java
@@ -1,0 +1,36 @@
+package io.kbrag.domain.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.kbrag.domain.entity.SearchInsight;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+
+/**
+ * Data access for t_kb_search_insight.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Mapper
+public interface SearchInsightMapper extends BaseMapper<SearchInsight> {
+
+    /**
+     * Physically removes the rows past the retention window.
+     *
+     * <p>A hand written statement for the same reason as the audit purge: the generated delete honours
+     * the logical delete flag, which would keep every insight row forever while the retention policy
+     * pretends to reclaim space. Unlike the audit trail nothing is archived first - an insight row is a
+     * statistic, not evidence, and the M10 contract keeps it out of object storage on purpose.
+     *
+     * <p>The row limit is the caller's batch size, so one statement never holds a long transaction over
+     * a table the request path keeps inserting into.
+     *
+     * @param before exclusive upper bound of {@code created_at}, the retention horizon
+     * @param limit  maximum rows deleted by this statement
+     * @return deleted row count
+     */
+    @Delete("DELETE FROM t_kb_search_insight WHERE created_at < #{before} LIMIT #{limit}")
+    int purgeExpired(@Param("before") LocalDateTime before, @Param("limit") int limit);
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/WebSourceMapper.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/WebSourceMapper.java
@@ -1,0 +1,27 @@
+package io.kbrag.domain.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.kbrag.domain.entity.WebSource;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * Data access for t_kb_web_source.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Mapper
+public interface WebSourceMapper extends BaseMapper<WebSource> {
+
+    /**
+     * Physically removes one registration row.
+     *
+     * <p>The inherited delete would only flip the {@code deleted} flag, and a soft-deleted row
+     * still occupies {@code uk_kb_url} - re-registering the same URL after a removal would then
+     * hit the unique key forever. Removal of a registration is contractually final (the document
+     * stays, the binding does not), so a hard delete is the correct shape, not a workaround.
+     */
+    @Delete("DELETE FROM t_kb_web_source WHERE id = #{id}")
+    int hardDeleteById(@Param("id") Long id);
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/WebPageFetcher.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/WebPageFetcher.java
@@ -1,0 +1,30 @@
+package io.kbrag.domain.port;
+
+/**
+ * Outbound port of the web page fetcher used by URL import, the M12 contract section 3.3.
+ *
+ * <p>Kept as a port so the sync semantics - unchanged detection, trash skip, rebinding after a
+ * purge - can be unit tested against a canned page instead of a HTTP server, and so the transport
+ * details (redirect policy, size cap, content type whitelist) stay in one infrastructure class.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public interface WebPageFetcher {
+
+    /**
+     * Fetches one page, following a bounded number of redirects with SSRF re-validation per hop.
+     *
+     * @param url address to fetch, already validated once by the caller
+     * @return page body and the file extension its content type maps to
+     */
+    FetchedPage fetch(String url);
+
+    /**
+     * One fetched page.
+     *
+     * @param body      raw response body
+     * @param extension file extension the content type maps to: html, txt or md
+     */
+    record FetchedPage(byte[] body, String extension) {
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/BizIdGenerator.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/BizIdGenerator.java
@@ -172,6 +172,33 @@ public class BizIdGenerator {
         return generate(KbConstants.SOURCE_MAPPING_ID_PREFIX);
     }
 
+    /**
+     * Generates a retrieval feedback row id.
+     *
+     * @return prefixed identifier
+     */
+    public String retrievalFeedbackId() {
+        return generate(KbConstants.RETRIEVAL_FEEDBACK_ID_PREFIX);
+    }
+
+    /**
+     * Generates a search insight row id.
+     *
+     * @return prefixed identifier
+     */
+    public String searchInsightId() {
+        return generate(KbConstants.SEARCH_INSIGHT_ID_PREFIX);
+    }
+
+    /**
+     * Generates a registered web source id.
+     *
+     * @return prefixed identifier
+     */
+    public String webSourceId() {
+        return generate(KbConstants.WEB_SOURCE_ID_PREFIX);
+    }
+
     private String generate(String prefix) {
         String random = UUID.randomUUID().toString().replace("-", "").substring(0, RANDOM_LENGTH);
         return prefix + KbConstants.ID_SEPARATOR + random;

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/GraphExtractionParser.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/GraphExtractionParser.java
@@ -107,8 +107,11 @@ public class GraphExtractionParser {
                 continue;
             }
             if (!entities.containsKey(source) || !entities.containsKey(target)) {
-                log.info("graph extraction answer rejected, reason=relation endpoint outside the entity list");
-                return null;
+                // 丢这一条，不作废整个答案：目标是"图里不长出没有抽取依据的节点"，跳过越界关系即可达成，
+                // 而整体拒绝会让同一段里已经抽对的实体和关系一起陪葬——上面缺 source/target 的分支
+                // 本来就是这么处理的，两者同为"这条关系不可用"，没有理由区别对待。
+                log.info("graph extraction relation dropped, reason=endpoint outside the entity list");
+                continue;
             }
             relations.add(new GraphRelation(source, typeOf(node, DEFAULT_RELATION_TYPE), target));
         }
@@ -129,17 +132,26 @@ public class GraphExtractionParser {
      */
     private JsonNode readObject(String raw) {
         if (raw == null || raw.isBlank()) {
+            log.info("graph extraction answer rejected, reason=empty answer");
             return null;
         }
         int start = raw.indexOf(JSON_OBJECT_START);
         int end = raw.lastIndexOf(JSON_OBJECT_END);
         if (start < 0 || end <= start) {
+            // 最常见的成因是生成预算耗尽把 JSON 截断在半路，此时根本没有收尾的花括号。
+            // 长度一并打出来，便于对照 kb.graph.extract-max-tokens 判断是否又是被截断。
+            log.info("graph extraction answer rejected, reason=no json object boundary, length={}", raw.length());
             return null;
         }
         try {
             JsonNode node = JsonUtil.mapper().readTree(raw.substring(start, end + 1));
-            return node != null && node.isObject() ? node : null;
+            if (node == null || !node.isObject()) {
+                log.info("graph extraction answer rejected, reason=payload is not an object");
+                return null;
+            }
+            return node;
         } catch (Exception e) {
+            log.info("graph extraction answer rejected, reason=malformed json, detail={}", e.getMessage());
             return null;
         }
     }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/UrlGuard.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/UrlGuard.java
@@ -1,0 +1,93 @@
+package io.kbrag.domain.service;
+
+import io.kbrag.common.exception.BizException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * The SSRF gate of URL import, the M12 contract section 3.2.
+ *
+ * <p>URL import is the first place in the system where an outbound request goes to an address a
+ * user typed rather than one an operator configured, so this guard is what keeps "index this page"
+ * from becoming "read the cloud metadata endpoint". Every address the host resolves to has to be
+ * public: a name with one public and one private A record is exactly the classic bypass.
+ *
+ * <p>The fetcher re-runs the guard on every redirect hop and on every sync (the registration may be
+ * days old and DNS may have moved), which is why validation lives in a stateless domain service
+ * both kb-app and the kb-infrastructure fetcher can share.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+public class UrlGuard {
+
+    private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+    /**
+     * Validates one outbound URL, rejecting anything that could reach an internal address.
+     *
+     * @param url address as the user or a redirect supplied it
+     * @return parsed URI, ready for the fetcher
+     */
+    public URI validate(String url) {
+        if (url == null || url.isBlank()) {
+            throw BizException.invalidParam("URL 不能为空");
+        }
+        URI uri = parse(url.trim());
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!ALLOWED_SCHEMES.contains(scheme)) {
+            throw BizException.invalidParam("仅支持 http/https 地址");
+        }
+        // Credentials in a URL are a smuggling vector ("http://internal@evil/") and no legitimate
+        // public page needs them; anonymous fetch is a scope decision of the contract.
+        if (uri.getUserInfo() != null) {
+            throw BizException.invalidParam("URL 不能携带用户名密码");
+        }
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw BizException.invalidParam("URL 缺少主机名");
+        }
+        for (InetAddress address : resolve(host)) {
+            if (isInternal(address)) {
+                log.info("url rejected by ssrf guard, host={}, address={}", host, address.getHostAddress());
+                throw BizException.invalidParam("该地址指向内网或本机，禁止抓取");
+            }
+        }
+        return uri;
+    }
+
+    private URI parse(String url) {
+        try {
+            return URI.create(url);
+        } catch (IllegalArgumentException e) {
+            throw BizException.invalidParam("URL 格式不正确");
+        }
+    }
+
+    private InetAddress[] resolve(String host) {
+        try {
+            return InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            throw BizException.invalidParam("无法解析该域名");
+        }
+    }
+
+    /**
+     * Whether an address is unreachable-from-outside territory: loopback, RFC1918, link local
+     * (which covers 169.254.169.254, the metadata endpoint), multicast or the wildcard.
+     */
+    private boolean isInternal(InetAddress address) {
+        return address.isLoopbackAddress()
+                || address.isSiteLocalAddress()
+                || address.isLinkLocalAddress()
+                || address.isMulticastAddress()
+                || address.isAnyLocalAddress();
+    }
+}

--- a/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/service/GraphExtractionParserTest.java
+++ b/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/service/GraphExtractionParserTest.java
@@ -13,8 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Covers the hard validation of the extraction model output, requirement section 4.4: a malformed answer,
- * an over long entity name and a relation endpoint outside the entity list are all rejected as a whole so
- * the caller can count the chunk as skipped.
+ * an over long entity name are rejected as a whole so the caller can count the chunk as skipped, while a
+ * relation whose endpoint was never extracted only costs that one relation.
  *
  * @author owlzhangfq@gmail.com
  */
@@ -85,10 +85,18 @@ class GraphExtractionParserTest {
     }
 
     @Test
-    void shouldRejectARelationWhoseEndpointWasNeverExtracted() {
-        assertNull(parser.parse("""
-                {"entities":[{"name":"A","type":"x"}],
-                 "relations":[{"source":"A","type":"knows","target":"B"}]}"""));
+    void shouldDropARelationWhoseEndpointWasNeverExtractedAndKeepTheRest() {
+        GraphExtractionParser.Result result = parser.parse("""
+                {"entities":[{"name":"A","type":"x"},{"name":"B","type":"x"}],
+                 "relations":[{"source":"A","type":"knows","target":"B"},
+                              {"source":"A","type":"knows","target":"未抽取到的实体"}]}""");
+
+        // 越界的那条被丢掉，同一答案里抽对的实体与关系照常保留：整体作废会让一条坏关系
+        // 拖垮整段的抽取成果，而"图里不长出无抽取依据的节点"这个目标丢掉该关系就已达成
+        assertNotNull(result);
+        assertEquals(2, result.entities().size());
+        assertEquals(1, result.relations().size());
+        assertEquals("B", result.relations().get(0).target());
     }
 
     @Test

--- a/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/service/UrlGuardTest.java
+++ b/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/service/UrlGuardTest.java
@@ -1,0 +1,75 @@
+package io.kbrag.domain.service;
+
+import io.kbrag.common.exception.BizException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers the SSRF gate of the M12 contract: URL import is the first outbound request built from
+ * user input, so everything that could reach loopback, RFC1918, link local (the cloud metadata
+ * endpoint lives there) or a smuggled credential has to be refused before a socket opens.
+ *
+ * <p>Every internal case uses an address literal, so no test depends on a resolver being online.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class UrlGuardTest {
+
+    private final UrlGuard guard = new UrlGuard();
+
+    @Test
+    void shouldAcceptAPublicHttpUrl() {
+        // A public address literal: accepted without any DNS round trip.
+        URI uri = guard.validate("http://93.184.216.34/docs/guide");
+
+        assertEquals("93.184.216.34", uri.getHost());
+    }
+
+    @Test
+    void shouldRejectABlankUrl() {
+        assertThrows(BizException.class, () -> guard.validate("   "));
+        assertThrows(BizException.class, () -> guard.validate(null));
+    }
+
+    @Test
+    void shouldRejectAMalformedUrl() {
+        assertThrows(BizException.class, () -> guard.validate("http://exa mple.com/"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ftp://93.184.216.34/file", "file:///etc/passwd", "gopher://93.184.216.34/"})
+    void shouldRejectAnyNonHttpScheme(String url) {
+        assertThrows(BizException.class, () -> guard.validate(url));
+    }
+
+    @Test
+    void shouldRejectCredentialsInsideTheUrl() {
+        // "http://internal@evil/" style smuggling: the userinfo part is refused outright.
+        assertThrows(BizException.class, () -> guard.validate("http://admin:secret@93.184.216.34/"));
+    }
+
+    @Test
+    void shouldRejectAUrlWithoutAHost() {
+        assertThrows(BizException.class, () -> guard.validate("http:///path-only"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Loopback, IPv4 and IPv6.
+            "http://127.0.0.1/", "http://localhost/", "http://[::1]/",
+            // RFC1918 private ranges.
+            "http://10.0.0.1/", "http://172.16.0.1/", "http://192.168.1.1/",
+            // Link local, which is where 169.254.169.254 - the metadata endpoint - lives.
+            "http://169.254.169.254/latest/meta-data/",
+            // Wildcard.
+            "http://0.0.0.0/"})
+    void shouldRejectEveryInternalAddress(String url) {
+        assertThrows(BizException.class, () -> guard.validate(url));
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/config/ModelProviderConfig.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/config/ModelProviderConfig.java
@@ -140,6 +140,50 @@ public class ModelProviderConfig {
     }
 
     /**
+     * Selects the graph extraction chat provider, requirement section 4.9.
+     *
+     * <p>Shares the credential, model and base URL of {@code kb.chat} and only substitutes the token
+     * budget: {@code kb.chat.max-tokens} sizes a single line query rewrite, while one extraction answer
+     * is a JSON object carrying every entity and relation of the passage. Running out mid object yields
+     * truncated JSON, which the parser can only reject - the chunk is then counted as skipped and the
+     * loss shows up as "output validation failed" although nothing was wrong with the model's answer.
+     *
+     * @param properties bound configuration
+     * @return configured provider, or the unconfigured placeholder
+     */
+    @Bean
+    public ChatProvider graphExtractionChatProvider(KbProperties properties) {
+        KbProperties.Chat chatConfig = properties.getChat();
+        if (chatConfig.getApiKey() == null || chatConfig.getApiKey().isBlank()) {
+            log.info("graph extraction chat provider not configured, extraction disabled");
+            return new UnconfiguredChatProvider();
+        }
+        KbProperties.Chat extractConfig = withMaxTokens(chatConfig, properties.getGraph().getExtractMaxTokens());
+        log.info("graph extraction chat provider configured, model={}, maxTokens={}",
+                extractConfig.getModel(), extractConfig.getMaxTokens());
+        return new DashScopeChatProvider(extractConfig);
+    }
+
+    /**
+     * Copies a chat configuration substituting only the token budget.
+     *
+     * @param source    configuration to copy
+     * @param maxTokens generation budget to substitute
+     * @return copy carrying the substituted budget
+     */
+    private KbProperties.Chat withMaxTokens(KbProperties.Chat source, int maxTokens) {
+        KbProperties.Chat copy = new KbProperties.Chat();
+        copy.setProvider(source.getProvider());
+        copy.setModel(source.getModel());
+        copy.setApiKey(source.getApiKey());
+        copy.setBaseUrl(source.getBaseUrl());
+        copy.setTimeoutMs(source.getTimeoutMs());
+        copy.setTemperature(source.getTemperature());
+        copy.setMaxTokens(maxTokens);
+        return copy;
+    }
+
+    /**
      * Copies a chat configuration substituting the model and forcing temperature to zero, so the judge
      * provider can point at a different, reproducible model without a second credential set.
      *

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/HttpWebPageFetcher.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/HttpWebPageFetcher.java
@@ -1,0 +1,162 @@
+package io.kbrag.infrastructure.web;
+
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.port.WebPageFetcher;
+import io.kbrag.domain.service.UrlGuard;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Fetches web pages for URL import, the M12 contract section 3.3.
+ *
+ * <p><b>Redirects are followed by hand, never by the HTTP client.</b> An automatic follow would
+ * request whatever Location the remote server names, which is exactly how a public URL that 302s to
+ * {@code 169.254.169.254} defeats a guard that only checked the first address - so every hop goes
+ * through {@link UrlGuard} again before a connection is opened to it.
+ *
+ * <p>The body is read in bounded chunks against the size cap rather than trusting Content-Length:
+ * a chunked response carries no length at all, and a hostile one may understate it.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+public class HttpWebPageFetcher implements WebPageFetcher {
+
+    private static final int BYTES_PER_MB = 1024 * 1024;
+    private static final int COPY_BUFFER_SIZE = 8192;
+    private static final String HEADER_LOCATION = "Location";
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+    private static final String USER_AGENT = "kb-rag/1.0 (+url-import)";
+
+    /** Content type (parameters stripped, lower case) to the extension the upload chain expects. */
+    private static final Map<String, String> EXTENSION_BY_CONTENT_TYPE = Map.of(
+            "text/html", "html",
+            "application/xhtml+xml", "html",
+            "text/plain", "txt",
+            "text/markdown", "md");
+
+    /** Extension assumed when the response carries no Content-Type header at all. */
+    private static final String DEFAULT_EXTENSION = "html";
+
+    private final UrlGuard urlGuard;
+    private final KbProperties properties;
+    private final HttpClient httpClient;
+
+    public HttpWebPageFetcher(UrlGuard urlGuard, KbProperties properties) {
+        this.urlGuard = urlGuard;
+        this.properties = properties;
+        this.httpClient = HttpClient.newBuilder()
+                // NEVER is the whole point: see the class comment on redirect handling.
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(Duration.ofMillis(properties.getWebImport().getFetchTimeoutMs()))
+                .build();
+    }
+
+    @Override
+    public FetchedPage fetch(String url) {
+        String current = url;
+        int maxRedirects = Math.max(0, properties.getWebImport().getMaxRedirects());
+        for (int hop = 0; hop <= maxRedirects; hop++) {
+            URI uri = urlGuard.validate(current);
+            HttpResponse<InputStream> response = send(uri);
+            int status = response.statusCode();
+            if (isRedirect(status)) {
+                current = redirectTarget(uri, response);
+                continue;
+            }
+            if (status < 200 || status >= 300) {
+                throw new BizException(ErrorCode.INTERNAL_ERROR, "页面返回状态码 " + status + "，抓取失败");
+            }
+            String extension = extensionOf(response);
+            return new FetchedPage(readBounded(response.body()), extension);
+        }
+        throw new BizException(ErrorCode.INTERNAL_ERROR,
+                "重定向超过 " + maxRedirects + " 次，抓取中止");
+    }
+
+    private HttpResponse<InputStream> send(URI uri) {
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofMillis(properties.getWebImport().getFetchTimeoutMs()))
+                .header("Accept", "text/html, text/plain, text/markdown, application/xhtml+xml")
+                .header("User-Agent", USER_AGENT)
+                .GET()
+                .build();
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (IOException e) {
+            log.info("web page fetch failed, uri={}, error={}", uri, e.getMessage());
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "页面抓取失败：" + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "页面抓取被中断", e);
+        }
+    }
+
+    private boolean isRedirect(int status) {
+        return status == 301 || status == 302 || status == 303 || status == 307 || status == 308;
+    }
+
+    private String redirectTarget(URI from, HttpResponse<InputStream> response) {
+        Optional<String> location = response.headers().firstValue(HEADER_LOCATION);
+        if (location.isEmpty() || location.get().isBlank()) {
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "页面返回重定向但缺少目标地址");
+        }
+        // A relative Location is legal per RFC 7231 and resolves against the hop that issued it.
+        return from.resolve(location.get().trim()).toString();
+    }
+
+    /**
+     * Maps the response content type onto the file extension the upload chain validates against.
+     * Anything outside the text whitelist is rejected: a PDF or an image behind a URL belongs to the
+     * file upload path where the magic number checks live.
+     */
+    private String extensionOf(HttpResponse<InputStream> response) {
+        Optional<String> header = response.headers().firstValue(HEADER_CONTENT_TYPE);
+        if (header.isEmpty() || header.get().isBlank()) {
+            return DEFAULT_EXTENSION;
+        }
+        String mediaType = header.get().split(";")[0].trim().toLowerCase(Locale.ROOT);
+        if (mediaType.isEmpty()) {
+            return DEFAULT_EXTENSION;
+        }
+        String extension = EXTENSION_BY_CONTENT_TYPE.get(mediaType);
+        if (extension == null) {
+            throw BizException.invalidParam("仅支持网页与文本类内容，该地址返回 " + mediaType);
+        }
+        return extension;
+    }
+
+    private byte[] readBounded(InputStream body) {
+        long maxBytes = (long) properties.getWebImport().getMaxPageSizeMb() * BYTES_PER_MB;
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[COPY_BUFFER_SIZE];
+        try (InputStream in = body) {
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                if (buffer.size() + read > maxBytes) {
+                    throw BizException.invalidParam("页面超过 "
+                            + properties.getWebImport().getMaxPageSizeMb() + " MB 上限，抓取中止");
+                }
+                buffer.write(chunk, 0, read);
+            }
+        } catch (IOException e) {
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "读取页面内容失败：" + e.getMessage(), e);
+        }
+        return buffer.toByteArray();
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/HttpWebPageFetcherTest.java
+++ b/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/HttpWebPageFetcherTest.java
@@ -1,0 +1,156 @@
+package io.kbrag.infrastructure.web;
+
+import com.sun.net.httpserver.HttpServer;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.port.WebPageFetcher;
+import io.kbrag.domain.service.UrlGuard;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the transport rules of the M12 contract against a real local HTTP server: the redirect
+ * that must be re-validated hop by hop, the content type whitelist and the streamed size cap.
+ *
+ * <p>The guard is replaced by a recording permissive one, because the production guard would
+ * rightly refuse the loopback address this test server lives on - and the recording is exactly how
+ * the per-hop re-validation is proven.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class HttpWebPageFetcherTest {
+
+    private final List<String> validatedUrls = new ArrayList<>();
+
+    private HttpServer server;
+    private KbProperties properties;
+    private HttpWebPageFetcher fetcher;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        properties = new KbProperties();
+        properties.getWebImport().setMaxPageSizeMb(1);
+        UrlGuard recordingGuard = new UrlGuard() {
+            @Override
+            public URI validate(String url) {
+                validatedUrls.add(url);
+                return URI.create(url);
+            }
+        };
+        fetcher = new HttpWebPageFetcher(recordingGuard, properties);
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void shouldMapTheContentTypeOntoTheUploadExtension() {
+        respond("/plain", 200, "text/plain; charset=utf-8", "hello".getBytes(StandardCharsets.UTF_8));
+
+        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/plain"));
+
+        assertThat(page.extension()).isEqualTo("txt");
+        assertThat(page.body()).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void shouldDefaultToHtmlWhenTheResponseCarriesNoContentType() {
+        respond("/bare", 200, null, "<html></html>".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(fetcher.fetch(url("/bare")).extension()).isEqualTo("html");
+    }
+
+    @Test
+    void shouldRejectAContentTypeOutsideTheTextWhitelist() {
+        // A PDF behind a URL belongs to the file upload path, where the magic number checks live.
+        respond("/pdf", 200, "application/pdf", new byte[]{0x25, 0x50});
+
+        assertThatThrownBy(() -> fetcher.fetch(url("/pdf")))
+                .isInstanceOf(BizException.class)
+                .hasMessageContaining("application/pdf");
+    }
+
+    @Test
+    void shouldRevalidateEveryRedirectHop() {
+        redirect("/a", "/b");
+        respond("/b", 200, "text/html", "final".getBytes(StandardCharsets.UTF_8));
+
+        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/a"));
+
+        assertThat(page.body()).isEqualTo("final".getBytes(StandardCharsets.UTF_8));
+        // Both the original URL and the redirect target went through the guard: this is the whole
+        // defence against a public page that 302s into the internal network.
+        assertThat(validatedUrls).containsExactly(url("/a"), url("/b"));
+    }
+
+    @Test
+    void shouldStopAfterTooManyRedirects() {
+        redirect("/loop", "/loop");
+
+        assertThatThrownBy(() -> fetcher.fetch(url("/loop")))
+                .isInstanceOf(BizException.class)
+                .hasMessageContaining("重定向");
+    }
+
+    @Test
+    void shouldRejectABodyOverTheSizeCap() {
+        byte[] oversized = new byte[1024 * 1024 + 1];
+        Arrays.fill(oversized, (byte) 'x');
+        respond("/big", 200, "text/html", oversized);
+
+        assertThatThrownBy(() -> fetcher.fetch(url("/big")))
+                .isInstanceOf(BizException.class)
+                .hasMessageContaining("MB");
+    }
+
+    @Test
+    void shouldFailOnANonSuccessStatus() {
+        respond("/gone", 404, "text/html", "not here".getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> fetcher.fetch(url("/gone")))
+                .isInstanceOf(BizException.class)
+                .hasMessageContaining("404");
+    }
+
+    private String url(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    private void respond(String path, int status, String contentType, byte[] body) {
+        server.createContext(path, exchange -> {
+            if (contentType != null) {
+                exchange.getResponseHeaders().add("Content-Type", contentType);
+            }
+            exchange.sendResponseHeaders(status, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+    }
+
+    private void redirect(String path, String target) {
+        server.createContext(path, exchange -> {
+            // A relative Location is legal per RFC 7231 and must resolve against the issuing hop.
+            exchange.getResponseHeaders().add("Location", target);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+    }
+}

--- a/kb-rag-web/CHANGELOG.md
+++ b/kb-rag-web/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
-本项目的版本记录遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 约定，按里程碑分节记录（对应 `kb-rag-deploy/docs/M1~M9-CONTRACTS.md`）。
+本项目的版本记录遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 约定，按里程碑分节记录（对应 `kb-rag-deploy/docs/M1~M13-CONTRACTS.md`）。
 
 ## [Unreleased]
 
 ### Added
+
+**M12 · 网页导入**（`docs/M12-CONTRACTS.md`）
+- 知识库详情新增「网页导入」Tab：URL 登记（登记即抓）、来源列表（最近同步四态 SUCCESS/UNCHANGED/SKIPPED/FAILED 标签 + 失败原因）、手动同步、定时同步开关、移除登记（二次确认，提示不删已导入文档）。
+- 注：M13 为纯后端运维指标（Prometheus），无前端改动。
+
+**M11 · 内容治理**（`docs/M11-CONTRACTS.md`）
+- 知识库详情文档列表新增发布状态 / 有效期列与审核操作（提审 / 通过 / 驳回，驳回理由录入）、有效期设置 / 清除弹窗；知识库级「上传需审核」开关（governance）。
+- 新增「回收站」Tab：已删文档列表、还原、彻底删除（二次确认）；文档删除按钮语义同步改为「移入回收站」。
+
+**M10 · 检索反馈与洞察**（`docs/M10-CONTRACTS.md`）
+- 知识库详情新增「反馈管理」Tab：反馈列表（有用 / 无用 + 原因）、转评测集（选择目标评测集）、忽略操作。
+- 新增「检索洞察」Tab：明细分页（脱敏摘要 / 命中数 / 降级标记）与内容缺口报表（零命中率、Top 未命中 query 分组）。
 
 **M9 · 标注迁移建议与图片检索输入**（`docs/M9-CONTRACTS.md`）
 - 待复核工作台：pending 行展开显示相似度迁移建议（`suggestions`：分数 + 内容预览 + 「迁移到此分片」确认框）。

--- a/kb-rag-web/CONTRIBUTING.md
+++ b/kb-rag-web/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 感谢你对 kb-rag-web 感兴趣。本仓库承载 kb-rag 知识库 RAG 系统的前端管理台；后端接口、
 部署编排与总体文档请分别参见 kb-rag-server / kb-rag-parser / kb-rag-deploy 仓库
-（接口契约见 `kb-rag-deploy/docs/M1~M9-CONTRACTS.md`，前端架构见
+（接口契约见 `kb-rag-deploy/docs/M1~M13-CONTRACTS.md`，前端架构见
 `kb-rag-deploy/docs/ARCHITECTURE.md` 第 5 节）。
 
 ## 代码原创红线

--- a/kb-rag-web/README.md
+++ b/kb-rag-web/README.md
@@ -2,7 +2,7 @@
 
 知识库 RAG 系统的前端管理台。技术栈：Vite 8 + React 18 + TypeScript 6 + Ant Design 5 + react-router-dom 6 + axios；静态检查用 oxlint；不引入 Redux/Zustand 等状态管理库（登录态与模型状态均用 React Context）。
 
-对应 `kb-rag-deploy/docs/ARCHITECTURE.md` 第 5 节（web 架构）与 `docs/M1~M9-CONTRACTS.md` 各里程碑契约。
+对应 `kb-rag-deploy/docs/ARCHITECTURE.md` 第 5 节（web 架构）与 `docs/M1~M13-CONTRACTS.md` 各里程碑契约。
 
 ## 快速开始
 
@@ -34,7 +34,7 @@ npm run dev      # 启动开发服务器，默认端口 20002
 | `/login` | - | 登录页 | 登录成功后若 `must_change_password=true` 强制跳转改密页 |
 | `/change-password` | - | 首登改密页 | 修改成功后放行到知识库列表 |
 | `/kb` | 知识库 | 知识库列表 | 卡片形式展示，支持新建（弹窗）、删除（二次确认）、空态引导 |
-| `/kb/:kbId` | 知识库 | 知识库详情 | 文档拖拽上传、文档列表（状态标签 + 3s 轮询）、失败原因提示、索引配置编辑与重建、分片抽屉、版本抽屉（pinned 标记）、聊天记录导入向导、知识图谱 Tab |
+| `/kb/:kbId` | 知识库 | 知识库详情 | 文档拖拽上传、文档列表（状态标签 + 3s 轮询）、失败原因提示、审核与有效期操作（M11）、索引配置编辑与重建、分片抽屉、版本抽屉（pinned 标记）、聊天记录导入向导；知识图谱 / 反馈管理 / 检索洞察 / 回收站 / 网页导入等 Tab |
 | `/search` | 检索调试 | 检索调试 | 知识库选择 + 参数面板（改写/召回/融合/重排/过滤/返回分组折叠），结果卡片展示各路原始分/归一化分/`fused_score`/`rerank_score`，`degraded` 非空时顶部告警，可收进评测集 |
 | `/chat` | 问答调试 | 问答调试 | 走 `/apps/{id}/chat-preview` SSE 流式问答（JWT 鉴权） |
 | `/apps` | 应用中心 | 应用列表 | 应用的新建与列表 |
@@ -79,6 +79,6 @@ src/
 
 - 整体架构（web 一节）：`kb-rag-deploy/docs/ARCHITECTURE.md` 第 5 节
 - 关键流程时序图（含前端参与的每条链路）：`kb-rag-deploy/docs/FLOWS.md`
-- 各里程碑接口契约：`kb-rag-deploy/docs/M1~M9-CONTRACTS.md`
+- 各里程碑接口契约：`kb-rag-deploy/docs/M1~M13-CONTRACTS.md`
 - 参与贡献、提交规范：`CONTRIBUTING.md`
 - 安全问题上报：`SECURITY.md`

--- a/kb-rag-web/src/api/document.ts
+++ b/kb-rag-web/src/api/document.ts
@@ -1,5 +1,5 @@
 // Author: owlzhangfq@gmail.com
-import { apiDelete, apiGet, apiPost, apiUpload } from './request';
+import { apiDelete, apiGet, apiPost, apiPut, apiUpload } from './request';
 import type {
   DocumentPreview,
   KbChunk,
@@ -29,9 +29,10 @@ export function reindexDocument(docId: string): Promise<void> {
 }
 
 /**
- * DELETE /api/v1/documents/{docId}: removes the document with every one of its versions and
- * chunks, including the copies held in the search engines. Irreversible -- there is no soft-delete
- * or restore path, so callers must confirm first.
+ * DELETE /api/v1/documents/{docId} (M11-CONTRACTS.md section 2.2): moves the document into the
+ * recycle bin. The URL predates M11 and kept its meaning of "delete this document", but the
+ * deletion is now reversible via the trash tab until the retention period runs out or an explicit
+ * purge follows.
  */
 export function deleteDocument(docId: string): Promise<void> {
   return apiDelete<void>(`/documents/${docId}`);
@@ -59,4 +60,56 @@ export function confirmDocument(docId: string): Promise<void> {
  */
 export function reparseDocument(docId: string, payload?: ReparseDocumentRequest): Promise<DocumentPreview> {
   return apiPost<DocumentPreview>(`/documents/${docId}/reparse`, payload);
+}
+
+// ---------------------------------------------------------------------------
+// Content governance (M11-CONTRACTS.md section 2.2)
+// ---------------------------------------------------------------------------
+
+/** POST /api/v1/documents/{docId}/submit-review: DRAFT | REJECTED -> PENDING_REVIEW. */
+export function submitDocumentReview(docId: string): Promise<KbDocument> {
+  return apiPost<KbDocument>(`/documents/${docId}/submit-review`);
+}
+
+/** POST /api/v1/documents/{docId}/approve: PENDING_REVIEW -> PUBLISHED, clears review_note. */
+export function approveDocument(docId: string): Promise<KbDocument> {
+  return apiPost<KbDocument>(`/documents/${docId}/approve`);
+}
+
+/** POST /api/v1/documents/{docId}/reject: PENDING_REVIEW -> REJECTED with a mandatory note. */
+export function rejectDocument(docId: string, note: string): Promise<KbDocument> {
+  return apiPost<KbDocument>(`/documents/${docId}/reject`, { note });
+}
+
+/**
+ * PUT /api/v1/documents/{docId}/validity: sets or clears the validity window. Null clears a bound,
+ * and an expires_at in the past is allowed on purpose -- it is how "take this offline now" works.
+ */
+export function updateDocumentValidity(
+  docId: string,
+  effectiveAt: string | null,
+  expiresAt: string | null,
+): Promise<KbDocument> {
+  return apiPut<KbDocument>(`/documents/${docId}/validity`, {
+    effective_at: effectiveAt,
+    expires_at: expiresAt,
+  });
+}
+
+/** GET /api/v1/kb/{kbId}/trash: pages the recycle bin, most recently trashed first. */
+export function listTrash(kbId: string, page?: number): Promise<PageResult<KbDocument>> {
+  return apiGet<PageResult<KbDocument>>(`/kb/${kbId}/trash`, { page });
+}
+
+/** POST /api/v1/documents/{docId}/restore: instant flag flip back out of the recycle bin. */
+export function restoreDocument(docId: string): Promise<KbDocument> {
+  return apiPost<KbDocument>(`/documents/${docId}/restore`);
+}
+
+/**
+ * DELETE /api/v1/documents/{docId}/purge: the irreversible removal, engine copies included. Only
+ * reachable for a document already in the trash -- the two-step confirmation against typos.
+ */
+export function purgeDocument(docId: string): Promise<void> {
+  return apiDelete<void>(`/documents/${docId}/purge`);
 }

--- a/kb-rag-web/src/api/kb.ts
+++ b/kb-rag-web/src/api/kb.ts
@@ -62,3 +62,11 @@ export function rebuildKb(kbId: string, payload?: RebuildRequest): Promise<void>
 export function confirmKbDocuments(kbId: string, payload?: ConfirmDocumentsRequest): Promise<void> {
   return apiPost<void>(`/kb/${kbId}/documents/confirm`, payload);
 }
+
+/**
+ * PUT /api/v1/kb/{kbId}/governance (M11-CONTRACTS.md section 2.2): flips the review switch. Only
+ * future uploads read it -- documents already present keep their publish_status.
+ */
+export function updateKbGovernance(kbId: string, reviewRequired: boolean): Promise<KnowledgeBase> {
+  return apiPut<KnowledgeBase>(`/kb/${kbId}/governance`, { review_required: reviewRequired });
+}

--- a/kb-rag-web/src/api/retrievalFeedback.ts
+++ b/kb-rag-web/src/api/retrievalFeedback.ts
@@ -1,10 +1,18 @@
 // Author: owlzhangfq@gmail.com
-import { apiPost } from './request';
+import { apiGet, apiPost } from './request';
+import type {
+  ConvertFeedbackRequest,
+  FeedbackVerdict,
+  ListRetrievalFeedbackParams,
+  PageResult,
+  RetrievalFeedbackEntry,
+} from './types';
 
 /**
- * 好/坏 verdict on one retrieval result (需求 §4.5 "检索结果反馈标注").
+ * 好/坏 verdict on one retrieval result (需求 §4.5 "检索结果反馈标注"). Alias of the shared
+ * FeedbackVerdict, kept so the search page's existing imports need no churn.
  */
-export type RetrievalVerdict = 'GOOD' | 'BAD';
+export type RetrievalVerdict = FeedbackVerdict;
 
 export interface RetrievalFeedbackRequest {
   kb_id: string;
@@ -14,14 +22,37 @@ export interface RetrievalFeedbackRequest {
 }
 
 /**
- * POST /api/v1/retrieval-feedback (M4b-CONTRACTS.md section 2).
+ * POST /api/v1/retrieval-feedback (M10-CONTRACTS.md section 2.1).
  *
- * Deliberately a log-only endpoint on the server: the payload carries no dataset_id, so a BAD
- * verdict has nowhere safe to land and no consumer in this milestone. The contract's own wording
- * (§8 of the M4b deviations) is that GOOD's real persistence path is the separate "收进评测集"
- * endpoint (POST cases/from-retrieval), which this page also exposes. Marking 好 here therefore
- * records the signal without creating a case -- use 收进评测集 when a case is what you want.
+ * The payload is unchanged from M4b -- the M10 compatibility line -- but the endpoint is no
+ * longer log-only: the verdict now lands as a persisted row (status=NEW) that the KB detail
+ * page's feedback management tab can list, convert into an evaluation case or dismiss.
  */
-export function submitRetrievalFeedback(payload: RetrievalFeedbackRequest): Promise<void> {
-  return apiPost<void>('/retrieval-feedback', payload);
+export function submitRetrievalFeedback(payload: RetrievalFeedbackRequest): Promise<RetrievalFeedbackEntry> {
+  return apiPost<RetrievalFeedbackEntry>('/retrieval-feedback', payload);
+}
+
+/** GET /api/v1/kb/{kbId}/retrieval-feedback (M10-CONTRACTS.md section 2.1), newest first. */
+export function listRetrievalFeedback(
+  kbId: string,
+  params?: ListRetrievalFeedbackParams,
+): Promise<PageResult<RetrievalFeedbackEntry>> {
+  return apiGet<PageResult<RetrievalFeedbackEntry>>(`/kb/${kbId}/retrieval-feedback`, params);
+}
+
+/**
+ * POST /api/v1/retrieval-feedback/{feedbackId}/convert (M10-CONTRACTS.md section 2.1): turns one
+ * GOOD, still-NEW feedback into an evaluation case (source=FEEDBACK) of the given dataset.
+ * BAD rows and rows already CONVERTED/DISMISSED are rejected server-side with INVALID_PARAM.
+ */
+export function convertRetrievalFeedback(
+  feedbackId: string,
+  payload: ConvertFeedbackRequest,
+): Promise<RetrievalFeedbackEntry> {
+  return apiPost<RetrievalFeedbackEntry>(`/retrieval-feedback/${feedbackId}/convert`, payload);
+}
+
+/** POST /api/v1/retrieval-feedback/{feedbackId}/dismiss (M10-CONTRACTS.md section 2.1): terminal, cannot be undone. */
+export function dismissRetrievalFeedback(feedbackId: string): Promise<RetrievalFeedbackEntry> {
+  return apiPost<RetrievalFeedbackEntry>(`/retrieval-feedback/${feedbackId}/dismiss`);
 }

--- a/kb-rag-web/src/api/searchInsight.ts
+++ b/kb-rag-web/src/api/searchInsight.ts
@@ -1,0 +1,32 @@
+// Author: owlzhangfq@gmail.com
+import { apiGet } from './request';
+import type {
+  ListSearchInsightParams,
+  PageResult,
+  SearchInsightEntry,
+  SearchInsightStats,
+} from './types';
+
+/**
+ * GET /api/v1/kb/{kbId}/search-insights (M10-CONTRACTS.md section 2.2), newest first. Rows are
+ * recorded automatically at retrieval time (console debug + OpenAPI); evaluation runs never
+ * produce them, so this listing is real traffic only.
+ */
+export function listSearchInsights(
+  kbId: string,
+  params?: ListSearchInsightParams,
+): Promise<PageResult<SearchInsightEntry>> {
+  return apiGet<PageResult<SearchInsightEntry>>(`/kb/${kbId}/search-insights`, params);
+}
+
+/**
+ * GET /api/v1/kb/{kbId}/search-insights/stats (M10-CONTRACTS.md section 2.2): the content-gap
+ * report -- totals, zero-hit rate, degraded count and the Top zero-hit query groups
+ * (case/whitespace-normalized, digest of the newest row per group).
+ */
+export function getSearchInsightStats(
+  kbId: string,
+  params?: Pick<ListSearchInsightParams, 'from' | 'to'>,
+): Promise<SearchInsightStats> {
+  return apiGet<SearchInsightStats>(`/kb/${kbId}/search-insights/stats`, params);
+}

--- a/kb-rag-web/src/api/types.ts
+++ b/kb-rag-web/src/api/types.ts
@@ -179,6 +179,12 @@ export interface KnowledgeBase {
    * emits a primitive boolean); optional here only so pre-M7 fixtures still type-check.
    */
   graph_enabled?: boolean;
+  /**
+   * M11-CONTRACTS.md section 2.2: when true, new documents of this KB start as DRAFT and must pass
+   * review before they become retrievable. Only future uploads read the switch. Optional so pre-M11
+   * fixtures still type-check; the server always emits it.
+   */
+  review_required?: boolean;
 }
 
 export interface CreateKbRequest {
@@ -212,6 +218,21 @@ export const IN_PROGRESS_STATUSES: ProcessStatus[] = ['UPLOADED', 'PARSING', 'PA
 export const FAILED_STATUSES: ProcessStatus[] = ['PARSE_FAILED', 'INDEX_FAILED'];
 
 /**
+ * t_kb_document.publish_status (M11-CONTRACTS.md section 2.1): the editorial state, orthogonal to
+ * process_status. Transitions: DRAFT | REJECTED -> PENDING_REVIEW -> PUBLISHED | REJECTED, with
+ * PUBLISHED terminal (taking content offline is an expiry or a trash operation, not a rollback).
+ */
+export type PublishStatus = 'DRAFT' | 'PENDING_REVIEW' | 'PUBLISHED' | 'REJECTED';
+
+/** Tag color + label per publish status, shared by the document list and the trash tab. */
+export const PUBLISH_STATUS_META: Record<PublishStatus, { color: string; label: string }> = {
+  DRAFT: { color: 'default', label: '草稿' },
+  PENDING_REVIEW: { color: 'processing', label: '待审核' },
+  PUBLISHED: { color: 'success', label: '已发布' },
+  REJECTED: { color: 'error', label: '已驳回' },
+};
+
+/**
  * DocumentResponse (server). The four upload-only fields at the bottom are populated exclusively by
  * POST /kb/{kbId}/documents (UploadOutcome) and are absent from the list/detail responses.
  * No updated_at is exposed.
@@ -226,6 +247,16 @@ export interface KbDocument {
   process_status: ProcessStatus;
   config_stale: boolean;
   fail_reason: string | null;
+  /** M11: editorial state; the server answers PUBLISHED for every document that predates M11. */
+  publish_status: PublishStatus;
+  /** M11: latest rejection reason, null unless publish_status is REJECTED. */
+  review_note: string | null;
+  /** M11: ISO lower bound of the validity window, null = no lower bound. */
+  effective_at: string | null;
+  /** M11: ISO upper bound of the validity window, null = no upper bound. */
+  expires_at: string | null;
+  /** M11: ISO instant the document entered the recycle bin, null outside it. */
+  trashed_at: string | null;
   created_at: string;
   /** Upload only: id of the document version this upload created. */
   version_id?: string;
@@ -920,8 +951,11 @@ export type AnchorType = 'SPAN' | 'DOCUMENT';
  */
 export type CaseStatus = 'ACTIVE' | 'EVIDENCE_STALE' | 'DEPRECATED';
 
-/** t_kb_eval_case.source (M4b-CONTRACTS.md section 1). */
-export type CaseSource = 'MANUAL' | 'DEBUG_PAGE' | 'IMPORTED';
+/**
+ * t_kb_eval_case.source (M4b-CONTRACTS.md section 1), extended by M10-CONTRACTS.md section 2.1:
+ * FEEDBACK marks cases born from converting a GOOD retrieval feedback in the feedback management tab.
+ */
+export type CaseSource = 'MANUAL' | 'DEBUG_PAGE' | 'IMPORTED' | 'FEEDBACK';
 
 /** t_kb_eval_run.status (M4b-CONTRACTS.md section 1). */
 export type RunStatus = 'PENDING' | 'RUNNING' | 'SUCCESS' | 'FAILED';
@@ -1733,3 +1767,138 @@ export interface GraphEntitySourceChunk {
   content: string;
   enabled: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Retrieval quality loop (M10-CONTRACTS.md sections 1/2)
+// ---------------------------------------------------------------------------
+
+/** t_kb_retrieval_feedback.verdict (M10-CONTRACTS.md section 1). */
+export type FeedbackVerdict = 'GOOD' | 'BAD';
+
+/**
+ * t_kb_retrieval_feedback.status (M10-CONTRACTS.md section 1): NEW is the only non-terminal
+ * state; CONVERTED and DISMISSED are both final server-side (a second convert/dismiss is
+ * rejected with INVALID_PARAM), so the UI hides the row actions once a row leaves NEW.
+ */
+export type FeedbackStatus = 'NEW' | 'CONVERTED' | 'DISMISSED';
+
+/**
+ * t_kb_retrieval_feedback row (M10-CONTRACTS.md section 2.1). The raw query is returned on
+ * purpose: the operator deciding whether to convert has to read the question actually asked.
+ * doc_id is null when the chunk was already deleted at submission time.
+ */
+export interface RetrievalFeedbackEntry {
+  feedback_id: string;
+  kb_id: string;
+  query: string;
+  chunk_id: string;
+  doc_id: string | null;
+  verdict: FeedbackVerdict;
+  status: FeedbackStatus;
+  /** Evaluation case created from this row, null until converted. */
+  converted_case_id: string | null;
+  note: string | null;
+  created_at: string;
+}
+
+/** GET /api/v1/kb/{kbId}/retrieval-feedback query params (M10-CONTRACTS.md section 2.1). */
+export interface ListRetrievalFeedbackParams {
+  verdict?: FeedbackVerdict;
+  status?: FeedbackStatus;
+  page?: number;
+  size?: number;
+}
+
+/** POST /api/v1/retrieval-feedback/{feedbackId}/convert request body (M10-CONTRACTS.md section 2.1). */
+export interface ConvertFeedbackRequest {
+  dataset_id: string;
+}
+
+/** t_kb_search_insight.source (M10-CONTRACTS.md section 2.2): which entrance ran the retrieval. */
+export type SearchInsightSource = 'CONSOLE' | 'OPEN_API';
+
+/**
+ * t_kb_search_insight row (M10-CONTRACTS.md section 2.2). query_digest is masked and truncated
+ * server-side (never the raw query -- insight rows are statistics, not evidence); top_score is
+ * null on zero hits; degraded lists the degradation markers the call carried (e.g. embedding
+ * fallback), empty for a clean call.
+ */
+export interface SearchInsightEntry {
+  insight_id: string;
+  kb_id: string;
+  source: SearchInsightSource;
+  query_digest: string;
+  result_count: number;
+  top_score: number | null;
+  zero_hit: boolean;
+  degraded: string[];
+  request_id: string | null;
+  created_at: string;
+}
+
+/**
+ * GET /api/v1/kb/{kbId}/search-insights query params (M10-CONTRACTS.md section 2.2).
+ * from/to are ISO date-times, e.g. 2026-07-26T00:00:00.
+ */
+export interface ListSearchInsightParams {
+  zero_hit?: boolean;
+  from?: string;
+  to?: string;
+  page?: number;
+  size?: number;
+}
+
+/** One zero-hit query group of the stats report, newest digest of the group + occurrence count. */
+export interface TopZeroHitQuery {
+  query_digest: string;
+  count: number;
+  last_at: string | null;
+}
+
+/** GET /api/v1/kb/{kbId}/search-insights/stats response (M10-CONTRACTS.md section 2.2). */
+export interface SearchInsightStats {
+  total: number;
+  zero_hit_count: number;
+  /** zero_hit_count / total, 0 when the window is empty. */
+  zero_hit_rate: number;
+  degraded_count: number;
+  /** Most frequent zero-hit query groups, largest first (case/whitespace-normalized grouping). */
+  top_zero_hit_queries: TopZeroHitQuery[];
+}
+
+// ---------------------------------------------------------------------------
+// Web source / URL import (M12-CONTRACTS.md)
+// ---------------------------------------------------------------------------
+
+/**
+ * t_kb_web_source.last_fetch_status (M12-CONTRACTS.md section 3.4). UNCHANGED and SKIPPED are
+ * successes of a kind: the fetch worked but writing anything would have been wrong (page hash
+ * identical / bound document sits in the recycle bin, respectively).
+ */
+export type WebSourceFetchStatus = 'SUCCESS' | 'UNCHANGED' | 'SKIPPED' | 'FAILED';
+
+/**
+ * t_kb_web_source row (M12-CONTRACTS.md section 1): one registered page URL and the outcome of
+ * its last sync. doc_id/file_name stay null until the first successful fetch; the binding is
+ * weak -- removing the registration never touches the document and vice versa.
+ */
+export interface WebSourceEntry {
+  source_id: string;
+  kb_id: string;
+  url: string;
+  doc_id: string | null;
+  file_name: string | null;
+  sync_enabled: boolean;
+  last_fetch_status: WebSourceFetchStatus | null;
+  last_fetch_at: string | null;
+  last_error: string | null;
+  created_at: string;
+}
+
+/** POST /api/v1/kb/{kbId}/web-sources request body (M12-CONTRACTS.md section 3.4). */
+export interface RegisterWebSourceRequest {
+  url: string;
+  /** Defaults to true server-side when omitted. */
+  sync_enabled?: boolean;
+}
+

--- a/kb-rag-web/src/api/webSource.ts
+++ b/kb-rag-web/src/api/webSource.ts
@@ -1,0 +1,39 @@
+// Author: owlzhangfq@gmail.com
+import { apiDelete, apiGet, apiPost, apiPut } from './request';
+import type { PageResult, RegisterWebSourceRequest, WebSourceEntry } from './types';
+
+/**
+ * POST /api/v1/kb/{kbId}/web-sources (M12-CONTRACTS.md section 3.4): registers a page URL and
+ * runs its first fetch inline, so the returned entry already carries the outcome -- FAILED here
+ * means the registration stuck but the page could not be fetched (the row keeps the error).
+ */
+export function registerWebSource(kbId: string, payload: RegisterWebSourceRequest): Promise<WebSourceEntry> {
+  return apiPost<WebSourceEntry>(`/kb/${kbId}/web-sources`, payload);
+}
+
+/** GET /api/v1/kb/{kbId}/web-sources (M12-CONTRACTS.md section 3.4), most recently registered first. */
+export function listWebSources(kbId: string, page = 1, size = 20): Promise<PageResult<WebSourceEntry>> {
+  return apiGet<PageResult<WebSourceEntry>>(`/kb/${kbId}/web-sources`, { page, size });
+}
+
+/**
+ * POST /api/v1/web-sources/{sourceId}/sync (M12-CONTRACTS.md section 3.4): one on-demand sync.
+ * Never rejects for a fetch problem -- the outcome (SUCCESS/UNCHANGED/SKIPPED/FAILED) rides on
+ * the returned entry's last_fetch_status, matching what the scheduled pass would have recorded.
+ */
+export function syncWebSource(sourceId: string): Promise<WebSourceEntry> {
+  return apiPost<WebSourceEntry>(`/web-sources/${sourceId}/sync`);
+}
+
+/** PUT /api/v1/web-sources/{sourceId} (M12-CONTRACTS.md section 3.4): flips the scheduled-sync switch. */
+export function updateWebSource(sourceId: string, syncEnabled: boolean): Promise<WebSourceEntry> {
+  return apiPut<WebSourceEntry>(`/web-sources/${sourceId}`, { sync_enabled: syncEnabled });
+}
+
+/**
+ * DELETE /api/v1/web-sources/{sourceId} (M12-CONTRACTS.md section 3.4): removes the registration
+ * only -- the document it fed stays in the knowledge base (weak binding).
+ */
+export function removeWebSource(sourceId: string): Promise<void> {
+  return apiDelete<void>(`/web-sources/${sourceId}`);
+}

--- a/kb-rag-web/src/pages/kb/KbDetailPage.tsx
+++ b/kb-rag-web/src/pages/kb/KbDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   Popconfirm,
   Progress,
   Space,
+  Switch,
   Table,
   Tabs,
   Tag,
@@ -25,17 +26,30 @@ import {
 } from 'antd';
 import type { UploadProps } from 'antd';
 import { useNavigate, useParams } from 'react-router-dom';
-import { deleteDocument, listDocuments, reindexDocument, uploadDocument } from '../../api/document';
-import { confirmKbDocuments, getKnowledgeBase, rebuildKb } from '../../api/kb';
+import {
+  approveDocument,
+  deleteDocument,
+  listDocuments,
+  reindexDocument,
+  submitDocumentReview,
+  uploadDocument,
+} from '../../api/document';
+import { confirmKbDocuments, getKnowledgeBase, rebuildKb, updateKbGovernance } from '../../api/kb';
+import { PUBLISH_STATUS_META } from '../../api/types';
 import type { KbDocument, KnowledgeBase } from '../../api/types';
 import { formatFileSize } from '../../utils/format';
 import { PROCESS_STATUS_META, metaOf } from '../../utils/statusMeta';
 import ChatImportWizard from './components/ChatImportWizard';
 import ChunkDrawer from './components/ChunkDrawer';
+import FeedbackTab from './components/FeedbackTab';
+import { RejectModal, ValidityModal } from './components/GovernanceModals';
 import GraphTab from './components/GraphTab';
 import IndexConfigDrawer from './components/IndexConfigDrawer';
+import InsightTab from './components/InsightTab';
 import ParsePreviewDrawer from './components/ParsePreviewDrawer';
+import TrashTab from './components/TrashTab';
 import VersionDrawer from './components/VersionDrawer';
+import WebSourcesTab from './components/WebSourcesTab';
 
 // Document list is polled every 3s while this page stays mounted, per M1-CONTRACTS.md section 7.
 // The same poll loop is reused to track rebuild progress (M2-CONTRACTS.md section 4): there is
@@ -60,6 +74,10 @@ export default function KbDetailPage() {
   const [selectedPendingIds, setSelectedPendingIds] = useState<string[]>([]);
   const [batchConfirming, setBatchConfirming] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  // M11 governance: rows the validity/reject modals are pointing at, and the KB-level switch.
+  const [validityDoc, setValidityDoc] = useState<KbDocument | null>(null);
+  const [rejectDoc, setRejectDoc] = useState<KbDocument | null>(null);
+  const [governanceSaving, setGovernanceSaving] = useState(false);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const loadKb = useCallback(async () => {
@@ -134,7 +152,7 @@ export default function KbDetailPage() {
     setDeletingId(doc.doc_id);
     try {
       await deleteDocument(doc.doc_id);
-      message.success(`已删除 ${doc.file_name}`);
+      message.success(`已将 ${doc.file_name} 移入回收站`);
       // Drop any drawer still pointing at the document that no longer exists.
       setChunkDoc((prev) => (prev?.doc_id === doc.doc_id ? null : prev));
       setPreviewDoc((prev) => (prev?.doc_id === doc.doc_id ? null : prev));
@@ -173,6 +191,32 @@ export default function KbDetailPage() {
 
   const handleVersionActivated = () => {
     loadDocuments();
+  };
+
+  const handleSubmitReview = async (doc: KbDocument) => {
+    await submitDocumentReview(doc.doc_id);
+    message.success('已提交审核');
+    loadDocuments();
+  };
+
+  const handleApprove = async (doc: KbDocument) => {
+    await approveDocument(doc.doc_id);
+    message.success(`已通过并发布 ${doc.file_name}`);
+    loadDocuments();
+  };
+
+  // KB-level review_required switch (M11-CONTRACTS.md section 2.2): only affects future uploads,
+  // which is why flipping it does not touch loadDocuments.
+  const handleGovernanceToggle = async (checked: boolean) => {
+    if (!kbId) return;
+    setGovernanceSaving(true);
+    try {
+      await updateKbGovernance(kbId, checked);
+      message.success(checked ? '已开启审核：之后上传的新文档需审核通过后才参与检索' : '已关闭审核：之后上传的新文档直接发布');
+      loadKb();
+    } finally {
+      setGovernanceSaving(false);
+    }
   };
 
   const handleBatchConfirm = async () => {
@@ -227,6 +271,17 @@ export default function KbDetailPage() {
           </Typography.Title>
         </Space>
         <Space>
+          <Tooltip title="开启后，之后上传的新文档默认为草稿，需提交审核并通过后才参与检索；已有文档不受影响">
+            <Space size={4}>
+              <Typography.Text type="secondary">新文档需审核</Typography.Text>
+              <Switch
+                size="small"
+                checked={kb?.review_required ?? false}
+                loading={governanceSaving}
+                onChange={handleGovernanceToggle}
+              />
+            </Space>
+          </Tooltip>
           <Button icon={<MessageOutlined />} onClick={() => setChatImportOpen(true)}>
             导入聊天记录
           </Button>
@@ -298,7 +353,7 @@ export default function KbDetailPage() {
                   </p>
                   <p className="ant-upload-text">点击或拖拽文件到此处上传</p>
                   <p className="ant-upload-hint">
-                    支持 pdf / docx / txt / md / xlsx / csv，单文件不超过 100MB，可批量上传
+                    支持 pdf / docx / txt / md / xlsx / csv / html，单文件不超过 100MB，可批量上传
                   </p>
                 </Upload.Dragger>
 
@@ -324,7 +379,7 @@ export default function KbDetailPage() {
                     {
                       title: '处理状态',
                       dataIndex: 'process_status',
-                      width: 160,
+                      width: 120,
                       render: (status: KbDocument['process_status'], record: KbDocument) => {
                         const meta = metaOf(PROCESS_STATUS_META, status);
                         const tag = <Tag color={meta.color}>{meta.label}</Tag>;
@@ -336,6 +391,41 @@ export default function KbDetailPage() {
                       },
                     },
                     {
+                      title: '发布状态',
+                      dataIndex: 'publish_status',
+                      width: 100,
+                      render: (status: KbDocument['publish_status'], record: KbDocument) => {
+                        const meta = metaOf(PUBLISH_STATUS_META, status);
+                        const tag = <Tag color={meta.color}>{meta.label}</Tag>;
+                        // Surface the rejection reason right on the tag, per M11's review loop.
+                        return status === 'REJECTED' && record.review_note ? (
+                          <Tooltip title={`驳回原因：${record.review_note}`}>{tag}</Tooltip>
+                        ) : (
+                          tag
+                        );
+                      },
+                    },
+                    {
+                      title: '有效期',
+                      width: 90,
+                      render: (_, record: KbDocument) =>
+                        record.effective_at || record.expires_at ? (
+                          <Tooltip
+                            title={`生效：${record.effective_at ?? '不限'}，失效：${record.expires_at ?? '不限'}`}
+                          >
+                            <Tag
+                              color={
+                                record.expires_at && new Date(record.expires_at) <= new Date() ? 'error' : 'blue'
+                              }
+                            >
+                              {record.expires_at && new Date(record.expires_at) <= new Date() ? '已过期' : '已设置'}
+                            </Tag>
+                          </Tooltip>
+                        ) : (
+                          <Tag color="default">长期</Tag>
+                        ),
+                    },
+                    {
                       title: '索引配置',
                       dataIndex: 'config_stale',
                       width: 100,
@@ -343,9 +433,9 @@ export default function KbDetailPage() {
                     },
                     {
                       title: '操作',
-                      width: 320,
+                      width: 380,
                       render: (_, record: KbDocument) => (
-                        <Space>
+                        <Space wrap>
                           <Button size="small" onClick={() => setChunkDoc(record)}>
                             查看分片
                           </Button>
@@ -357,6 +447,32 @@ export default function KbDetailPage() {
                               预览确认
                             </Button>
                           )}
+                          {(record.publish_status === 'DRAFT' || record.publish_status === 'REJECTED') && (
+                            <Button size="small" type="link" onClick={() => handleSubmitReview(record)}>
+                              提交审核
+                            </Button>
+                          )}
+                          {record.publish_status === 'PENDING_REVIEW' && (
+                            <>
+                              <Popconfirm
+                                title="通过审核并发布？"
+                                description="发布后文档即参与检索，且不可退回草稿（下架需设置失效时间或移入回收站）"
+                                okText="通过"
+                                cancelText="取消"
+                                onConfirm={() => handleApprove(record)}
+                              >
+                                <Button size="small" type="link">
+                                  通过
+                                </Button>
+                              </Popconfirm>
+                              <Button size="small" type="link" danger onClick={() => setRejectDoc(record)}>
+                                驳回
+                              </Button>
+                            </>
+                          )}
+                          <Button size="small" type="link" onClick={() => setValidityDoc(record)}>
+                            有效期
+                          </Button>
                           <Popconfirm
                             title="确认重建该文档的解析与索引？"
                             okText="重建"
@@ -368,15 +484,15 @@ export default function KbDetailPage() {
                             </Button>
                           </Popconfirm>
                           <Popconfirm
-                            title="删除该文档？"
+                            title="移入回收站？"
                             description={
                               <>
-                                将连同它的<b>全部版本与分片</b>一并删除（含两个检索引擎中的副本），
+                                文档将移入回收站并立即从检索中下线；
                                 <br />
-                                删除后不可恢复，如需重新入库须重新上传。
+                                可在「回收站」标签页随时还原，超过保留期后自动清除。
                               </>
                             }
-                            okText="删除"
+                            okText="移入回收站"
                             okButtonProps={{ danger: true }}
                             cancelText="取消"
                             onConfirm={() => handleDelete(record)}
@@ -398,6 +514,29 @@ export default function KbDetailPage() {
             label: '知识图谱',
             children: kbId ? <GraphTab kbId={kbId} kb={kb} onKbChanged={loadKb} /> : null,
           },
+          // M10-CONTRACTS.md section 3: the retrieval quality loop's two console entrances.
+          {
+            key: 'feedback',
+            label: '反馈管理',
+            children: kbId ? <FeedbackTab kbId={kbId} /> : null,
+          },
+          {
+            key: 'insight',
+            label: '检索洞察',
+            children: kbId ? <InsightTab kbId={kbId} /> : null,
+          },
+          // M11-CONTRACTS.md section 2.2: reversible deletion lives here until retention expiry.
+          {
+            key: 'trash',
+            label: '回收站',
+            children: kbId ? <TrashTab kbId={kbId} onRestored={loadDocuments} /> : null,
+          },
+          // M12-CONTRACTS.md section 3.4: URL registration + incremental sync management.
+          {
+            key: 'webSources',
+            label: '网页导入',
+            children: kbId ? <WebSourcesTab kbId={kbId} onSynced={loadDocuments} /> : null,
+          },
         ]}
       />
 
@@ -414,6 +553,10 @@ export default function KbDetailPage() {
       />
 
       <VersionDrawer doc={versionDoc} onClose={() => setVersionDocId(null)} onActivated={handleVersionActivated} />
+
+      <ValidityModal doc={validityDoc} onClose={() => setValidityDoc(null)} onSaved={loadDocuments} />
+
+      <RejectModal doc={rejectDoc} onClose={() => setRejectDoc(null)} onRejected={loadDocuments} />
 
       {kbId && (
         <ChatImportWizard

--- a/kb-rag-web/src/pages/kb/components/FeedbackTab.tsx
+++ b/kb-rag-web/src/pages/kb/components/FeedbackTab.tsx
@@ -1,0 +1,259 @@
+// Author: owlzhangfq@gmail.com
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Form, Input, Modal, Popconfirm, Radio, Select, Space, Table, Tag, Tooltip, Typography, message } from 'antd';
+import { createEvalDataset, listEvalDatasets } from '../../../api/evalDataset';
+import {
+  convertRetrievalFeedback,
+  dismissRetrievalFeedback,
+  listRetrievalFeedback,
+} from '../../../api/retrievalFeedback';
+import type { EvalDataset, FeedbackStatus, FeedbackVerdict, RetrievalFeedbackEntry } from '../../../api/types';
+import { FEEDBACK_STATUS_META, FEEDBACK_VERDICT_META, metaOf } from '../../../utils/statusMeta';
+
+interface FeedbackTabProps {
+  kbId: string;
+}
+
+type TargetMode = 'existing' | 'new';
+
+interface ConvertFormValues {
+  target_mode: TargetMode;
+  dataset_id?: string;
+  new_dataset_name?: string;
+}
+
+const PAGE_SIZE = 20;
+
+/**
+ * 反馈管理 tab of the KB detail page (M10-CONTRACTS.md section 3): lists the persisted good/bad
+ * verdicts the debug page submitted, with a convert-to-eval-case action for GOOD rows (dataset
+ * picker modelled on the debug page's CollectToEvalModal) and a dismiss action. Both actions are
+ * terminal server-side, so the buttons only render while a row is still NEW.
+ */
+export default function FeedbackTab({ kbId }: FeedbackTabProps) {
+  const [items, setItems] = useState<RetrievalFeedbackEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [verdictFilter, setVerdictFilter] = useState<FeedbackVerdict | undefined>();
+  const [statusFilter, setStatusFilter] = useState<FeedbackStatus | undefined>();
+  // Row being converted; doubles as the modal's open flag.
+  const [converting, setConverting] = useState<RetrievalFeedbackEntry | null>(null);
+  const [datasets, setDatasets] = useState<EvalDataset[]>([]);
+  const [loadingDatasets, setLoadingDatasets] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form] = Form.useForm<ConvertFormValues>();
+  const targetMode = Form.useWatch('target_mode', form) ?? 'existing';
+
+  const load = useCallback(async (targetPage: number, verdict?: FeedbackVerdict, status?: FeedbackStatus) => {
+    setLoading(true);
+    try {
+      const result = await listRetrievalFeedback(kbId, {
+        verdict,
+        status,
+        page: targetPage,
+        size: PAGE_SIZE,
+      });
+      setItems(result.items);
+      setTotal(result.total);
+      setPage(targetPage);
+    } finally {
+      setLoading(false);
+    }
+  }, [kbId]);
+
+  useEffect(() => {
+    load(1, verdictFilter, statusFilter);
+  }, [load, verdictFilter, statusFilter]);
+
+  const openConvert = (row: RetrievalFeedbackEntry) => {
+    setConverting(row);
+    form.setFieldsValue({ target_mode: 'existing', dataset_id: undefined, new_dataset_name: undefined });
+    setLoadingDatasets(true);
+    listEvalDatasets(kbId)
+      .then((result) => {
+        setDatasets(result);
+        form.setFieldsValue({ target_mode: result.length > 0 ? 'existing' : 'new' });
+      })
+      .finally(() => setLoadingDatasets(false));
+  };
+
+  const handleConvert = async () => {
+    if (!converting) return;
+    const values = await form.validateFields();
+    setSubmitting(true);
+    try {
+      const datasetId =
+        values.target_mode === 'new'
+          ? (await createEvalDataset(kbId, { name: values.new_dataset_name! })).dataset_id
+          : values.dataset_id!;
+      await convertRetrievalFeedback(converting.feedback_id, { dataset_id: datasetId });
+      message.success('已转入评测集（case source=FEEDBACK）');
+      setConverting(null);
+      form.resetFields();
+      load(page, verdictFilter, statusFilter);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDismiss = async (row: RetrievalFeedbackEntry) => {
+    await dismissRetrievalFeedback(row.feedback_id);
+    message.success('已忽略该反馈');
+    load(page, verdictFilter, statusFilter);
+  };
+
+  return (
+    <>
+      <Space style={{ marginBottom: 16 }}>
+        <Select
+          allowClear
+          placeholder="好/坏筛选"
+          style={{ width: 140 }}
+          value={verdictFilter}
+          onChange={(value) => setVerdictFilter(value)}
+          options={[
+            { label: '好结果', value: 'GOOD' },
+            { label: '坏结果', value: 'BAD' },
+          ]}
+        />
+        <Select
+          allowClear
+          placeholder="状态筛选"
+          style={{ width: 140 }}
+          value={statusFilter}
+          onChange={(value) => setStatusFilter(value)}
+          options={[
+            { label: '待处理', value: 'NEW' },
+            { label: '已转评测集', value: 'CONVERTED' },
+            { label: '已忽略', value: 'DISMISSED' },
+          ]}
+        />
+        <Button onClick={() => load(page, verdictFilter, statusFilter)}>刷新</Button>
+      </Space>
+
+      <Table<RetrievalFeedbackEntry>
+        rowKey="feedback_id"
+        loading={loading}
+        dataSource={items}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (nextPage) => load(nextPage, verdictFilter, statusFilter),
+        }}
+        columns={[
+          {
+            title: '检索问题',
+            dataIndex: 'query',
+            ellipsis: { showTitle: false },
+            render: (query: string) => (
+              <Tooltip title={query} placement="topLeft">
+                {query}
+              </Tooltip>
+            ),
+          },
+          {
+            title: '判定',
+            dataIndex: 'verdict',
+            width: 100,
+            render: (verdict: FeedbackVerdict) => {
+              const meta = metaOf(FEEDBACK_VERDICT_META, verdict);
+              return <Tag color={meta.color}>{meta.label}</Tag>;
+            },
+          },
+          {
+            title: '状态',
+            dataIndex: 'status',
+            width: 120,
+            render: (status: FeedbackStatus, record) => {
+              const meta = metaOf(FEEDBACK_STATUS_META, status);
+              const tag = <Tag color={meta.color}>{meta.label}</Tag>;
+              return record.converted_case_id ? (
+                <Tooltip title={`case: ${record.converted_case_id}`}>{tag}</Tooltip>
+              ) : (
+                tag
+              );
+            },
+          },
+          {
+            title: '来源分片',
+            dataIndex: 'chunk_id',
+            width: 220,
+            render: (chunkId: string, record) => (
+              <Typography.Text type={record.doc_id ? undefined : 'secondary'} copyable={{ text: chunkId }}>
+                {record.doc_id ? chunkId : `${chunkId}（原文档已删除）`}
+              </Typography.Text>
+            ),
+          },
+          { title: '提交时间', dataIndex: 'created_at', width: 180 },
+          {
+            title: '操作',
+            width: 200,
+            render: (_, record) =>
+              record.status === 'NEW' ? (
+                <Space>
+                  {record.verdict === 'GOOD' && (
+                    <Button size="small" type="link" onClick={() => openConvert(record)}>
+                      转入评测集
+                    </Button>
+                  )}
+                  <Popconfirm
+                    title="忽略该反馈？"
+                    description="忽略后不可恢复，该反馈将不再出现在待处理列表"
+                    okText="忽略"
+                    cancelText="取消"
+                    onConfirm={() => handleDismiss(record)}
+                  >
+                    <Button size="small" type="link" danger>
+                      忽略
+                    </Button>
+                  </Popconfirm>
+                </Space>
+              ) : null,
+          },
+        ]}
+      />
+
+      <Modal
+        title="转入评测集"
+        open={converting !== null}
+        onOk={handleConvert}
+        onCancel={() => setConverting(null)}
+        confirmLoading={submitting}
+        okText="转入"
+        cancelText="取消"
+        destroyOnClose
+      >
+        <Typography.Paragraph type="secondary">
+          将该条好结果反馈（query + 命中分片）转成一条评测 case（source=FEEDBACK），反馈状态随之变为「已转评测集」。
+        </Typography.Paragraph>
+        <Form<ConvertFormValues> form={form} layout="vertical">
+          <Form.Item name="target_mode" label="目标评测集">
+            <Radio.Group>
+              <Radio value="existing" disabled={datasets.length === 0}>
+                选择已有评测集
+              </Radio>
+              <Radio value="new">新建评测集</Radio>
+            </Radio.Group>
+          </Form.Item>
+          {targetMode === 'existing' ? (
+            <Form.Item name="dataset_id" rules={[{ required: true, message: '请选择评测集' }]}>
+              <Select
+                loading={loadingDatasets}
+                placeholder={datasets.length === 0 ? '该知识库暂无评测集，请先新建' : '请选择评测集'}
+                options={datasets.map((dataset) => ({ label: dataset.name, value: dataset.dataset_id }))}
+              />
+            </Form.Item>
+          ) : (
+            <Form.Item name="new_dataset_name" rules={[{ required: true, message: '请输入新评测集名称' }]}>
+              <Input placeholder="新评测集名称" maxLength={64} />
+            </Form.Item>
+          )}
+        </Form>
+      </Modal>
+    </>
+  );
+}

--- a/kb-rag-web/src/pages/kb/components/GovernanceModals.tsx
+++ b/kb-rag-web/src/pages/kb/components/GovernanceModals.tsx
@@ -1,0 +1,159 @@
+// Author: owlzhangfq@gmail.com
+import { useEffect, useState } from 'react';
+import { DatePicker, Form, Input, Modal, Typography, message } from 'antd';
+import dayjs, { type Dayjs } from 'dayjs';
+import { rejectDocument, updateDocumentValidity } from '../../../api/document';
+import type { KbDocument } from '../../../api/types';
+
+// Matches the zone-less ISO literal the governance endpoints parse server-side
+// (LocalDateTime.parse); Dayjs#toISOString's trailing Z would be rejected.
+const TIME_PARAM_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
+interface ValidityModalProps {
+  /** Document being edited; doubles as the modal's open flag. */
+  doc: KbDocument | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+interface ValidityFormValues {
+  effective_at?: Dayjs | null;
+  expires_at?: Dayjs | null;
+}
+
+/**
+ * 有效期设置 modal (M11-CONTRACTS.md section 2.2): both bounds optional, null = unbounded. An
+ * expires_at in the past is deliberately allowed -- it is how "take this document offline right
+ * now" works -- so no disabledDate guard on either picker.
+ */
+export function ValidityModal({ doc, onClose, onSaved }: ValidityModalProps) {
+  const [form] = Form.useForm<ValidityFormValues>();
+  const [submitting, setSubmitting] = useState(false);
+
+  // Re-seed the pickers from the row every time the modal opens for a different document.
+  useEffect(() => {
+    if (doc) {
+      form.setFieldsValue({
+        effective_at: doc.effective_at ? dayjs(doc.effective_at) : null,
+        expires_at: doc.expires_at ? dayjs(doc.expires_at) : null,
+      });
+    }
+  }, [doc, form]);
+
+  const handleOk = async () => {
+    if (!doc) return;
+    const values = await form.validateFields();
+    setSubmitting(true);
+    try {
+      await updateDocumentValidity(
+        doc.doc_id,
+        values.effective_at ? values.effective_at.format(TIME_PARAM_FORMAT) : null,
+        values.expires_at ? values.expires_at.format(TIME_PARAM_FORMAT) : null,
+      );
+      message.success('有效期已更新');
+      onClose();
+      onSaved();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={`设置有效期${doc ? ` - ${doc.file_name}` : ''}`}
+      open={doc !== null}
+      onOk={handleOk}
+      onCancel={onClose}
+      confirmLoading={submitting}
+      okText="保存"
+      cancelText="取消"
+      destroyOnClose
+    >
+      <Typography.Paragraph type="secondary">
+        仅在有效期窗口内的文档参与检索。两端均可留空表示不设界；将「失效时间」设为过去可立即下架。
+      </Typography.Paragraph>
+      <Form<ValidityFormValues> form={form} layout="vertical">
+        <Form.Item name="effective_at" label="生效时间（留空 = 立即生效）">
+          <DatePicker showTime style={{ width: '100%' }} placeholder="不设生效下界" />
+        </Form.Item>
+        <Form.Item
+          name="expires_at"
+          label="失效时间（留空 = 永久有效）"
+          dependencies={['effective_at']}
+          rules={[
+            ({ getFieldValue }) => ({
+              validator(_, value: Dayjs | null | undefined) {
+                const effective = getFieldValue('effective_at') as Dayjs | null | undefined;
+                if (value && effective && !value.isAfter(effective)) {
+                  return Promise.reject(new Error('失效时间必须晚于生效时间'));
+                }
+                return Promise.resolve();
+              },
+            }),
+          ]}
+        >
+          <DatePicker showTime style={{ width: '100%' }} placeholder="不设失效上界" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}
+
+interface RejectModalProps {
+  /** Document being rejected; doubles as the modal's open flag. */
+  doc: KbDocument | null;
+  onClose: () => void;
+  onRejected: () => void;
+}
+
+interface RejectFormValues {
+  note: string;
+}
+
+/** 驳回 modal: the note is mandatory (server rejects a blank one) and lands in review_note. */
+export function RejectModal({ doc, onClose, onRejected }: RejectModalProps) {
+  const [form] = Form.useForm<RejectFormValues>();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleOk = async () => {
+    if (!doc) return;
+    const values = await form.validateFields();
+    setSubmitting(true);
+    try {
+      await rejectDocument(doc.doc_id, values.note.trim());
+      message.success('已驳回，作者可修改后重新提交审核');
+      form.resetFields();
+      onClose();
+      onRejected();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={`驳回文档${doc ? ` - ${doc.file_name}` : ''}`}
+      open={doc !== null}
+      onOk={handleOk}
+      onCancel={() => {
+        form.resetFields();
+        onClose();
+      }}
+      confirmLoading={submitting}
+      okText="驳回"
+      okButtonProps={{ danger: true }}
+      cancelText="取消"
+      destroyOnClose
+    >
+      <Form<RejectFormValues> form={form} layout="vertical">
+        <Form.Item
+          name="note"
+          label="驳回原因"
+          rules={[{ required: true, whitespace: true, message: '请填写驳回原因' }]}
+        >
+          <Input.TextArea rows={4} maxLength={512} showCount placeholder="说明需要修改的内容，将展示给文档提交人" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/kb-rag-web/src/pages/kb/components/InsightTab.tsx
+++ b/kb-rag-web/src/pages/kb/components/InsightTab.tsx
@@ -1,0 +1,200 @@
+// Author: owlzhangfq@gmail.com
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Card, Col, DatePicker, Row, Select, Space, Statistic, Table, Tag, Typography } from 'antd';
+import type { Dayjs } from 'dayjs';
+import { getSearchInsightStats, listSearchInsights } from '../../../api/searchInsight';
+import type { SearchInsightEntry, SearchInsightSource, SearchInsightStats, TopZeroHitQuery } from '../../../api/types';
+import { SEARCH_INSIGHT_SOURCE_META, metaOf } from '../../../utils/statusMeta';
+
+interface InsightTabProps {
+  kbId: string;
+}
+
+const PAGE_SIZE = 20;
+
+// The backend binds from/to with LocalDateTime.parse, which rejects a trailing zone designator,
+// so the pickers are serialized as zone-less ISO literals instead of Dayjs#toISOString's ...Z form.
+const TIME_PARAM_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
+/**
+ * 检索洞察 tab of the KB detail page (M10-CONTRACTS.md section 3): the content-gap report
+ * (totals / zero-hit rate / degraded count / Top zero-hit query groups) over a picked time
+ * window, plus the paged insight detail listing with a zero-hit filter. Only masked digests are
+ * shown -- the raw queries are never stored server-side for this table.
+ */
+export default function InsightTab({ kbId }: InsightTabProps) {
+  const [stats, setStats] = useState<SearchInsightStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const [items, setItems] = useState<SearchInsightEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [listLoading, setListLoading] = useState(false);
+  const [zeroHitFilter, setZeroHitFilter] = useState<boolean | undefined>();
+  const [timeRange, setTimeRange] = useState<[Dayjs | null, Dayjs | null] | null>(null);
+
+  const from = timeRange?.[0]?.format(TIME_PARAM_FORMAT);
+  const to = timeRange?.[1]?.format(TIME_PARAM_FORMAT);
+
+  const loadStats = useCallback(async (fromParam?: string, toParam?: string) => {
+    setStatsLoading(true);
+    try {
+      setStats(await getSearchInsightStats(kbId, { from: fromParam, to: toParam }));
+    } finally {
+      setStatsLoading(false);
+    }
+  }, [kbId]);
+
+  const loadList = useCallback(
+    async (targetPage: number, zeroHit?: boolean, fromParam?: string, toParam?: string) => {
+      setListLoading(true);
+      try {
+        const result = await listSearchInsights(kbId, {
+          zero_hit: zeroHit,
+          from: fromParam,
+          to: toParam,
+          page: targetPage,
+          size: PAGE_SIZE,
+        });
+        setItems(result.items);
+        setTotal(result.total);
+        setPage(targetPage);
+      } finally {
+        setListLoading(false);
+      }
+    },
+    [kbId],
+  );
+
+  useEffect(() => {
+    loadStats(from, to);
+  }, [loadStats, from, to]);
+
+  useEffect(() => {
+    loadList(1, zeroHitFilter, from, to);
+  }, [loadList, zeroHitFilter, from, to]);
+
+  return (
+    <>
+      <Space style={{ marginBottom: 16 }} wrap>
+        <DatePicker.RangePicker
+          showTime
+          value={timeRange}
+          onChange={(range) => setTimeRange(range)}
+          placeholder={['开始时间', '结束时间']}
+        />
+        <Select
+          allowClear
+          placeholder="命中筛选"
+          style={{ width: 140 }}
+          value={zeroHitFilter}
+          onChange={(value) => setZeroHitFilter(value)}
+          options={[
+            { label: '仅零命中', value: true },
+            { label: '仅有命中', value: false },
+          ]}
+        />
+        <Button
+          onClick={() => {
+            loadStats(from, to);
+            loadList(page, zeroHitFilter, from, to);
+          }}
+        >
+          刷新
+        </Button>
+        <Typography.Text type="secondary">统计默认最近 7 天，可通过时间范围调整</Typography.Text>
+      </Space>
+
+      <Row gutter={16} style={{ marginBottom: 16 }}>
+        <Col span={6}>
+          <Card size="small" loading={statsLoading}>
+            <Statistic title="总检索次数" value={stats?.total ?? 0} />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card size="small" loading={statsLoading}>
+            <Statistic
+              title="零命中率"
+              value={(stats?.zero_hit_rate ?? 0) * 100}
+              precision={1}
+              suffix="%"
+              valueStyle={(stats?.zero_hit_rate ?? 0) > 0.2 ? { color: '#cf1322' } : undefined}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card size="small" loading={statsLoading}>
+            <Statistic title="零命中次数" value={stats?.zero_hit_count ?? 0} />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card size="small" loading={statsLoading}>
+            <Statistic title="降级次数" value={stats?.degraded_count ?? 0} />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card size="small" title="Top 未命中问题（按归一化后的相同问题分组）" style={{ marginBottom: 16 }}>
+        <Table<TopZeroHitQuery>
+          rowKey="query_digest"
+          size="small"
+          loading={statsLoading}
+          dataSource={stats?.top_zero_hit_queries ?? []}
+          pagination={false}
+          locale={{ emptyText: '时间窗口内没有零命中检索' }}
+          columns={[
+            { title: '问题摘要（已脱敏）', dataIndex: 'query_digest' },
+            { title: '未命中次数', dataIndex: 'count', width: 120 },
+            { title: '最近发生', dataIndex: 'last_at', width: 200 },
+          ]}
+        />
+      </Card>
+
+      <Table<SearchInsightEntry>
+        rowKey="insight_id"
+        loading={listLoading}
+        dataSource={items}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (nextPage) => loadList(nextPage, zeroHitFilter, from, to),
+        }}
+        columns={[
+          { title: '问题摘要（已脱敏）', dataIndex: 'query_digest', ellipsis: true },
+          {
+            title: '来源',
+            dataIndex: 'source',
+            width: 120,
+            render: (source: SearchInsightSource) => {
+              const meta = metaOf(SEARCH_INSIGHT_SOURCE_META, source);
+              return <Tag color={meta.color}>{meta.label}</Tag>;
+            },
+          },
+          {
+            title: '命中数',
+            dataIndex: 'result_count',
+            width: 100,
+            render: (count: number, record) =>
+              record.zero_hit ? <Tag color="error">零命中</Tag> : count,
+          },
+          {
+            title: '最高分',
+            dataIndex: 'top_score',
+            width: 100,
+            render: (score: number | null) => (score == null ? '-' : score.toFixed(4)),
+          },
+          {
+            title: '降级',
+            dataIndex: 'degraded',
+            width: 180,
+            render: (degraded: string[]) =>
+              degraded.length === 0 ? '-' : degraded.map((item) => <Tag key={item}>{item}</Tag>),
+          },
+          { title: '时间', dataIndex: 'created_at', width: 180 },
+        ]}
+      />
+    </>
+  );
+}

--- a/kb-rag-web/src/pages/kb/components/TrashTab.tsx
+++ b/kb-rag-web/src/pages/kb/components/TrashTab.tsx
@@ -1,0 +1,144 @@
+// Author: owlzhangfq@gmail.com
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Popconfirm, Space, Table, Tooltip, Typography, message } from 'antd';
+import { listTrash, purgeDocument, restoreDocument } from '../../../api/document';
+import type { KbDocument } from '../../../api/types';
+import { formatFileSize } from '../../../utils/format';
+
+interface TrashTabProps {
+  kbId: string;
+  /** Fired after a successful restore so the parent can refresh the live document list. */
+  onRestored: () => void;
+}
+
+const PAGE_SIZE = 20;
+
+/**
+ * 回收站 tab of the KB detail page (M11-CONTRACTS.md section 2.2): lists trashed documents most
+ * recently trashed first, with restore (instant flag flip) and purge (irreversible, engine copies
+ * included). Purge sits behind a Popconfirm because it is the second half of the two-step delete
+ * the trash exists for -- the first DELETE already needed a confirmation on the documents tab.
+ */
+export default function TrashTab({ kbId, onRestored }: TrashTabProps) {
+  const [items, setItems] = useState<KbDocument[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  // doc_id of the row whose restore/purge request is in flight, to scope the button spinner.
+  const [actingId, setActingId] = useState<string | null>(null);
+
+  const load = useCallback(async (targetPage: number) => {
+    setLoading(true);
+    try {
+      const result = await listTrash(kbId, targetPage);
+      setItems(result.items);
+      setTotal(result.total);
+      setPage(targetPage);
+    } finally {
+      setLoading(false);
+    }
+  }, [kbId]);
+
+  useEffect(() => {
+    load(1);
+  }, [load]);
+
+  const handleRestore = async (row: KbDocument) => {
+    setActingId(row.doc_id);
+    try {
+      await restoreDocument(row.doc_id);
+      message.success(`已还原 ${row.file_name}`);
+      load(page);
+      onRestored();
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handlePurge = async (row: KbDocument) => {
+    setActingId(row.doc_id);
+    try {
+      await purgeDocument(row.doc_id);
+      message.success(`已彻底删除 ${row.file_name}`);
+      load(page);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  return (
+    <>
+      <Typography.Paragraph type="secondary">
+        回收站中的文档不参与检索，可随时还原；超过保留期后会被定时任务自动清除。
+      </Typography.Paragraph>
+
+      <Table<KbDocument>
+        rowKey="doc_id"
+        loading={loading}
+        dataSource={items}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (nextPage) => load(nextPage),
+        }}
+        columns={[
+          {
+            title: '文件名',
+            dataIndex: 'file_name',
+            ellipsis: { showTitle: false },
+            render: (name: string) => (
+              <Tooltip title={name} placement="topLeft">
+                {name}
+              </Tooltip>
+            ),
+          },
+          { title: '类型', dataIndex: 'file_ext', width: 80 },
+          {
+            title: '大小',
+            dataIndex: 'file_size',
+            width: 100,
+            render: (size: number) => formatFileSize(size),
+          },
+          { title: '移入时间', dataIndex: 'trashed_at', width: 180 },
+          {
+            title: '操作',
+            width: 200,
+            render: (_, record) => (
+              <Space>
+                <Button
+                  size="small"
+                  type="link"
+                  loading={actingId === record.doc_id}
+                  onClick={() => handleRestore(record)}
+                >
+                  还原
+                </Button>
+                <Popconfirm
+                  title="彻底删除该文档？"
+                  description={
+                    <>
+                      将连同它的<b>全部版本与分片</b>一并删除（含两个检索引擎中的副本），
+                      <br />
+                      删除后不可恢复，如需重新入库须重新上传。
+                    </>
+                  }
+                  okText="彻底删除"
+                  okButtonProps={{ danger: true }}
+                  cancelText="取消"
+                  onConfirm={() => handlePurge(record)}
+                >
+                  <Button size="small" type="link" danger loading={actingId === record.doc_id}>
+                    彻底删除
+                  </Button>
+                </Popconfirm>
+              </Space>
+            ),
+          },
+        ]}
+      />
+    </>
+  );
+}

--- a/kb-rag-web/src/pages/kb/components/WebSourcesTab.tsx
+++ b/kb-rag-web/src/pages/kb/components/WebSourcesTab.tsx
@@ -1,0 +1,249 @@
+// Author: owlzhangfq@gmail.com
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Form, Input, Popconfirm, Space, Switch, Table, Tag, Tooltip, Typography, message } from 'antd';
+import {
+  listWebSources,
+  registerWebSource,
+  removeWebSource,
+  syncWebSource,
+  updateWebSource,
+} from '../../../api/webSource';
+import type { WebSourceEntry, WebSourceFetchStatus } from '../../../api/types';
+import { WEB_SOURCE_STATUS_META, metaOf } from '../../../utils/statusMeta';
+
+interface WebSourcesTabProps {
+  kbId: string;
+  /** Fired after a sync that may have created/updated a document, so the parent refreshes the list. */
+  onSynced: () => void;
+}
+
+const PAGE_SIZE = 20;
+
+/** Register + manual sync both write a fetch outcome onto the row; turn it into operator feedback. */
+function reportOutcome(entry: WebSourceEntry) {
+  switch (entry.last_fetch_status) {
+    case 'SUCCESS':
+      message.success(`已抓取并入库：${entry.file_name ?? entry.url}`);
+      break;
+    case 'UNCHANGED':
+      message.info('页面内容未变化，未生成新版本');
+      break;
+    case 'SKIPPED':
+      message.warning(entry.last_error ?? '绑定的文档在回收站中，本次同步已跳过');
+      break;
+    case 'FAILED':
+      message.error(`抓取失败：${entry.last_error ?? '未知原因'}`);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * 网页导入 tab of the KB detail page (M12-CONTRACTS.md section 3.4): register page URLs, watch
+ * each one's last sync outcome, trigger a sync by hand, flip the nightly-sync switch, remove the
+ * registration. The fetch outcome never surfaces as a request error -- register and manual sync
+ * always resolve and carry the outcome on the row, which is why every action re-reads the list.
+ */
+export default function WebSourcesTab({ kbId, onSynced }: WebSourcesTabProps) {
+  const [items, setItems] = useState<WebSourceEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [registering, setRegistering] = useState(false);
+  // source_id of the row whose sync/toggle/remove request is in flight, to scope the spinners.
+  const [actingId, setActingId] = useState<string | null>(null);
+  const [form] = Form.useForm<{ url: string }>();
+
+  const load = useCallback(async (targetPage: number) => {
+    setLoading(true);
+    try {
+      const result = await listWebSources(kbId, targetPage);
+      setItems(result.items);
+      setTotal(result.total);
+      setPage(targetPage);
+    } finally {
+      setLoading(false);
+    }
+  }, [kbId]);
+
+  useEffect(() => {
+    load(1);
+  }, [load]);
+
+  const handleRegister = async (values: { url: string }) => {
+    setRegistering(true);
+    try {
+      const entry = await registerWebSource(kbId, { url: values.url.trim() });
+      reportOutcome(entry);
+      form.resetFields();
+      load(1);
+      if (entry.last_fetch_status === 'SUCCESS') {
+        onSynced();
+      }
+    } finally {
+      setRegistering(false);
+    }
+  };
+
+  const handleSync = async (row: WebSourceEntry) => {
+    setActingId(row.source_id);
+    try {
+      const entry = await syncWebSource(row.source_id);
+      reportOutcome(entry);
+      load(page);
+      if (entry.last_fetch_status === 'SUCCESS') {
+        onSynced();
+      }
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleToggle = async (row: WebSourceEntry, enabled: boolean) => {
+    setActingId(row.source_id);
+    try {
+      await updateWebSource(row.source_id, enabled);
+      message.success(enabled ? '已开启定时同步' : '已关闭定时同步');
+      load(page);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleRemove = async (row: WebSourceEntry) => {
+    setActingId(row.source_id);
+    try {
+      await removeWebSource(row.source_id);
+      message.success('已移除登记，已入库的文档保持不变');
+      load(page);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  return (
+    <>
+      <Typography.Paragraph type="secondary">
+        登记网页地址后立即抓取入库；开启定时同步的地址会在每日定时任务中重新抓取，内容有变化时生成新版本。
+        移除登记不会删除已入库的文档。
+      </Typography.Paragraph>
+
+      <Form form={form} layout="inline" onFinish={handleRegister} style={{ marginBottom: 16 }}>
+        <Form.Item
+          name="url"
+          style={{ flex: 1, maxWidth: 560 }}
+          rules={[
+            { required: true, message: '请输入网页地址' },
+            { type: 'url', message: '请输入合法的 http/https 地址' },
+          ]}
+        >
+          <Input placeholder="https://example.com/docs/guide" allowClear />
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" htmlType="submit" loading={registering}>
+            登记并抓取
+          </Button>
+        </Form.Item>
+      </Form>
+
+      <Table<WebSourceEntry>
+        rowKey="source_id"
+        loading={loading}
+        dataSource={items}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (nextPage) => load(nextPage),
+        }}
+        columns={[
+          {
+            title: '网页地址',
+            dataIndex: 'url',
+            ellipsis: { showTitle: false },
+            render: (url: string) => (
+              <Tooltip title={url} placement="topLeft">
+                <a href={url} target="_blank" rel="noreferrer">
+                  {url}
+                </a>
+              </Tooltip>
+            ),
+          },
+          {
+            title: '绑定文档',
+            dataIndex: 'file_name',
+            width: 220,
+            ellipsis: { showTitle: false },
+            render: (name: string | null) =>
+              name ? (
+                <Tooltip title={name} placement="topLeft">
+                  {name}
+                </Tooltip>
+              ) : (
+                <Typography.Text type="secondary">未入库</Typography.Text>
+              ),
+          },
+          {
+            title: '定时同步',
+            dataIndex: 'sync_enabled',
+            width: 100,
+            render: (_, record) => (
+              <Switch
+                size="small"
+                checked={record.sync_enabled}
+                loading={actingId === record.source_id}
+                onChange={(checked) => handleToggle(record, checked)}
+              />
+            ),
+          },
+          {
+            title: '最近状态',
+            dataIndex: 'last_fetch_status',
+            width: 110,
+            render: (status: WebSourceFetchStatus | null, record) => {
+              if (!status) {
+                return <Tag>未抓取</Tag>;
+              }
+              const meta = metaOf(WEB_SOURCE_STATUS_META, status);
+              const tag = <Tag color={meta.color}>{meta.label}</Tag>;
+              // FAILED/SKIPPED keep the reason on the row; surface it without widening the table.
+              return record.last_error ? <Tooltip title={record.last_error}>{tag}</Tooltip> : tag;
+            },
+          },
+          { title: '最近抓取时间', dataIndex: 'last_fetch_at', width: 180 },
+          {
+            title: '操作',
+            width: 180,
+            render: (_, record) => (
+              <Space>
+                <Button
+                  size="small"
+                  type="link"
+                  loading={actingId === record.source_id}
+                  onClick={() => handleSync(record)}
+                >
+                  立即同步
+                </Button>
+                <Popconfirm
+                  title="移除该登记？"
+                  description="仅移除网页登记，已抓取入库的文档会保留在知识库中。"
+                  okText="移除"
+                  okButtonProps={{ danger: true }}
+                  cancelText="取消"
+                  onConfirm={() => handleRemove(record)}
+                >
+                  <Button size="small" type="link" danger loading={actingId === record.source_id}>
+                    移除登记
+                  </Button>
+                </Popconfirm>
+              </Space>
+            ),
+          },
+        ]}
+      />
+    </>
+  );
+}

--- a/kb-rag-web/src/pages/search/SearchPage.tsx
+++ b/kb-rag-web/src/pages/search/SearchPage.tsx
@@ -172,7 +172,8 @@ export default function SearchPage() {
       verdict,
     });
     setFeedbackByChunkId((prev) => ({ ...prev, [chunkId]: verdict }));
-    message.success(verdict === 'GOOD' ? '已标记为好结果' : '已标记为坏结果');
+    // M10-CONTRACTS.md section 3: BAD now lands as a manageable row, so tell the operator where it went.
+    message.success(verdict === 'GOOD' ? '已标记为好结果' : '已记录，可在知识库详情的反馈管理中查看');
   };
 
   const selectedNodes = result?.nodes.filter((node) => selectedChunkIds.includes(node.chunk_id)) ?? [];

--- a/kb-rag-web/src/utils/statusMeta.ts
+++ b/kb-rag-web/src/utils/statusMeta.ts
@@ -11,6 +11,8 @@ import type {
   DocumentVersionStatus,
   EmbeddingStatus,
   EvalMode,
+  FeedbackStatus,
+  FeedbackVerdict,
   FusionMode,
   GraphTaskStatus,
   IkDictStatus,
@@ -22,9 +24,11 @@ import type {
   RollbackMode,
   RunStatus,
   ScoreType,
+  SearchInsightSource,
   SourceMappingType,
   SplitStrategy,
   ThresholdAppliedOn,
+  WebSourceFetchStatus,
 } from '../api/types';
 
 /** Ant Design Tag color + Chinese label per process_status, single source of truth for the UI. */
@@ -167,11 +171,45 @@ export const CASE_STATUS_META: Record<CaseStatus, TagMeta> = {
   DEPRECATED: { color: 'default', label: '已废弃' },
 };
 
-/** t_kb_eval_case.source Tag meta (M4b-CONTRACTS.md section 1). */
+/** t_kb_eval_case.source Tag meta (M4b-CONTRACTS.md section 1; FEEDBACK added by M10-CONTRACTS.md section 2.1). */
 export const CASE_SOURCE_META: Record<CaseSource, TagMeta> = {
   MANUAL: { color: 'default', label: '手动标注' },
   DEBUG_PAGE: { color: 'processing', label: '检索调试收录' },
   IMPORTED: { color: 'cyan', label: '导入' },
+  FEEDBACK: { color: 'gold', label: '反馈转化' },
+};
+
+/** t_kb_retrieval_feedback.verdict Tag meta (M10-CONTRACTS.md section 2.1). */
+export const FEEDBACK_VERDICT_META: Record<FeedbackVerdict, TagMeta> = {
+  GOOD: { color: 'success', label: '好结果' },
+  BAD: { color: 'error', label: '坏结果' },
+};
+
+/**
+ * t_kb_retrieval_feedback.status Tag meta (M10-CONTRACTS.md section 2.1). CONVERTED and
+ * DISMISSED are both terminal server-side; the feedback tab keys its row actions off NEW only.
+ */
+export const FEEDBACK_STATUS_META: Record<FeedbackStatus, TagMeta> = {
+  NEW: { color: 'processing', label: '待处理' },
+  CONVERTED: { color: 'success', label: '已转评测集' },
+  DISMISSED: { color: 'default', label: '已忽略' },
+};
+
+/** t_kb_search_insight.source Tag meta (M10-CONTRACTS.md section 2.2). */
+export const SEARCH_INSIGHT_SOURCE_META: Record<SearchInsightSource, TagMeta> = {
+  CONSOLE: { color: 'processing', label: '控制台调试' },
+  OPEN_API: { color: 'purple', label: 'OpenAPI' },
+};
+
+/**
+ * t_kb_web_source.last_fetch_status Tag meta (M12-CONTRACTS.md section 3.4). UNCHANGED/SKIPPED
+ * are deliberate non-writes, not failures, hence the neutral colors.
+ */
+export const WEB_SOURCE_STATUS_META: Record<WebSourceFetchStatus, TagMeta> = {
+  SUCCESS: { color: 'success', label: '已入库' },
+  UNCHANGED: { color: 'default', label: '内容未变' },
+  SKIPPED: { color: 'warning', label: '已跳过' },
+  FAILED: { color: 'error', label: '失败' },
 };
 
 /** t_kb_eval_run.status Tag meta (M4b-CONTRACTS.md sections 1/3.1). */

--- a/自测步骤.md
+++ b/自测步骤.md
@@ -18,7 +18,7 @@ cd /AI/kb-rag/kb-rag-parser && .venv/bin/uvicorn app.main:app --host 127.0.0.1 -
 ```bash
 # 2. 启动主服务 server（终端 B）——关键：加载 .env 里的 Key
 cd /AI/kb-rag/kb-rag-deploy && set -a && source .env && set +a && \
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home && \
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.0.1.jdk/Contents/Home && \
 $JAVA_HOME/bin/java -jar ../kb-rag-server/kb-api/target/kb-rag-server.jar
 ```
 
@@ -66,7 +66,7 @@ docker compose -f docker-compose.lite.yml -f docker-compose.es-ik.yml up -d --bu
 然后：系统设置 → ik 词典 → 加一个文档里的专有词（如产品代号）→ 约 1 分钟后（ik 轮询词典）重建该库 → 用该词检索，BM25 命中应改善。
 
 ### E. 聊天记录过滤（metadata_filter，界面路径）
-检索调试页 → 过滤组：填会话 ID / 发送人 / 时间范围。当前库里没有聊天数据（M3 未开发），**预期填任意会话 ID 返回 0 条**——证明过滤在引擎侧真实生效。
+检索调试页 → 过滤组：填会话 ID / 发送人 / 时间范围。若库里没有聊天数据（未走过 M3/M8 聊天导入），**预期填任意会话 ID 返回 0 条**——证明过滤在引擎侧真实生效。
 
 ### F. 压测（M2 验收 6，命令行）
 ```bash


### PR DESCRIPTION
四个里程碑（M10-M13）的功能开发，外加一处 GraphRAG 抽取的缺陷修复。

## M10 检索质量闭环

检索结果的好/差反馈落库（`t_kb_retrieval_feedback`），查询洞察统计（`t_kb_search_insight`）沉淀零召回与低分查询。管理台新增「反馈」与「洞察」两个 tab，让检索质量问题从"用户抱怨"变成可统计的数据。

Flyway `V12__retrieval_feedback_and_search_insight.sql`。

## M11 内容治理

`t_kb_document` 新增 `publish_status` / `review_note` / `effective_at` / `expires_at` / `trashed` / `trashed_at`，支持审核发布、有效期与回收站。检索按发布态与有效期过滤，过期内容不再被召回。

Flyway `V13__document_governance.sql`。

## M12 数据接入：URL 导入与增量同步

新增 `t_kb_web_source`，URL 登记即抓，增量同步四态可见：`SUCCESS` / `UNCHANGED`（内容 hash 未变，不建版本）/ `SKIPPED`（绑定文档在回收站）/ `FAILED`。

**SSRF 防线收敛在一处** —— `kb-domain` 的 `UrlGuard` 领域服务：仅允许 http/https，拒绝内网、回环与链路本地地址；重定向由 `HttpWebPageFetcher` 手动跟随，避免跟随过程绕过校验。新增出站端口 `WebPageFetcher`。

Flyway `V14__web_source.sql`。

**一处需要留意的默认值变更**：`UPLOAD_ALLOWED_EXTENSIONS` 默认值新增 `html` —— 网页抓取产物走上传管线的前提。已显式配置过该变量的部署需要自行补上 `html`。

## M13 运维可观测

补齐 `micrometer-registry-prometheus`，激活既有 actuator 的 `/actuator/prometheus`，暴露知识库与任务积压两组业务指标。纯新增：无表变更、无新环境变量、无既有端点行为变化。该端点与 health 同口径暂不鉴权，生产由部署侧网络隔离。

## 修复：GraphRAG 抽取大面积跳过

界面显示「跳过 53 个分片（输出校验未通过）」，实测同一批 10 个真实分片：

| | 成功 | 抽出实体 | 抽出关系 |
| --- | --- | --- | --- |
| 修复前 | 1/10 | 5 | 4 |
| 修复后 | **10/10** | **123** | **32** |

两个成因叠加，只修其一无效（只修 ① 时成功率仍是 1/10，9 个截断转为 9 个端点越界）。

### ① Token 预算错配

抽取走 `chatProvider.complete()`，用的是 `kb.chat.max-tokens=128` —— 而 `application.yml` 的注释自己就写明这个值是为「一行 query 改写」设计的（当初开放 chat 端点就因此单独加了 `answer-max-tokens=1024`，图抽取被漏掉）。

抽取要输出整段的实体关系 JSON，128 tokens 直接截断在半句。实测 10 个分片有 9 个 `finish_reason=length`、正好打满 128，JSON 断在 `'},{"name":"资金方","type":"机构"}],"relations":[{"'` 这种位置，parser 只能拒绝。

**更麻烦的是 `/healthz` 式的假象**：模型答得好好的，是系统自己把它截断的，界面却报「输出校验未通过」，指向完全错误的方向。

修法：新增 `kb.graph.extract-max-tokens`（默认 2048）与专用 bean `graphExtractionChatProvider`，沿用 `judgeChatProvider` 的既有模式（复制 chat 配置、仅替换所需项）。`GraphExtractionService` 改显式构造函数 + `@Qualifier` —— 与 `EvalJudgeService` 一致，因为没有 lombok.config 的 copyableAnnotations，Lombok 传不了注解。

### ② 惩罚过重

`GraphExtractionParser` 里，一条关系端点越界就 `return null` 让整个答案作废，同段抽对的十几个实体一并陪葬。

而**同一个循环里**，缺 `source`/`target` 的关系本就是 `continue` 跳过的：

```java
if (source == null || target == null) {
    continue;        // 缺字段：跳过这一条
}
if (!entities.containsKey(source) || !entities.containsKey(target)) {
    return null;     // 端点越界：整个答案作废
}
```

两者同为「这条关系不可用」，没有理由区别对待。改为丢弃该关系、保留其余 —— 设计目标「图里不长出没有抽取依据的节点」，跳过越界关系即已达成。

### 顺带：补上静默失败的日志

`GraphExtractionParser` 有三个 `return null` 分支不打任何日志，而截断恰好落在「找不到 JSON 边界」那一条 —— 日志里搜不到任何线索，这是排查困难的直接原因。现补上拒绝原因与长度。

## 验证

- 全量单测 **921 个通过**（kb-domain 357 / kb-app 540 / kb-api 12 / kb-infrastructure 12），`BUILD SUCCESS`
- GraphRAG 修复用真实分片调用真实模型验证，数据见上表
- `GraphExtractionParserTest` 更新了断言旧「整体拒绝」语义的用例，改为断言「丢坏关系、保留其余」

## 升级说明

三个 Flyway 迁移（V12/V13/V14）自动执行。`GRAPH_EXTRACT_MAX_TOKENS` 有默认值 2048，`.env` 不改也生效；已启用 GraphRAG 的部署重启后重新抽取，此前被跳过的分片会被重新处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
