### PR TITLE
feat(m14): 三期第一批——连接器、元数据抽取、切分扩展、混合重排、多模态索引与以图搜图

### DIFF
--- a/docs/知识库需求文档.md
+++ b/docs/知识库需求文档.md
@@ -1,9 +1,9 @@
 # 企业级 RAG 知识库系统 · 需求文档
 
-> 版本：v1.16
+> 版本：v1.17
 > 日期：2026-07-29
 > 作者：RichardFyoung / Claude
-> 状态：一期（M1–M7）与二期（M8–M13）均已开发完成，本文档与当前分支（feature/kb-core-enhancements）代码实测对齐
+> 状态：一期（M1–M7）与二期（M8–M13）均已开发完成并与代码实测对齐；三期第一批（M14，§4.13）契约已定稿、开发进行中（feature/m14 分支），M14 条款为契约先行稿
 > 维护说明：本文件为 monorepo `docs/` 下的需求文档；对外发布事实源为 `kb-rag-deploy/docs/知识库需求文档.md`（当前停留在 v1.15，尚未回补 M10-M13——合并本分支 PR 时须将 v1.16 内容同步过去，遵守"实现偏离须在同一 PR 内修订仓库内文档"铁律）
 > 变更记录：
 >
@@ -23,6 +23,7 @@
 > - v1.14（二期第一批 M8 完成后的文档回补）：①聊天记录格式范围（§4.2）TXT/HTML 转正实现——内置留痕/微信 PC 行模板与留痕 DOM 选择器模板按公开约定编写、随映射档案界面可配，**真实导出样例仍未到位，模板待样例校准**；②PaddleOCR 本地 OCR 兜底转正（§8）：parser 可选依赖 + OCR_ENGINE 开关，VLM→本地 OCR→跳过三级次序；③聊天聚合重叠滑窗转正（§4.2）：window_overlap 知识库级参数（默认 0 兼容既有顺切）+ 检索侧近重复归并；④字段映射维护界面转正（§4.2/§6）：t_kb_source_mapping 于 M8 建表（V9）并种子化内置模板、提供 CRUD 与复制。详见 `kb-rag-deploy/docs/M8-CONTRACTS.md`
 > - v1.15（二期收官批 M9 完成后的文档回补）：①父片禁用子片精确剔除转正（§4.5）——t_kb_chunk 落 parent_start_offset/parent_end_offset，剔除以固定省略标记替换、任一禁用子片无偏移则整片回退；②标注相似度辅助迁移转正（§4.5）——对称 Dice（字符 3-gram），候选=同文档当前激活版本分片 top3 阈值 0.35 可配；只推荐+人工逐条确认，不自动迁移不批量；③图片 query 转正（§4.8）——search/chat/chat-preview 增可选 images（仅 base64 防 SSRF，≤3 张/单张 5MB/总 10MB），VLM 转文本以「[图片内容] 」前缀拼 query 尾部且在改写之前；degraded 枚举补 `image_understanding_unavailable`。详见 `kb-rag-deploy/docs/M9-CONTRACTS.md`
 > - v1.16（二期第二批 M10-M13 完成后的文档回补，落实"代码与文档完全一致"规则）：①**检索质量闭环**（M10，§4.5/§4.10/§6/§7）——检索结果好/坏反馈由"仅日志"升级为落库管理（NEW→CONVERTED/DISMISSED 状态机；GOOD 可转评测 case，source=FEEDBACK；BAD 不可转，价值在洞察统计）；新增**检索洞察**：管理台与开放 API 检索边界异步落洞察行（query 摘要脱敏截断、query_hash 归一化分组、zero_hit/degraded），聚合"内容缺口报表"（零命中率、Top 未命中 query），评测/门禁离线跑不落洞察，保留期默认 90 天直接删；②**内容治理**（M11，§4.11/§6/§7）——文档审核发布（KB 级 review_required 开关 + DRAFT→PENDING_REVIEW→PUBLISHED/REJECTED 状态机）、文档有效期时间窗、回收站（DELETE 语义升级为可恢复移入，超期定时彻底清除，另设 purge 端点）；治理三态收敛为检索门控（ActiveVersionResolver）单点行过滤，不写任何状态进引擎；已发布快照冻结语料不受治理回溯；③**URL 导入与增量同步**（M12，§4.12/§6/§7）——登记网页 URL→抓取→复用既有上传链路入库（不新增入库旁路），content_hash 未变不产生新版本；新建 SSRF 防线（UrlGuard + 重定向逐跳重验 + 限时限体积）；parser 新增 html 通用解析器并解锁 .html 直接上传；④**Prometheus 业务指标**（M13，§5）——/actuator/prometheus 激活，kb.search / kb.task.completed / kb.task.backlog / kb.openapi.rejected / kb.websource.sync 五支业务指标，拒绝 per-KB/per-key 无界基数标签；⑤正文同步 v1.14/v1.15 已宣告的转正项（§4.2/§4.5/§4.8/§8），并修复图谱抽取输出被 LLM max_tokens 截断的问题；⑥新增 D17 演进优先级决策（§2）、§10 二期里程碑表（M8-M13 全部交付）、§13 未完成功能与后续规划。详见 `kb-rag-deploy/docs/M10-CONTRACTS.md` ~ `M13-CONTRACTS.md`
+> - v1.17（三期第一批 M14 契约先行稿——开发进行中，实现完成后回补核实）：竞品（阿里云百炼知识库）能力对齐批次，六特性单分支 feature/m14 一次交付（§4.13）：①**外部数据源连接器**——连接器 SPI + S3/OSS 兼容对象存储首个实现（MinIO 可本地自测），ETag 增量同步，复用既有上传链路不新增入库旁路；②**配置化元数据抽取**——KB 级 metadata_rules（常量/正则/词表三类），引擎侧 ext_ 前缀镜像，检索 custom 等值过滤；③**切分策略扩展**——补齐 §4.3 策略清单的 separator/heading/page 三项；④**Rerank 混合模式**——rerank_mode=hybrid 语义重排分与归一化 BM25 分线性加权，阈值语义不变；⑤**视觉理解整页索引**——KB 级 multimodal_enabled，DashScope multimodal-embedding-v1，IMAGE chunk 额外产多模态向量，检索新增第三召回路（RRF）；⑥**以图搜图入口**——管理台检索增 images 入参，mm 可用直查多模态空间、否则回落 VLM 转写。degraded 枚举补 `mm_route_skipped`/`mm_route_unavailable`（§4.8）；Flyway V15（t_kb_ext_source / t_kb_ext_source_item）。详见 `kb-rag-deploy/docs/M14-CONTRACTS.md`
 
 ---
 
@@ -152,9 +153,9 @@
 - **分片方式**（策略插件化设计——新增切分策略只需新增一个策略实现类）：
   1. **智能切分**（默认）—— 实现定义：embedding 语义切分 + 结构规则混合。文档按句切开逐句嵌入，在相邻句相似度骤降处切分，同时融合结构信号（标题层级、段落边界）修正切点；可调参数：相似度骤降阈值、最小/最大分段长度。完全可重复，评测可回归，成本仅为 embedding 费用
   2. 按长度切分（固定长度 + 重叠，最大分段长度 10-6000 token 滑杆配置）
-  3. 按页切分
-  4. 按标题层级切分
-  5. 按正则切分（v1.6 合并——分隔符切分是正则的退化情形，界面提供"常用分隔符"快捷填充模板）
+  3. 按页切分（M14 落地 `page` 策略——按解析产物 pages[] 边界切分，见 §4.13）
+  4. 按标题层级切分（M14 落地 `heading` 策略——markdown 标题层级 1-6 可配，见 §4.13）
+  5. 按正则切分（v1.6 合并——分隔符切分是正则的退化情形，界面提供"常用分隔符"快捷填充模板；M14 落地 `separator` 策略——字面量/正则分隔符，见 §4.13）
   6. **表格行级切分**：Excel/CSV 专用，按行成片 + 表头拼装开关，受 §4.2 单文档分片数上限保护
   7. **LLM 语义切分**（M4b 落地，适用无结构长文）—— 实现约束：LLM **只输出切分点**（句子编号/行号），原文由代码按位置切，内容零改写；temperature=0 + 切分结果落库缓存（**缓存 key 含切分模型标识与提示词版本**）；超长文档滑动窗口分批判定，窗口间重叠区对齐切点；切分时顺带产出每个 chunk 的标题/摘要/关键词写入 metadata；定位：a) 无结构文本的最优切法；b) 评测中的"质量天花板"基准
 - 切分策略为**知识库级默认值**，同时支持**按文件格式覆盖**：格式→策略映射表界面可配；xlsx/xls/csv 默认强制走表格行级切分，图片类默认走独立分片规则（§4.2），其余格式走库级默认策略；用评测数据（§4.6）驱动选择
@@ -246,7 +247,7 @@
 ### 4.8 开放 API
 - **REST API**（对外，API Key 鉴权，形态参照百炼）：
   - `POST /api/v1/knowledge/search`：入参 query、app_id、**app_version（可选，缺省路由到当前正式版；显式传参可调用测试版做灰度验证，审计标记 target_stage=beta）**、messages（可选，多轮对话历史数组，服务端据此做多轮改写——API 保持无状态）、max_content_length（可选）、**images（可选，M9 转正——仅 base64 防 SSRF，≤3 张/单张 5MB/总 10MB；VLM 转文本以「[图片内容] 」前缀拼 query 尾部且在改写之前；纯图无文本且理解失败报 INVALID_PARAM）**、可选 metadata_filter/参数覆盖（**仅限白名单**，见 §5 配置分层）；出参 nodes + request_id + **degraded 数组**（空数组表示无降级）
-  - **degraded 枚举**（历次扩充后全集）：`query_rewrite_timeout` / `query_rewrite_error` / `query_rewrite_unavailable` / `rerank_timeout` / `rerank_error` / `rerank_unavailable` / `vector_route_unavailable`（零 Key 或嵌入不可用，退化 BM25 单路）/ `route_fallback_all`（路由白名单未命中，回退检索全部关联库）/ `threshold_inactive`（阈值因量纲不可比而未生效）/ `snapshot_index_missing`（v1.12：正式版调用发现其索引快照缺失，回退实时别名与当前激活集合）/ `graph_route_unavailable`（v1.13：知识库开启图路但 Neo4j 未配置或不可达，图路跳过）/ `image_understanding_unavailable`（v1.15：带图调用但视觉模型未配置/失败/超时，忽略全部图片仅文本检索）。**degraded 非空时 node.score_type 必须同步反映实际作用的分数类型**
+  - **degraded 枚举**（历次扩充后全集）：`query_rewrite_timeout` / `query_rewrite_error` / `query_rewrite_unavailable` / `rerank_timeout` / `rerank_error` / `rerank_unavailable` / `vector_route_unavailable`（零 Key 或嵌入不可用，退化 BM25 单路）/ `route_fallback_all`（路由白名单未命中，回退检索全部关联库）/ `threshold_inactive`（阈值因量纲不可比而未生效）/ `snapshot_index_missing`（v1.12：正式版调用发现其索引快照缺失，回退实时别名与当前激活集合）/ `graph_route_unavailable`（v1.13：知识库开启图路但 Neo4j 未配置或不可达，图路跳过）/ `image_understanding_unavailable`（v1.15：带图调用但视觉模型未配置/失败/超时，忽略全部图片仅文本检索）/ `mm_route_skipped`、`mm_route_unavailable`（v1.17/M14 开发中：多模态第三召回路——weighted 融合模式下不参与跳过 / provider 失败或超时跳过，主路均不受影响，见 §4.13）。**degraded 非空时 node.score_type 必须同步反映实际作用的分数类型**
   - **score 上报语义**（v1.9）：传阈值时报被过滤的那个分（rerank 分或标准 cosine 分）；未传阈值时报排序所用的分（双路为 `fused_rrf`/`fused_weighted`，BM25 单路为原始 `bm25_rank` 分）；各路原始分、归一化分、融合分、rerank 分全量放 node.metadata
   - **统一检索结果结构 RetrievalNode**（v1.6 补）：search 的 `nodes` 与 chat 的 `references` **同构复用同一 schema**，在 OpenAPI 中定义为共享组件：
     `{doc_id, document_version_id, chunk_id, chunk_type(text|image|chat_log), content, score, score_type, retrieval_source(vector|bm25|graph), metadata, image_urls[], preview_url}`
@@ -317,6 +318,18 @@
 - **界面**：知识库详情新增 **网页来源** tab——URL 输入 + "添加并抓取"、列表（URL/最近抓取/结果 Tag 含失败原因 Tooltip/自动同步 Switch）、行操作（立即同步、移除登记——文案明确"仅移除登记，已入库文档不受影响"）
 - **本期不做**（见 §13.1）：站点级爬取/多页递归、JS 渲染页面（SPA）、登录态/Cookie 抓取、RSS/API 等其他数据源
 
+### 4.13 三期第一批：连接器 / 元数据抽取 / 切分扩展 / 混合重排 / 多模态索引 / 以图搜图（M14，v1.17 契约先行稿，开发中）
+
+> 竞品（阿里云百炼知识库）能力对齐批次，六特性单分支 `feature/m14` 一次交付，开发顺序 F1→F6（F6 依赖 F5）。兼容红线：纯新增表/端点/配置键，全部新 JSON 配置字段缺省即现状、存量行为零变化。音视频、计费、RBAC（D17）照旧排除。契约详情见 `kb-rag-deploy/docs/M14-CONTRACTS.md`。
+
+- **F1 外部数据源连接器（S3/OSS）**：连接器 SPI（`ExternalConnector`：type/listObjects/fetchObject/testConnection，`ConnectorRouter` 按 source_type 路由，未知类型拒不回落）+ 首个实现 S3 兼容对象存储（复用 MinIO SDK，MinIO/阿里 OSS 均可接）；登记 endpoint/bucket/prefix/凭证（t_kb_ext_source，Flyway V15）→ 扫描对象（仅上传白名单内扩展名，单源单轮上限默认 500 超出记 PARTIAL）→ 走既有 `DocumentService.upload` 入库（**不新增入库旁路**，M12 铁律沿用，治理/版本/索引管道免费继承）；**ETag 增量同步**（t_kb_ext_source_item 逐对象台账：etag 未变 UNCHANGED、文档在回收站 SKIPPED、对象消失 SKIPPED 不动文档——弱绑定与 M12 同口径）；登记后**异步**首同步（对象数不可控，与 M12 登记即抓的差异点）+ 手动 sync + 每日定时（`kb.ext-source.*` 五配置键）；凭证 secret 明文落库（D17 前提：单管理员+网络隔离，KMS 归权限批次）、读 API 恒返回 `******`、更新传空=保留；endpoint 不过 UrlGuard（管理员配置项非终端用户输入，合法场景就是内网 MinIO）；Confluence/飞书/钉钉等 API 型连接器 SPI 已就位留后续里程碑
+- **F2 配置化元数据抽取**：KB 级 `index_config.metadata_rules`（≤10 条，key 规范 `^[a-z][a-z0-9_]{1,31}$` 且不得撞保留键）三类型：`constant` 固定值 / `regex` 第一捕获组（编译失败 INVALID_PARAM，未命中不写键）/ `keyword_match` 命中词子集；执行点在切分之后落 chunk 之前（`MetadataRuleExtractor` 纯函数），与保留键冲突时抽取值让位；引擎侧统一加 **`ext_` 前缀**镜像（ES dynamic template `ext_*`→keyword、Qdrant payload），MySQL metadata 存原始键名；规则计入 chunk 指纹（改规则→config_stale→重建生效）；检索 `metadata_filter` 增 `custom` Map 等值过滤（AND，keyword_match 键按数组包含），开放 API 同步（白名单本含 metadata_filter 无新覆盖面）；百炼"变量"型元数据不做（无请求级上下文来源）
+- **F3 切分策略扩展**：三个新 TextSplitter bean（SplitterRouter 自动收集，补齐 §4.3 策略清单 3/4/5 项）——`separator`（`split_separator` 默认 `\n\n` + `split_separator_is_regex`，切段后贪心装包到 chunk_max_tokens，分隔符不保留）、`heading`（`split_heading_level` 1-6 默认 2，markdown 标题行开新段，全文无标题回落 fixed_length）、`page`（按解析产物 pages[] 边界，无分页格式整文一页；chunk metadata 增 `page_no` 可过滤）；超长段落统一回落 fixed_length 二次切分；**父子分片 + 新策略 = INVALID_PARAM**（页/标题边界与两级预算语义冲突，不做貌合神离的组合）；新策略不产 title/summary/keywords
+- **F4 Rerank 混合模式**：`rerank_mode`（`semantic` 默认/`hybrid`）+ `rerank_w_semantic`（0-1 默认 0.7），五层配置优先级照旧；hybrid 排序分 = `w × rerank分 + (1-w) × minmax(BM25分)`（候选集内归一化，纯向量命中无 BM25 分按 0 计）；**阈值语义不变**——score_threshold 仍作用纯语义 rerank 分（归一化分跨查询不可比，hybrid 只影响排序）；rerank 降级链路照旧不新增降级码；模型端原生 hybrid（qwen3-rerank 内建）本期以线性混合实现同等语义
+- **F5 视觉理解整页索引（多模态向量）**：新 port `MultimodalEmbeddingProvider`（embedTexts/embedImages）+ DashScope 实现（原生端点非 OpenAI 兼容面，model `multimodal-embedding-v1` 1024 维，图片 base64 内联；`kb.multimodal-embedding.*` 配置键，Key 缺省继承 DASHSCOPE_API_KEY，blank=能力关闭零 Key 降级）；KB 级 `index_config.multimodal_enabled`（默认 false）开启且 provider 就绪时，**IMAGE 类 chunk（内嵌图/独立上传图/扫描页整页渲染三 kind）额外产多模态向量**，VLM 文本代理链路保留不变（加路不换路）；物理索引 `{kbId}_mm_{model}` 复用 registry 与双写补偿机制；检索时文本 query 同时嵌入多模态空间作**第三召回路参与 RRF**（图文同空间，文本可命中图）；weighted 融合模式 mm 路不参与记 `mm_route_skipped`、provider 失败记 `mm_route_unavailable`，主路均不受影响；开关翻转计入指纹→config_stale→重建补齐/清除
+- **F6 以图搜图入口**：管理台 `SearchRequest` 增 `images`（与开放 API 同约束：仅 base64、≤3 张/单张 5MB/总 10MB，复用 ImageQueryService 校验单点）；mm 可用→`embedImages` 直查多模态路（图搜图/图搜文）与文本各路 RRF 融合；否则回落现状 VLM 转写拼 query；**query 仍必填**（空 query 纯图检索本期不做）；开放 API `PublicSearchRequest.images` 已存在，行为同口径增强、请求形状零变化；web 检索调试页增图片上传与 rerank 模式面板
+- **界面**：知识库详情新增 **外部数据源** tab（登记/同步/连通测试/对象明细，先例 WebSourcesTab）；IndexConfigDrawer 增新切分策略项与条件字段、元数据抽取规则编辑、多模态开关；检索调试页增 rerank 模式选择与图片上传
+
 ## 5. 非功能需求
 
 - **部署**：本地开发全部依赖（MySQL、Qdrant、ES、MinIO、Redis、Neo4j——后者以 profile=graph 可选）用 docker-compose 一键拉起；应用本身可 docker 化
@@ -327,7 +340,7 @@
 - **容量设计边界**：按十万级文档、千万级以下分片设计（Qdrant/ES 单机版在此量级内可支撑）；超出此边界属集群化演进范畴（见 §13.1）；边界与 P95 承诺均有压测验收落点（§10 M2/M6），压测脚本随 kb-rag-deploy 分发
 - **测试策略**：Java/Python 核心逻辑（切分、融合、命中判定、UrlGuard、治理状态机、指标埋点）单元测试必备，含"引擎一致性单测"（同语料同 query 下 ES 与 Qdrant TopK 与标准化分数偏差 < 1e-3）；服务间接口按 OpenAPI 契约做契约测试；每个里程碑收尾跑"上传→索引→检索"E2E 冒烟
 - **配置分层模型**：五层优先级（低→高）——①环境变量/yml → ②全局系统设置（DB）→ ③知识库级 → ④应用版本快照（发布固化，不再回落全局）→ ⑤API 请求级覆盖。请求级覆盖**仅限白名单**：top_n、score_threshold、metadata_filter、max_content_length；版本/禁用/治理过滤、recall_top_k、融合与重排配置**不可覆盖**，白名单外返回 INVALID_PARAM 并记审计；kb-rag-deploy 维护全部可配参数总表作为单一事实源
-- **升级与迁移**：MySQL schema 变更一律走 **Flyway** 版本化迁移（当前已演进至 **V14**：V9 来源映射 / V10 父片偏移 / V11 登录 token / V12 反馈与洞察 / V13 治理 / V14 网页来源），应用启动自动执行，禁止手工 DDL；迁移脚本向后兼容一个版本（先加列后删列、不重命名）；ES/Qdrant schema 变更复用"从事实源重建 + 别名原子切换"，索引 metadata 记录 schema_version；语义化版本 + UPGRADING.md，compose 镜像 tag 固定版本号，CHANGELOG 标注是否含 schema 变更
+- **升级与迁移**：MySQL schema 变更一律走 **Flyway** 版本化迁移（当前已演进至 **V14**：V9 来源映射 / V10 父片偏移 / V11 登录 token / V12 反馈与洞察 / V13 治理 / V14 网页来源；M14 开发中将增 **V15** 外部数据源两表，见 §4.13），应用启动自动执行，禁止手工 DDL；迁移脚本向后兼容一个版本（先加列后删列、不重命名）；ES/Qdrant schema 变更复用"从事实源重建 + 别名原子切换"，索引 metadata 记录 schema_version；语义化版本 + UPGRADING.md，compose 镜像 tag 固定版本号，CHANGELOG 标注是否含 schema 变更
 - **Redis 职责边界**：仅承担 Query 改写缓存、API 限流计数、异步任务互斥锁三类易失性数据；**可选依赖**——单实例部署（含 lite）降级为进程内实现（Caffeine + Guava RateLimiter + JVM 锁），配置 cache.provider=local|redis 显式切换
 - **备份与恢复**：kb-rag-deploy 提供备份脚本（mysqldump 每日全量 + MinIO 数据目录同步，保留份数可配）；恢复顺序 MySQL → MinIO → 触发"从事实源重建索引"；RPO 默认 ≤24h；M6 已完成"备份-删库-恢复-检索可用"演练
 - **可观测**（三层——"界面可见"是看板不是告警，无人盯屏时故障必须主动触达）：
@@ -375,6 +388,7 @@
 | t_kb_retrieval_feedback | **检索反馈（V12 新增，M10）**：feedback_id、kb_id、query 原文（供转 case）、chunk_id、doc_id（反查冗余可空）、verdict（GOOD/BAD）、status（NEW/CONVERTED/DISMISSED）、converted_case_id；复合索引 (kb_id, status) |
 | t_kb_search_insight | **检索洞察（V12 新增，M10）**：insight_id、kb_id、source（CONSOLE/OPEN_API）、query_digest（脱敏截断，**绝不存原文**）、query_hash（归一化 SHA-256 分组键）、result_count、top_score、zero_hit、degraded JSON、request_id；复合索引 (kb_id, zero_hit, created_at) |
 | t_kb_web_source | **网页来源登记（V14 新增，M12）**：source_id、kb_id、url、url_hash、doc_id（弱绑定回填）、file_name（派生稳定名）、sync_enabled、last_content_hash、last_fetch_at/status/error；唯一键 (kb_id, url_hash) |
+| t_kb_ext_source / t_kb_ext_source_item | **外部数据源登记与对象台账（V15，M14 开发中）**：源表——source_id（exts_ 前缀）、kb_id、source_type（本期仅 s3）、name、endpoint/region/bucket/prefix、access_key/secret_key（读 API 恒脱敏）、sync_enabled、last_sync_at/status/error，唯一键 (kb_id, name)；台账表——object_key/object_key_hash、etag（增量依据）、doc_id（弱绑定）、last_status/error/sync_at，唯一键 (source_id, object_key_hash)，见 §4.13 |
 
 **引擎侧字段约定**（可过滤字段全集，在 Qdrant collection 建 payload 索引、在 ES index 显式声明；其余 metadata 只存 MySQL）：
 
@@ -450,6 +464,12 @@
 
 > 另有两项随二期批次落地的横切转正：登录态 Token 落库（Flyway V11，§4.8）、图谱抽取 max_tokens 截断修复（§4.9）。
 
+### 10.3 三期（M14 起；契约见 kb-rag-deploy/docs/M14-CONTRACTS.md）
+
+| 里程碑 | 内容概要 | 关键落点 | 状态 |
+|---|---|---|---|
+| M14 百炼能力对齐第一批 | 外部数据源连接器（SPI + S3/OSS，ETag 增量）、配置化元数据抽取（三类规则 + custom 过滤）、切分策略扩展（separator/heading/page）、Rerank 混合模式（hybrid 线性加权）、视觉理解整页索引（multimodal-embedding-v1 第三召回路）、以图搜图入口 | Flyway V15、§4.13、degraded 增 mm_route_skipped/mm_route_unavailable | 🚧 开发中（feature/m14） |
+
 ## 11. 风险与对策
 
 | 风险 | 对策 |
@@ -506,7 +526,7 @@
 | 数据接入 | 站点级爬取 / 多页递归（sitemap） | M12 边界：一条登记 = 一个 URL = 一个文档 |
 | 数据接入 | JS 渲染页面（SPA） | M12 边界：仅抓服务端返回的 HTML，抓到什么入什么 |
 | 数据接入 | 登录态 / 带 Cookie 抓取 | M12 边界：仅公开可匿名访问的 URL |
-| 数据接入 | RSS / 第三方 API 等其他数据源连接器 | M12 边界外，未排期 |
+| 数据接入 | RSS 数据源连接器；Confluence/飞书/钉钉等 API 型连接器 | 对象存储连接器与 SPI 已于 M14 排入（§4.13），API 型连接器基于同一 SPI 留后续里程碑 |
 | 内容治理 | chunk 级治理 | M11 边界：文档级足够，chunk 已有 enabled 开关 |
 | 内容治理 | 审核审批流（多级审批、审核人记录） | 依赖用户体系，归入 §13.2 |
 | 质量闭环 | 开放 API 终端用户反馈端点 | 需要终端用户身份，归入 §13.2 |
@@ -532,8 +552,9 @@
 ### 13.4 遗留待办
 
 1. **聊天记录真实导出样例校准**：微信 / 留痕 / 钉钉的真实导出样例仍未到位——M8 内置的 TXT 行模板与 HTML DOM 选择器模板按公开格式约定编写，拿到真实样例后需校准映射档案（见 §4.2）；钉钉格式适配未排期。
-2. **deploy 事实源文档回补**：`kb-rag-deploy/docs/知识库需求文档.md` 当前停留在 v1.15（M9 完成时点），本文件为 v1.16 先行稿——`feature/kb-core-enhancements` 合并 PR 时**必须**将 M10-M13 内容回补事实源文档，并同步 OpenAPI（kb-server.yaml 已升至 0.13.0-m12）与各仓库 CHANGELOG（"实现偏离须同 PR 修订文档"铁律）。
+2. **deploy 事实源文档回补**：`kb-rag-deploy/docs/知识库需求文档.md` 当前停留在 v1.15（M9 完成时点），本文件为先行稿——合并 PR 时**必须**将 M10-M14 内容回补事实源文档，并同步 OpenAPI（kb-server.yaml M14 完成后升 0.14.0-m14）与各仓库 CHANGELOG（"实现偏离须同 PR 修订文档"铁律）。
+3. **M14 实现完成后的文档核实**：§4.13 为契约先行稿，实现中若出现偏离（如 multimodal provider 实测拒收 base64 data URL 需降级预签名 URL），须在同分支内同步修订本文档与 M14-CONTRACTS.md，并将 §10.3 状态翻为 ✅。
 
 ---
 
-> 文档结束。本文档描述的全部功能条款均已对照 `feature/kb-core-enhancements` 分支代码（Flyway V1-V14、M1-M13 契约、四仓库实现与单测）核实；未实现内容一律收敛于 §13。
+> 文档结束。本文档 M1-M13 功能条款均已对照代码（Flyway V1-V14、M1-M13 契约、四仓库实现与单测）核实；M14 条款（§4.13）为契约先行稿，实现完成后回补核实；其余未实现内容一律收敛于 §13。

--- a/kb-rag-deploy/.env.example
+++ b/kb-rag-deploy/.env.example
@@ -226,3 +226,33 @@ WEB_IMPORT_SYNC_CRON="0 30 2 * * *"
 WEB_IMPORT_SYNC_ENABLED=true
 # 单轮定时同步处理的登记数上限（按 id 升序取一批，单条失败不中断本轮）
 WEB_IMPORT_SYNC_BATCH_SIZE=50
+
+# --- 外部数据源连接器（M14，docs/M14-CONTRACTS.md §2.4）---
+# S3/OSS 兼容对象存储连接器：登记 bucket/prefix 后按前缀扫描对象走上传链路入库，ETag 增量同步。
+# 定时扫描调度与开关（cron 含空格必须加引号，理由同 WEB_IMPORT_SYNC_CRON）
+EXT_SOURCE_SYNC_CRON="0 0 3 * * *"
+EXT_SOURCE_SYNC_ENABLED=true
+# 单轮定时扫描处理的数据源数上限；每个源扫描整桶，故批量小于 URL 导入
+EXT_SOURCE_SYNC_BATCH_SIZE=10
+# 单次扫描入库的对象数上限；列举超出即将本次同步标记为 PARTIAL 而非无界拉取
+EXT_SOURCE_MAX_OBJECTS_PER_SOURCE=500
+# 单次对象存储调用超时（毫秒），连接与读取同预算
+EXT_SOURCE_FETCH_TIMEOUT_MS=30000
+
+# --- 视觉理解整页索引：多模态向量（M14，docs/M14-CONTRACTS.md §6.1）---
+# 多模态嵌入模型（DashScope multimodal-embedding-v1，1024 维，与全家桶同 Key）；
+# MULTIMODAL_EMBEDDING_API_KEY 留空则继承 DASHSCOPE_API_KEY，两者皆空 = 多模态能力整体关闭
+# （知识库多模态开关可存但索引/检索跳过，行为同零 Key 降级）
+MULTIMODAL_EMBEDDING_MODEL=multimodal-embedding-v1
+MULTIMODAL_EMBEDDING_API_KEY=
+MULTIMODAL_EMBEDDING_DIM=1024
+# DashScope 多模态嵌入走原生端点（非 OpenAI 兼容面），故为完整 URL
+MULTIMODAL_EMBEDDING_URL=https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding
+MULTIMODAL_EMBEDDING_TIMEOUT_MS=30000
+
+# --- Rerank 混合模式（M14，docs/M14-CONTRACTS.md §5）---
+# 部署级重排模式默认：semantic=纯语义重排分排序（现状）；hybrid=语义重排分与归一化 BM25 分线性加权，
+# 仅影响排序、不改变 score_threshold 的绝对阈值语义。请求 > 知识库 > 此部署默认（五层优先级照旧）
+RETRIEVAL_RERANK_MODE=semantic
+# hybrid 模式下语义分权重（0-1），BM25 权重 = 1 - 此值
+RETRIEVAL_RERANK_W_SEMANTIC=0.7

--- a/kb-rag-deploy/.env.example
+++ b/kb-rag-deploy/.env.example
@@ -57,6 +57,11 @@ VISION_TIMEOUT_MS=20000
 # 整页渲染成图片交给 VisionProvider 转录
 SCANNED_PAGE_TEXT_THRESHOLD=20
 
+# 乱码页判定阈值（M3 §2.1 补充，kb-rag-parser 消费）：pdf 页面文本层长度达标但可识别字符
+# （ASCII/CJK/假名/中日标点等）占比低于此百分比，即判定为内嵌字体 ToUnicode CMap 损坏导致的乱码，
+# 该页文本置空并按扫描页渲染成图片交 OCR/VLM 兜底。调高更激进（更多页走 OCR），调低更保守
+GARBLED_PAGE_VALID_CHAR_RATIO_PCT=50
+
 # 本地 OCR 兜底（M8/二期，docs/M8-CONTRACTS.md §0.4，kb-rag-parser 消费）：none=不启用（默认，
 # 行为与 M3 一致）；paddle=扫描页由 parser 本地 PaddleOCR 出文本（零 Key/离线可用），需先在 parser
 # 环境执行 pip install -r requirements-ocr.txt，未装依赖时 parser 启动即报错。带 OCR 文本的页

--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -8,6 +8,42 @@
 
 ### Added
 
+- **三期第一批：连接器 / 元数据抽取 / 切分扩展 / 混合重排 / 多模态索引 / 以图搜图（M14，docs/M14-CONTRACTS.md）**：
+  ①外部数据源连接器——连接器 SPI（`ExternalConnector`/`ConnectorRouter`，为后续 Confluence/飞书预留）+
+  首个实现 S3/OSS 兼容对象存储；`POST/GET /kb/{kbId}/ext-sources` 登记/列表、`POST
+  /ext-sources/{id}/sync` 手动异步同步、`GET /ext-sources/{id}/items` 对象明细、
+  `PUT`/`POST .../test`/`DELETE /ext-sources/{id}` 更新/连通性测试/移除；按 prefix 扫描桶内对象
+  走既有上传管线入库（派生稳定文件名，ETag 未变→UNCHANGED 不重传、变了→新版本），源与文档
+  弱绑定——移除登记或对象消失均不删文档（SKIPPED）；两张新表 `t_kb_ext_source`/
+  `t_kb_ext_source_item`（Flyway V15）；②配置化元数据抽取——知识库级 `metadata_rules`
+  （constant/regex/keyword_match 三类，≤10 条），切分后逐 chunk 抽取入 metadata 并以 `ext_`
+  前缀镜像引擎，检索侧 `metadata_filter.custom` 等值过滤；规则计入 chunk 指纹；③切分策略扩展——
+  新增 `separator`（分隔符/正则）、`heading`（markdown 标题层级）、`page`（解析页边界）三个
+  TextSplitter 策略，超长段统一回落 fixed_length，与父子分片互斥（组合报 INVALID_PARAM）；
+  ④Rerank 混合模式——`rerank_mode=hybrid` 将语义重排分与归一化 BM25 分线性加权（`rerank_w_semantic`
+  默认 0.7）决定排序，仅影响排序、不改变 `score_threshold` 的绝对阈值语义，rerank 降级链路照旧；
+  ⑤视觉理解整页索引——知识库级 `multimodal_enabled` 开关，开启且多模态 provider 配置时对 IMAGE
+  类 chunk（内嵌图/独立上传图/扫描页整页渲染）额外产多模态向量（DashScope multimodal-embedding-v1，
+  1024 维，物理索引 `{kbId}_mm`），检索新增第三召回路进 RRF 融合（图文同空间，文本可命中图），
+  VLM 文本代理链路保留不变；⑥以图搜图入口——管理台检索调试页 `SearchRequest.images`（裸 base64，
+  ≤3 张/单张 5MB/总量 10MB），multimodal 开启时图片直接嵌入多模态空间检索、否则回落 VLM 转写。
+  web：知识库详情新增「外部数据源」Tab、索引配置抽屉增切分条件字段/元数据抽取分组/多模态开关、
+  检索调试页增重排模式选择与图片上传；新增 `EXT_SOURCE_SYNC_CRON`/`EXT_SOURCE_SYNC_ENABLED`/
+  `EXT_SOURCE_SYNC_BATCH_SIZE`/`EXT_SOURCE_MAX_OBJECTS_PER_SOURCE`/`EXT_SOURCE_FETCH_TIMEOUT_MS`、
+  `MULTIMODAL_EMBEDDING_MODEL`/`MULTIMODAL_EMBEDDING_API_KEY`/`MULTIMODAL_EMBEDDING_DIM`/
+  `MULTIMODAL_EMBEDDING_URL`/`MULTIMODAL_EMBEDDING_TIMEOUT_MS`、`RETRIEVAL_RERANK_MODE`/
+  `RETRIEVAL_RERANK_W_SEMANTIC`；`degraded` 枚举新增 `mm_route_unavailable`（多模态检索不可用降级）/
+  `mm_route_skipped`（加权融合下多模态路跳过）；OpenAPI 升 0.14.0-m14。纯新增表/端点/配置键，
+  存量行为零变化——新 JSON 配置字段缺省即现状（`metadata_rules` 空、`split_strategy` 旧值不变、
+  `rerank_mode=semantic`、`multimodal_enabled=false`）；`MULTIMODAL_EMBEDDING_API_KEY` 留空则
+  继承 `DASHSCOPE_API_KEY`，两者皆空 = 多模态能力整体关闭
+
+### Security
+
+- **外部数据源凭证明文存储（M14，醒目声明）**：`t_kb_ext_source.secret_key` 明文落库，读 API
+  恒返回 `******`、更新时传空 = 保留旧值。取舍前提与 D17 一致——管理台单管理员 + 网络隔离；
+  引入 KMS/信封加密属权限体系批次，不在本期范围。部署侧务必保证数据库与网络访问隔离
+
 - **运维可观测：Prometheus 业务指标（M13，docs/M13-CONTRACTS.md）**：kb-rag-server 自本版起
   可被 Prometheus 抓取——补齐 `micrometer-registry-prometheus` 依赖激活既有 actuator 的
   `/actuator/prometheus` 端点（JVM/HTTP 基础指标随 actuator 自动配置免费提供）；新增业务

--- a/kb-rag-deploy/README.md
+++ b/kb-rag-deploy/README.md
@@ -9,15 +9,19 @@ OpenAPI 接口契约、备份/预检脚本与总体文档。
 React 管理台，三者围绕 MySQL（事实源）/ Elasticsearch 与 Qdrant（检索引擎）/
 MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过 docker-compose 一键拉起中间件。**
 
-> 本仓库当前状态：**一期（M1-M7）与二期（M8-M9）已完成，核心能力增强（M10-M13）已完成**。
+> 本仓库当前状态：**一期（M1-M7）与二期（M8-M9）已完成，核心能力增强（M10-M13）
+> 与竞品能力对齐（M14）已完成**。
 > 一期交付上传解析→混合检索（向量+BM25+图路三路融合）→分片标注→评测闭环→应用发布→
 > 多知识库路由→索引快照回滚→GraphRAG 的完整链路；二期增强聊天记录导入
 > （TXT/HTML 格式、本地 OCR 兜底、重叠滑窗归并、映射档案维护界面，M8）与标注
 > 语义/图搜能力（M9）；核心能力增强补齐检索质量闭环（M10）、内容治理（M11）、
-> URL 导入与增量同步（M12）、Prometheus 业务指标（M13），见下文
-> [核心能力增强（M10-M13）](#核心能力增强m10-m13)。
+> URL 导入与增量同步（M12）、Prometheus 业务指标（M13）；M14 对齐竞品能力，补齐
+> 外部数据源连接器、配置化元数据抽取、切分策略扩展、Rerank 混合模式、视觉理解整页
+> 索引与以图搜图六项特性，见下文
+> [核心能力增强（M10-M13）](#核心能力增强m10-m13)与
+> [竞品能力对齐（M14）](#竞品能力对齐m14)。
 > 各里程碑契约见 [`docs/M1-CONTRACTS.md`](docs/M1-CONTRACTS.md) ~
-> [`docs/M13-CONTRACTS.md`](docs/M13-CONTRACTS.md)；系统整体架构与核心流程图见
+> [`docs/M14-CONTRACTS.md`](docs/M14-CONTRACTS.md)；系统整体架构与核心流程图见
 > [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) 与 [`docs/FLOWS.md`](docs/FLOWS.md)。
 
 ## 目录
@@ -37,6 +41,7 @@ MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过 dock
 - [Demo 数据集与聊天记录映射（M3）](#demo-数据集与聊天记录映射m3)
 - [聊天记录格式扩展与映射维护（M8）](#聊天记录格式扩展与映射维护m8)
 - [核心能力增强（M10-M13）](#核心能力增强m10-m13)
+- [竞品能力对齐（M14）](#竞品能力对齐m14)
 - [接口契约（OpenAPI）](#接口契约openapi)
 - [开源工程文档](#开源工程文档)
 
@@ -397,6 +402,28 @@ docker compose -f docker-compose.lite.yml --profile graph up -d
   `kb_websource_sync_total` 及 JVM/HTTP 基础指标；无新环境变量，该端点与 health 同口径
   暂无鉴权，生产由部署侧网络隔离
 
+## 竞品能力对齐（M14）
+
+六项特性均为纯新增能力，向后兼容既有端点；契约见 [`docs/M14-CONTRACTS.md`](docs/M14-CONTRACTS.md)：
+
+- **外部数据源连接器**：新增 `ext-source` 端点族（登记/列表/同步/条目/编辑/连通性测试/移除），
+  首个实现为 S3/OSS 兼容对象存储，登记后异步首同步并支持增量（hash 去重、四态条目结果）；
+  凭证 `secret_key` 恒以掩码返回、编辑留空即保留旧值。新增 `EXT_SOURCE_*` 相关变量
+- **配置化元数据抽取**：索引配置新增 `metadata_rules`（constant / regex / keyword_match 三类，
+  单库至多 10 条），抽取值随分片指纹参与陈旧判定；检索过滤新增 `custom` 等值过滤
+- **切分策略扩展**：`split_strategy` 由 `fixed_length` / `llm_semantic` 扩展至
+  `separator` / `heading` / `page`，配套 `split_separator` / `split_separator_is_regex` /
+  `split_heading_level` 条件字段
+- **Rerank 混合模式**：检索请求新增 `rerank_mode`（`semantic` / `hybrid`）与
+  `rerank_w_semantic`（0-1，仅 `hybrid` 生效），语义分与原始融合分线性加权
+- **视觉理解整页索引**：索引配置新增 `multimodal_enabled`，开启后整页走多模态向量
+  （DashScope multimodal-embedding-v1）；新增 `MULTIMODAL_*` 相关变量与
+  `mm_route_skipped` / `mm_route_unavailable` 降级码
+- **以图搜图入口**：检索请求新增 `images`（至多 3 张裸 base64），走多模态向量近邻检索
+
+以上六项新增约 12 个环境变量，详见 [`.env.example`](.env.example) 中 M14 分节与
+模型状态接口的 `multimodal_configured` 字段。
+
 ## 接口契约（OpenAPI）
 
 - [`docs/openapi/kb-server.yaml`](docs/openapi/kb-server.yaml)：kb-rag-server 管理台
@@ -436,6 +463,6 @@ python3 -c "import yaml, sys; yaml.safe_load(open(sys.argv[1]))" docs/openapi/kb
 - [知识库需求文档（v1.14，唯一事实源）](docs/知识库需求文档.md)
 - [系统架构总览（ARCHITECTURE.md）](docs/ARCHITECTURE.md) /
   [核心流程图（FLOWS.md）](docs/FLOWS.md)
-- [M1](docs/M1-CONTRACTS.md) ~ [M13 开发契约](docs/M13-CONTRACTS.md)（按里程碑记录
+- [M1](docs/M1-CONTRACTS.md) ~ [M14 开发契约](docs/M14-CONTRACTS.md)（按里程碑记录
   实现细节与已接受偏离）
 - [OpenAPI 定义](docs/openapi/)

--- a/kb-rag-deploy/docs/ARCHITECTURE.md
+++ b/kb-rag-deploy/docs/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # kb-rag 架构文档
 
-> 版本：v1.2（基线 = 一期 M1-M7 + 二期 M8/M9 + 核心能力增强 M10-M13，2026-07-28；v1.1 基线为 M9，v1.0 基线为 M8）
-> 日期：2026-07-28
+> 版本：v1.3（基线 = 一期 M1-M7 + 二期 M8/M9 + 核心能力增强 M10-M13 + 竞品能力对齐 M14，2026-07-29；v1.2 基线为 M13，v1.1 基线为 M9，v1.0 基线为 M8）
+> 日期：2026-07-29
 > 作者：RichardFyoung / Claude
 >
 > **文档定位**：本文描述系统的实际实现架构（以代码为准），与以下文档互补——
 > - `知识库需求文档.md`：需求与设计决策的唯一事实源（"为什么做、做什么"）
-> - `M1~M13-CONTRACTS.md`：各里程碑的实现契约与已接受偏离（"每一期怎么做的"）
+> - `M1~M14-CONTRACTS.md`：各里程碑的实现契约与已接受偏离（"每一期怎么做的"）
 > - `openapi/kb-server.yaml`、`openapi/kb-parser.yaml`：HTTP 接口的唯一契约源
 > - `FLOWS.md`：核心流程图（与本文配套阅读）
 
@@ -91,14 +91,14 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | 模块 | 职责 | 关键内容 |
 |---|---|---|
 | **kb-common** | 无 Spring 依赖的基础件 | `Result` 统一响应信封、`ErrorCode`、`BizException`/`ProviderException`、`JsonUtil`/`HashUtil`、`RequestIdHolder`、`KbConstants`（业务 ID 前缀与 `kb-sk-` Key 前缀） |
-| **kb-domain** | 实体 + 端口 + 纯领域算法 | MyBatis-Plus 实体/Mapper（与 26 张业务表一一对应）、30+ 枚举、60+ 领域模型、**14 个出站端口接口**（`domain.port`）、无状态领域服务（切分/融合/指纹/评测指标/门禁裁决/标注迁移相似度等纯函数）、`KbProperties`（`@ConfigurationProperties(prefix="kb")`，二十余个嵌套段） |
-| **kb-infrastructure** | 端口实现，按外部依赖分包 | `search.es` / `search.qdrant` / `graph` / `provider.{chat,embedding,rerank,vision}` / `storage` / `parser` / `notify` / `web` / `config` |
+| **kb-domain** | 实体 + 端口 + 纯领域算法 | MyBatis-Plus 实体/Mapper（与 28 张业务表一一对应）、30+ 枚举、60+ 领域模型、**16 个出站端口接口**（`domain.port`）、无状态领域服务（切分/融合/指纹/评测指标/门禁裁决/标注迁移相似度等纯函数）、`KbProperties`（`@ConfigurationProperties(prefix="kb")`，二十余个嵌套段） |
+| **kb-infrastructure** | 端口实现，按外部依赖分包 | `search.es` / `search.qdrant` / `graph` / `provider.{chat,embedding,rerank,vision}` / `connector` / `storage` / `parser` / `notify` / `web` / `config` |
 | **kb-app** | 应用编排层（架构主体） | 20 个业务域包：`kb` / `document` / `index` / `retrieval` / `graph` / `annotation` / `eval` / `appcenter` / `openapi` / `chat` / `alert` / `dict` / `auth` / `system` / `config` / `feedback` / `insight` / `governance` / `websource` / `metrics` |
 | **kb-api** | HTTP 边界与装配点 | 24 个 Controller、过滤器/拦截器、SSE、健康探针、`application.yml`、Flyway 脚本；`@SpringBootApplication(scanBasePackages="io.kbrag")` 为唯一装配点 |
 
 分层规则：Controller 只依赖 kb-app 的 Service 与 kb-domain 的 model/enum；kb-app 只依赖端口接口，**从不依赖 kb-infrastructure 具体类**；kb-infrastructure 实现端口，与 kb-app 互不感知。
 
-### 3.2 领域端口与实现（14 个）
+### 3.2 领域端口与实现（16 个）
 
 | 端口 | 实现（默认 / 降级） | 说明 |
 |---|---|---|
@@ -116,6 +116,8 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | `TokenEstimator` | `SimpleTokenEstimator` | 分片长度以 token 计、`max_content_length` 预算 |
 | `VersionPinChecker` | `AppVersionPinChecker` | 被应用版本可见集引用的文档版本禁止归档（已下线版本同样 pin——chunk 正文只在 MySQL） |
 | `WebPageFetcher`（M12） | `HttpWebPageFetcher` | 网页抓取（URL 导入/增量同步）：SSRF 防护由调用侧经 kb-domain 的 `UrlGuard` 前置校验，Content-Type 白名单、体积上限、超时控制 |
+| `MultimodalEmbeddingProvider`（M14） | `DashScopeMultimodalEmbeddingProvider` / `NoopMultimodalEmbeddingProvider` | 视觉理解整页索引与以图搜图的共用向量通道（DashScope multimodal-embedding-v1）；未配置时注入 Noop 实现，开关置灰、多模态路跳过并记 `mm_route_unavailable`；开启但多模态权重为 0 时跳过并记 `mm_route_skipped` |
+| `ExternalConnector`（M14） | `S3CompatibleConnector` | 外部数据源 SPI：扫描 S3/OSS 兼容对象存储、拉取对象体馈入普通上传链；source_type 为路由键，本期仅 s3 一种实现 |
 
 **零 Key / 能力开关统一装置**：`ModelProviderConfig` 是唯一读模型凭据的地方，凭据为空即注入 `Unconfigured*` 实现；`GraphStoreConfig`（NEO4J_URI 空 → `DisabledGraphStore`）与 `QdrantClientConfig`（QDRANT_URI 空 → 不建 client、不注册健康探针）镜像同一模式。上游代码只写 `isConfigured()/isEnabled()` 一个分支，全链路无 null 检查——这是需求 §5"防御式编程只做一处且高复用"的落地点。
 
@@ -146,7 +148,7 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | `VectorScoreNormalizer` | 跨引擎向量分统一：ES `(1+cos)/2` 先还原、Qdrant 原生 cosine，统一映射到 [0,1]；两实现共享一份"引擎一致性单测" |
 | `FusionRouter` → `RrfFusion`/`WeightedFusion` | 加权融合先按候选集 min-max 归一化；开图路的库强制 RRF（`GraphFusionPolicy`——图关联度是第三种量纲） |
 | `CrossKbRrfFusion` + `KbQuotaAllocator` | 跨库只用名次不用分数；rerank 候选预算是**全局总量**按权重配额切分（向下取整、余量归最高权重库） |
-| `RerankService` | 候选上限 50（父子开启时联动 `max(50, top_n×5)`，硬上限 100）；超时 1.5s 降级粗排；rerank 分是唯一跨库跨路可比的绝对分 |
+| `RerankService` | 候选上限 50（父子开启时联动 `max(50, top_n×5)`，硬上限 100）；超时 1.5s 降级粗排；rerank 分是唯一跨库跨路可比的绝对分；M14 新增 `rerank_mode=hybrid`：将语义重排分与原始融合分按 `rerank_w_semantic`（0-1，默认 0.7）线性加权，`semantic` 模式与旧行为一致 |
 | `ParentChildMerger` | 召回/融合/rerank 全在子片粒度，之后按 parent_id 归并、父片得分取子片 max；目标父片数 `max(top_n×3, 20)` |
 | `DisabledChildVisibility` + `ParentTextRedactor`（M9） | 含禁用子片的父片：默认整片返回并标注 `disabled_child_ids`；M9 起对偏移非 null 的禁用子片按 [start,end) **倒序**精确剔除文本段、置省略标记与 `redacted_child_count`；任一禁用子片偏移为 null 则整片回退（半剔除比不剔除更误导）；库级开关 `hide_parent_with_disabled_child` 打开则整父片隐藏 |
 | `ScoreThresholdPolicy` | 阈值只作用于 rerank 分；降级时作用于标准 cosine 分；BM25 单路阈值失效并透出 `threshold_inactive`；`score_type` 必须如实上报 |
@@ -158,7 +160,7 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 
 **图路（M7）**：`GraphRetrievalService` 检索侧零 LLM——query 轻量切词（`GraphQueryTokenizer`）→ Neo4j 实体名 fulltext（cjk 分析器）匹配 → N 跳扩展（默认 2）→ 溯源边回 chunk，关联度 = 归一化匹配分 / (1+跳数)（`GraphRelevanceScorer`）；快照上下文图路直接关闭且不记降级（能力边界而非故障）。抽取侧 `GraphExtractionService` 逐分片 LLM 抽取 + 输出强校验（非法跳过计 `t_kb_task.skipped_count`）。
 
-**degraded 枚举**（`DegradedReason`，与需求 §4.8 一一对应）：`query_rewrite_timeout/error/unavailable`、`rerank_timeout/error/unavailable`、`vector_route_unavailable`、`route_fallback_all`、`threshold_inactive`、`snapshot_index_missing`、`graph_route_unavailable`、`image_understanding_unavailable`（M9）。
+**degraded 枚举**（`DegradedReason`，与需求 §4.8 一一对应）：`query_rewrite_timeout/error/unavailable`、`rerank_timeout/error/unavailable`、`vector_route_unavailable`、`route_fallback_all`、`threshold_inactive`、`snapshot_index_missing`、`graph_route_unavailable`、`image_understanding_unavailable`（M9）、`mm_route_skipped`/`mm_route_unavailable`（M14：多模态开启但权重 0 跳过 / provider 未配置或失败）。
 
 ### 3.5 索引管线（`io.kbrag.app.document` + `io.kbrag.app.index`）
 
@@ -199,9 +201,9 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | `ApiAuditArchiveService` | cron 03:30 | 审计日志归档 MinIO → 分批物理删除 |
 | `AppSnapshotRetentionService` | cron 04:15 | SUPERSEDED 版本快照按保留数清理（RELEASED 永不清理） |
 
-### 3.8 数据模型（26 张业务表，Flyway V1-V14）
+### 3.8 数据模型（28 张业务表，Flyway V1-V15）
 
-全部 InnoDB，统一 `id / created_at / updated_at / lock_version / deleted`，审计字段由 `AuditFieldFiller` 填充，业务 ID 带类型前缀（kb/doc/dv/ck/task/img/upt/an/evds/evc/evr/evre/app/av/ak/aud/smp/rfb/si/ws）。
+全部 InnoDB，统一 `id / created_at / updated_at / lock_version / deleted`，审计字段由 `AuditFieldFiller` 填充，业务 ID 带类型前缀（kb/doc/dv/ck/task/img/upt/an/evds/evc/evr/evre/app/av/ak/aud/smp/rfb/si/ws/exts）。
 
 | 迁移 | 表 / 变更 |
 |---|---|
@@ -219,6 +221,7 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | V12（M10） | `t_kb_retrieval_feedback`（检索反馈，带幂等键）/ `t_kb_search_insight`（检索洞察埋点，只增不改） |
 | V13（M11） | `t_kb_document` 加 `publish_status` / `review_note` / `effective_at` / `expires_at` / `trashed` / `trashed_at`；`t_kb_knowledge_base` 加 `review_required` |
 | V14（M12） | `t_kb_web_source`（网页来源登记：URL/content_hash/四态同步状态/派生文档关联） |
+| V15（M14） | `t_kb_ext_source`（外部对象存储源登记：端点/桶/前缀/凭证，secret_key 从不回读、库内 name 唯一）/ `t_kb_ext_source_item`（逐对象同步结果：object_key_hash 去重、etag 未变检查、四态 last_status，弱绑定于派生文档） |
 
 引擎侧可过滤字段全集（Qdrant 标量 / ES filter，建索引时显式声明）：`kb_id`、`doc_id`、`document_version_id`、`enabled`、`parent_id`、`chunk_type`、`tag_ids`、`session_id`、`sender`、`msg_time`、`chunk_seq`；其余 metadata 只存 MySQL。新增可过滤维度视为 schema 变更，走索引重建迁移。
 
@@ -302,7 +305,7 @@ Vite 8 + React 18 + TypeScript 6 + Ant Design 5 + react-router-dom 6 + axios；l
 | `scripts/benchmark.sh` | 纯 bash+curl 压测（P50/P95/P99），验收口径 P95<2s；`seed-bench.py` 零 Key 直灌 10 万分片种子数据 |
 | `demo/` | 4 篇原创文档（md/docx/pdf/xlsx 各一，字节级可复现生成）+ `eval-cases.json`（10 条，含文档级锚定图片 case，按文件名+content_hash 关联导入） |
 | `mappings/` | 聊天记录列名映射模板分发（memotrace 等） |
-| `docs/` | 需求文档、M1-M13 契约、OpenAPI（`kb-server.yaml` 0.13.0-m12，92 条路径 / `kb-parser.yaml` 0.12.0-m12，3 端点）、备份恢复手册、本文档与 `FLOWS.md` |
+| `docs/` | 需求文档、M1-M14 契约、OpenAPI（`kb-server.yaml` 0.14.0-m14，97 条路径 / `kb-parser.yaml` 0.12.0-m12，3 端点）、备份恢复手册、本文档与 `FLOWS.md` |
 
 ---
 

--- a/kb-rag-deploy/docs/M14-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M14-CONTRACTS.md
@@ -1,0 +1,160 @@
+# M14 开发契约（三期第一批：连接器 / 元数据抽取 / 切分扩展 / 混合重排 / 多模态索引 / 以图搜图 · 增量于 M1-M13 契约）
+
+> 需求依据：知识库需求文档 §13 后续规划 + 竞品（阿里云百炼知识库）能力对齐（文档与图片口径，音视频与计费明确排除）。本期六个特性在单分支 `feature/m14` 一次交付。
+> 全局约定沿用 M1 §0（@author owlzhangfq@gmail.com、英文注释、info/error 日志带错误码、lombok、CollectionUtils 判空、无魔法值、fast-fail 只在 Controller、不主动 commit）；web 枚举展示走 metaOf；单测离线可跑（`mvn -B -ntp verify` / `pytest`）。
+> 用户已确认的三项选型：①连接器 SPI + 首个实现 **S3/OSS 兼容对象存储**（MinIO 可本地自测）；②多模态向量 **DashScope multimodal-embedding-v1**（与全家桶同 Key）；③单里程碑单契约。
+
+## 0. 范围与边界
+
+**本期做（六特性）**：
+
+| # | 特性 | 一句话定义 |
+|---|---|---|
+| F1 | 外部数据源连接器 | 连接器 SPI + S3/OSS 实现：登记 bucket/prefix → 扫描对象 → 走既有上传链路入库，ETag 增量同步 |
+| F2 | 配置化元数据抽取 | KB 级 metadata_rules（常量/正则/词表三类），切分后逐 chunk 抽取入 metadata 并镜像引擎，检索侧 custom 等值过滤 |
+| F3 | 切分策略扩展 | 新增 `separator`（分隔符/正则）、`heading`（markdown 标题层级）、`page`（解析页边界）三个 TextSplitter 策略 |
+| F4 | Rerank 混合模式 | `rerank_mode=hybrid`：语义重排分与归一化 BM25 分线性加权决定排序 |
+| F5 | 视觉理解整页索引 | KB 级 multimodal 开关：IMAGE chunk（含扫描页整页渲染）额外产多模态向量，检索新增第三召回路 |
+| F6 | 以图搜图入口 | 管理台检索调试页支持图片查询；multimodal 开启时图片直接嵌入多模态空间检索，否则回落 VLM 转写 |
+
+**本期不做**：Confluence/飞书/钉钉等 API 型连接器（SPI 已就位，留后续里程碑）；百炼"变量"型元数据（无请求级上下文来源）；rerank 模型端原生 hybrid（qwen3-rerank hybrid 是模型内能力，本期以线性混合实现同等语义）；音视频、计费、RBAC（D17 延后决策不变）。
+
+**兼容红线**：纯新增表/端点/配置键，存量行为零变化；所有新 JSON 配置字段缺省即现状（`metadata_rules` 空、`split_strategy` 旧值不变、`rerank_mode=semantic`、`multimodal_enabled=false`）；旧配置行反序列化靠 `@JsonIgnoreProperties(ignoreUnknown=true)` 天然兼容。
+
+**开发顺序**（依赖关系决定）：F1 → F2 → F3 → F4 → F5 → F6（F6 依赖 F5 的 provider 与路由）。
+
+## 1. 数据模型（Flyway V15，两张新表；其余全部落既有 JSON 配置列）
+
+| 表 | 定义 |
+|---|---|
+| t_kb_ext_source | `id` BIGINT PK AUTO、`source_id` VARCHAR(64) UK（`exts_` 前缀）、`kb_id` VARCHAR(64) NOT NULL、`source_type` VARCHAR(16) NOT NULL（本期仅 `s3`）、`name` VARCHAR(128) NOT NULL、`endpoint` VARCHAR(512) NOT NULL、`region` VARCHAR(64) NULL、`bucket` VARCHAR(128) NOT NULL、`prefix` VARCHAR(512) NULL、`access_key` VARCHAR(256) NOT NULL、`secret_key` VARCHAR(512) NOT NULL、`sync_enabled` TINYINT NOT NULL DEFAULT 1、`last_sync_at` DATETIME NULL、`last_sync_status` VARCHAR(16) NULL（SUCCESS/PARTIAL/FAILED）、`last_error` VARCHAR(512) NULL、通用列；KEY `idx_kb(kb_id)`，UK `uk_kb_name(kb_id, name)` |
+| t_kb_ext_source_item | `id` BIGINT PK AUTO、`source_id` VARCHAR(64) NOT NULL、`object_key` VARCHAR(1024) NOT NULL、`object_key_hash` CHAR(64) NOT NULL（sha256，等值定位）、`etag` VARCHAR(128) NULL、`doc_id` VARCHAR(64) NULL、`last_status` VARCHAR(16) NULL（SUCCESS/UNCHANGED/SKIPPED/FAILED）、`last_error` VARCHAR(512) NULL、`last_sync_at` DATETIME NULL、通用列；UK `uk_source_object(source_id, object_key_hash)`，KEY `idx_source(source_id)` |
+
+- **凭证存储取舍**：`secret_key` 明文落库、读 API 恒返回 `******`、更新时传空 = 保留旧值。前提与 D17 一致：管理台单管理员 + 网络隔离；引入 KMS/信封加密属权限体系批次。CHANGELOG 醒目声明。
+- JSON 配置列扩展（无 DDL）：`t_kb_knowledge_base.index_config` 增 `metadata_rules`、`split_separator`、`split_separator_is_regex`、`split_heading_level`、`multimodal_enabled`；`retrieval_config` 增 `rerank_mode`、`rerank_w_semantic`。
+
+## 2. F1 外部数据源连接器（S3/OSS）
+
+### 2.1 SPI（kb-domain port，为后续 Confluence/飞书预留）
+- `ExternalConnector`：`String type()`、`List<RemoteObject> listObjects(ExtSourceConfig config)`（RemoteObject = key/etag/size/lastModified）、`byte[] fetchObject(ExtSourceConfig config, String objectKey)`、`HealthStatus testConnection(ExtSourceConfig config)`。
+- `ConnectorRouter`（kb-domain service，先例 SplitterRouter）：按 `source_type` 从容器收集实现路由；未知类型 INVALID_PARAM（不回落——连不上的连接器没有"默认行为"可言）。
+- kb-infrastructure 实现 `S3CompatibleConnector`（type=`s3`）：**复用已依赖的 MinIO SDK**（对象存储适配器同款），listObjects 带 prefix、单次列举上限 `max-objects-per-source`（默认 500，超出记 PARTIAL + last_error 说明截断）；仅保留扩展名在 `kb.upload.allowed-extensions` 白名单内的对象。
+- **endpoint 不过 UrlGuard**：连接器 endpoint 是管理员配置项而非终端用户输入，且合法场景就是内网 MinIO/OSS 内网域名——与 M12"用户给什么抓什么"的威胁模型不同。契约明示此取舍。
+
+### 2.2 同步语义（登记后异步首同步、手动 sync、定时任务三处共用）
+1. `testConnection` 失败 → 源级 FAILED + last_error，不逐对象；
+2. listObjects → 逐对象比对 item 行：`etag` 未变 → UNCHANGED 不触上传链；绑定文档在回收站 → SKIPPED（M12 同口径文案）；对象已从 bucket 消失 → item 记 SKIPPED"对象已不存在"（**弱绑定：不动文档**）；
+3. 其余 → `fetchObject` → `DocumentService.upload(kbId, fileName, bytes)`——派生文件名 `{对象名 slug}-{key_hash 前 8 位}.{ext}`（M12 先例，防不同 key 撞名合并）；回填 doc_id/etag；
+4. 单对象失败记 item FAILED 不中断本源其余对象；源级状态 = 全成 SUCCESS / 有失败或截断 PARTIAL / 源级错误 FAILED；
+5. 治理/版本/索引管道全部经上传链路免费继承，**不新增入库旁路**（M12 铁律沿用）。
+
+### 2.3 端点（ExtSourceController + ExtSourceService，kb-app 包 extsource）
+- `POST /api/v1/kb/{kbId}/ext-sources`：`{source_type, name, endpoint, region?, bucket, prefix?, access_key, secret_key, sync_enabled?=true}` → 落行 + **异步**触发首同步（对象数不可控，不能同步阻塞登记请求；与 M12"登记即抓"的差异点，契约明示）；同 KB 重名 INVALID_PARAM。
+- `GET /api/v1/kb/{kbId}/ext-sources?page=&size=`：列表（secret 恒脱敏）。
+- `POST /api/v1/ext-sources/{sourceId}/sync`：手动同步，**异步受理**返回 `{accepted: true}`，结果看列表状态。
+- `GET /api/v1/ext-sources/{sourceId}/items?page=&size=`：对象明细（同步结果逐对象可见）。
+- `PUT /api/v1/ext-sources/{sourceId}`：可改 name/endpoint/region/bucket/prefix/access_key/secret_key(空=保留)/sync_enabled。
+- `POST /api/v1/ext-sources/{sourceId}/test`：连通性测试（同步执行，返回 HealthStatus）。
+- `DELETE /api/v1/ext-sources/{sourceId}`：硬删源行 + items 行；**不动文档**。
+
+### 2.4 配置键（KbProperties.ExtSource）
+`kb.ext-source.sync-cron=0 0 3 * * *`（EXT_SOURCE_SYNC_CRON）、`sync-enabled=true`、`sync-batch-size=10`（每轮源数）、`max-objects-per-source=500`、`fetch-timeout-ms=30000`。定时任务与 M12 同模式：disabled 短路、单源失败不中断批次。
+
+## 3. F2 配置化元数据抽取
+
+### 3.1 规则模型（KbIndexConfig.metadata_rules，≤10 条）
+```json
+[{"key":"dept","type":"constant","value":"研发部"},
+ {"key":"contract_no","type":"regex","pattern":"合同编号[:：]\\s*(\\S+)"},
+ {"key":"product","type":"keyword_match","keywords":["百炼","通义","灵码"]}]
+```
+- `key` 规范 `^[a-z][a-z0-9_]{1,31}$`，且不得与 ChunkMetadataKeys 既有保留键冲突（冲突 INVALID_PARAM，Controller 单点校验）；
+- `constant`：固定值（截 256）；`regex`：Java Pattern（长度 ≤64，编译失败 INVALID_PARAM），命中取第一个捕获组、无捕获组取整体匹配，值截 256，未命中不写键；`keyword_match`：词表（≤50 词、每词 ≤32 字符），值为命中子集 JSON 数组，空命中不写键。
+
+### 3.2 执行与存储
+- 执行点：索引管线切分之后、落 chunk 之前，`MetadataRuleExtractor`（kb-domain service，纯函数）逐 chunk 抽取，结果合并进 `metadataOf(...)`——与保留键冲突时抽取值让位（保留键语义优先）。
+- 引擎镜像：抽取键统一加 **`ext_` 前缀**写入 ES 字段（dynamic template：`ext_*` → keyword）与 Qdrant payload；MySQL metadata JSON 存原始键名（`dept` 而非 `ext_dept`）——前缀只是引擎侧命名空间，防与既有 mapping 冲突。
+- 指纹：`metadata_rules` 计入 chunk 指纹（改规则 → config_stale → 重建后生效，M3 先例）。
+
+### 3.3 检索过滤
+- `MetadataFilterRequest` 增 `custom: {"dept":"研发部"}`（Map<String,String>，AND 等值；keyword_match 键按"数组包含"匹配）；key 不符规范 INVALID_PARAM；映射到引擎 `ext_` 字段。`MetadataFilter` 域模型、开放 API `PublicSearchRequest.metadata_filter` 同步扩展（白名单参数本就含 metadata_filter，无新增覆盖面）。
+
+## 4. F3 切分策略扩展（三个新 TextSplitter bean，SplitterRouter 自动收集）
+
+| 策略 code | 配置 | 语义 |
+|---|---|---|
+| `separator` | `split_separator`（1-64 字符，默认 `\n\n`）、`split_separator_is_regex`（默认 false） | 按字面量/正则分隔符切段后贪心装包到 `chunk_max_tokens`（复用 FixedLengthTextSplitter 的装包语义）；正则编译失败 INVALID_PARAM（Controller 单点）；分隔符不保留 |
+| `heading` | `split_heading_level`（1-6，默认 2） | 按 markdown `^#{1,level} ` 标题行开新段，标题行归属其后内容；全文无标题 → 整文回落 fixed_length |
+| `page` | 无新参数 | 按解析产物 `pages[]` 边界切分（管线级特例：从 parsed.json 取分页文本，非 markdown 正则）；无 pages 的格式（txt/html 单页）→ 整文一页 |
+
+- **超长兜底统一**：三个策略产出的任何超过 `chunk_max_tokens` 的段落，回落 fixed_length 二次切分（LLM 语义切分已有同款先例）；
+- **父子分片组合限制**：`parent_child_enabled=true` 时 `split_strategy` 仅允许 `fixed_length`/`llm_semantic`（现状），三个新策略 + 父子 → INVALID_PARAM（Controller 单点）——页/标题边界与"父长子短两级预算"语义天然冲突，不做貌合神离的组合；
+- 新策略均不产 title/summary/keywords 元数据（那是 LLM 策略的伴生物）；`page` 策略 chunk metadata 增 `page_no`（进 ChunkMetadataKeys 声明，镜像引擎可过滤）。
+
+## 5. F4 Rerank 混合模式
+
+- `KbRetrievalConfig` + `SearchRequest` 增：`rerank_mode`（`semantic`(默认)/`hybrid`）、`rerank_w_semantic`（0-1，默认 0.7）；五层优先级照旧（请求 > KB > 部署默认 `kb.retrieval.rerank-mode=semantic`）。
+- **实现**：融合阶段为每个候选保留其 BM25 路原始分（`RetrievalCandidate` 增 nullable `bm25Score`——纯向量命中无此分）；rerank 成功后，`hybrid` 的排序分 = `w * rerankScore + (1-w) * minmax(bm25Score)`（min-max 在本次候选集内归一化，无 BM25 分按 0 计）。
+- **阈值语义不变**：`score_threshold` 仍作用于纯语义 rerank 分（ScoreThresholdPolicy 不动）——min-max 归一化分跨查询不可比，把它混进阈值会摧毁"绝对阈值"承诺；hybrid 只影响**排序**。契约明示，前端参数面板同步说明文案。
+- 降级链路照旧：rerank 未配置/超时/失败 → 保持融合序，`hybrid` 请求同样记 `rerank_unavailable`/`rerank_timeout`/`rerank_error`，不新增降级码。
+
+## 6. F5 视觉理解整页索引（多模态向量）
+
+### 6.1 Provider（新 port + DashScope 实现）
+- kb-domain 新 port `MultimodalEmbeddingProvider`：`providerName()/model()/dimension()/isConfigured()/maxBatchSize()`、`List<float[]> embedTexts(List<String>)`、`List<float[]> embedImages(List<ImageInput>)`（ImageInput = bytes + mediaType）、`healthCheck()`。
+- kb-infrastructure `DashScopeMultimodalEmbeddingProvider`：DashScope 原生端点 `POST {url}/services/embeddings/multimodal-embedding/multimodal-embedding`（**非 OpenAI 兼容面**，与 rerank 同款全 URL 配置），model `multimodal-embedding-v1`，1024 维；图片以 **data URL（base64）内联**（桶私有不出网，VisionProvider 同一理由）。⚠️ 若 provider 实测拒收 data URL，实现期降级为 MinIO 预签名 URL 并回补本契约修订记录。
+- 配置键（KbProperties.MultimodalEmbedding）：`kb.multimodal-embedding.model=multimodal-embedding-v1`（MULTIMODAL_EMBEDDING_MODEL）、`api-key`（默认继承 DASHSCOPE_API_KEY，**blank = 整个多模态能力关闭**）、`url=https://dashscope.aliyuncs.com/api/v1`、`dimension=1024`、`batch-size=8`、`timeout-ms=30000`。零 Key 时 `NoopMultimodalEmbeddingProvider`（isConfigured=false）。
+
+### 6.2 索引侧
+- `KbIndexConfig.multimodal_enabled`（默认 false）；开启且 provider 已配置时，索引管线对 **IMAGE 类 chunk**（内嵌图、独立上传图、扫描页 page_render——即 t_kb_image_asset 全部三 kind）额外产多模态向量：`embedImages` 原图字节。VLM 文本代理链路**保留不变**（多模态是加路不是换路，文本代理仍进主索引供 BM25/文本向量召回）。
+- 物理索引：`{kbId}_mm_{model}`、别名 `{kbId}_mm`，t_kb_index_registry 新行（engine 沿用部署引擎、embedding_provider/model 记多模态款）；双写同步行复用 t_kb_chunk_index_sync（physical_index_name 区分），补偿扫描零改动。
+- **引擎边界**：多模态向量仅写向量引擎（qdrant 模式写 Qdrant mm collection；lite/es 模式写 ES `{kbId}_mm` dense_vector 索引）；zero-key（无多模态 Key）→ 开关可存但索引跳过（EmbeddingStatus SKIPPED 先例）。
+- 开关翻转 → 计入 chunk 指纹 → config_stale → 重建补齐/清除 mm 向量。
+
+### 6.3 检索侧（第三召回路）
+- KB `multimodal_enabled` 且 provider 配置时，文本查询同时 `embedTexts` 进多模态空间查 `{kbId}_mm`（图文同空间，文本可命中图）；
+- 融合：mm 路作为第三路参与 **RRF**；`fusion_mode=weighted` 时 mm 路不参与并记 degraded `mm_route_skipped`（先例：graph 与 weighted 互斥的 GraphFusionPolicy 单点，同一处扩展）；
+- mm 命中的是 IMAGE chunk（引擎里 chunk_id 同主索引同一行语义），去重靠 chunk_id ——同一 chunk 主路 mm 路都命中时 RRF 天然聚合；
+- provider 调用失败/超时 → 跳过 mm 路记 degraded `mm_route_unavailable`，主路不受影响。
+
+## 7. F6 以图搜图入口
+
+- **管理台** `SearchRequest` 增 `images?: string[]`（裸 base64，无 data: 前缀；≤3 张、单张解码 ≤5MB、总量 ≤10MB——与 PublicSearchRequest.images 完全同约束同校验，复用 ImageQueryService 的校验单点）。
+- 行为分派（单点在 RetrievalService 编排入口前）：
+  1. KB `multimodal_enabled` 且 mm provider 配置 → `embedImages` 直接查 mm 路（图搜图/图搜文），与文本 query 各路结果 RRF 融合；query 可为空字符串？否——`query` 仍必填（空 query 纯图检索本期不做，百炼图片问答也要求文本意图；契约明示）；
+  2. 否则 → 回落现状：VisionProvider 转写文本追加进 query（ImageQueryService 既有逻辑，degraded `image_understanding_unavailable` 语义不变）。
+- **开放 API**：`PublicSearchRequest.images` 已存在，行为增强同口径（快照 KB multimodal 开启即走 mm 路），请求形状零变化。
+- web：检索调试页增图片上传（≤3、缩略图预览、超限前端先拦 + 服务端兜底）；结果卡片 IMAGE chunk 展示已有，无新增。
+
+## 8. kb-rag-web 汇总
+
+- **外部数据源 tab**（知识库详情，先例 WebSourcesTab）：源列表（名称/bucket/prefix/最近同步 Tag/自动同步 Switch/操作：立即同步、测试连接、编辑、删除 Popconfirm"仅移除登记，已入库文档不受影响"）、新建/编辑抽屉（secret 占位提示"留空保留原值"）、对象明细抽屉（items 分页表）。
+- **IndexConfigDrawer**：切分策略下拉增三项（SPLIT_STRATEGY_META），条件字段（separator 输入 + 正则开关 / heading level 选择）；父子开关与新策略互斥禁用；"元数据抽取"分组（规则列表编辑：key/类型/值-模式-词表，≤10 条）；"多模态索引"开关（mm provider 未配置时禁用 + Alert）。
+- **检索调试页**：rerank 模式选择（semantic/hybrid + w_semantic 滑杆，阈值语义说明文案）、图片上传。
+- api 层：`extSource.ts`（七函数）；types.ts 增 ExtSource/ExtSourceItem/MetadataRule/RerankMode 等类型与 META 表。
+
+## 9. kb-rag-deploy 汇总
+
+- OpenAPI kb-server.yaml：ext-sources 7 端点 + schema、SearchRequest/IndexConfig/RetrievalConfig 扩展字段、版本升 **0.14.0-m14**。
+- `.env.example` 增：EXT_SOURCE_ 五变量、MULTIMODAL_EMBEDDING_ 四变量、RETRIEVAL_RERANK_MODE、RETRIEVAL_RERANK_W_SEMANTIC。
+- CHANGELOG：六特性 + secret 明文存储声明 + degraded 新码（`mm_route_unavailable`/`mm_route_skipped`）。
+
+## 10. 单测清单（必须，离线，精确断言）
+
+- **F1**：ConnectorRouter 未知类型拒；同步语义（etag 未变→UNCHANGED 不触 upload、变了→upload 回填、trashed→SKIPPED、对象消失→SKIPPED 不动文档、单对象失败不中断、超上限→PARTIAL）；派生文件名稳定性/不撞名；secret 脱敏与"空=保留"；定时 disabled 短路。S3 列举/取回 mock MinIO client。
+- **F2**：key 规范与保留键冲突拒；三类规则各正/负例（regex 捕获组/无捕获组/未命中不写键、keyword 子集/空不写键、constant 截断）；保留键冲突让位；规则进指纹；custom 过滤映射 ext_ 前缀、非法 key 拒。
+- **F3**：separator 字面量/正则/编译失败拒/分隔符不保留；heading 各 level 边界/无标题回落；page 多页/无 pages 单页；三策略超长回落 fixed_length；父子组合拒；page_no 入 metadata。
+- **F4**：hybrid 排序分公式（含无 bm25 分按 0、min-max 单点集退化）；阈值仍作用语义分；rerank 降级时 hybrid 行为同现状；参数五层优先级。
+- **F5**：开关+provider 齐备才产 mm 向量；zero-key SKIPPED；registry/同步行落 mm 索引名；weighted 模式 mm 路跳过记 degraded；provider 失败降级不影响主路；开关进指纹。
+- **F6**：mm 可用走 embedImages、不可用回落 VLM 转写；images 约束校验复用单点（超张数/超体积拒）；query 仍必填。
+- **回归红线**：全部新字段缺省时，现有单测零修改通过（兼容承诺的机器验证）。
+
+## 11. 验收清单（实现完成后用户自测）
+
+1. 登记本地 MinIO bucket（放 pdf/docx/图片各一）→ 异步同步后文档全部 INDEXED 可检索；改对象重传 → sync 产生新版本；删对象 → sync 后文档仍在（SKIPPED）；secret 列表恒 `******`。
+2. 配置 metadata_rules（合同编号 regex + 产品词表）→ 重建后 chunk metadata 可见抽取值 → 检索 `custom:{contract_no:...}` 精确命中。
+3. 四种新旧切分策略各建一库导同一文档，切片边界符合各自语义；父子 + separator 组合被拒。
+4. hybrid 模式下关键词强匹配文档排序上升；阈值过滤行为与 semantic 模式一致。
+5. 开启 multimodal 的库上传扫描件与图片 → 文本 query 可命中图片 chunk（mm 路 RRF 融合可在 debug 页看到 retrieval_source）。
+6. 检索调试页传图 → mm 库直接图搜图命中原图 chunk；非 mm 库回落 VLM 转写仍有结果；开放 API images 同口径。
+7. `mvn -B -ntp verify` 全绿；`pytest` 全绿（parser 本期无改动，跑回归）；oxlint/tsc 全绿。

--- a/kb-rag-deploy/docs/M3-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M3-CONTRACTS.md
@@ -25,6 +25,7 @@
 ```
 - `kind=embedded`：pdf/docx 内嵌图片；`kind=page_render`：整页无文本层（扫描件），把该页渲染为 PNG（150 dpi）
 - **扫描页判定**：该页抽取文本去空白后长度 < `SCANNED_PAGE_TEXT_THRESHOLD`（默认 20 字符）即视为扫描页，`pages[].scanned=true` 且产出一个 `page_render` 图片，其占位符插入该页文本位置
+- **乱码页判定**（后补，与代码一致）：文本层长度达标但可识别字符（ASCII/CJK/假名/中日标点等区段）占比 < `GARBLED_PAGE_VALID_CHAR_RATIO_PCT`%（默认 50，可环境变量覆盖）——典型为内嵌子集字体 ToUnicode CMap 缺失/损坏导致的错码位"字形汤"——该页降级走扫描页路径：乱码文本**置空不入库**，产出 `page_render` 图片交 OCR/VLM 兜底，并在 `data.warnings[]` 记录一条说明
 - 占位符格式固定 `[[IMAGE:{image_id}]]`，一行独占，便于 server 精确替换
 - 图片上限保护：单文档图片数上限（默认 100，`MAX_IMAGES_PER_DOC`）、单图字节上限（默认 10MB），超限跳过并在响应 `data.warnings[]` 中说明（不失败整篇）
 

--- a/kb-rag-deploy/docs/openapi/kb-server.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-server.yaml
@@ -141,8 +141,31 @@ info:
 
     （UPLOAD_ALLOWED_EXTENSIONS 新增 html）。
 
+
+    0.14.0-m14（六特性：外部数据源连接器/配置化元数据抽取/切分策略扩展/Rerank 混合模式/视觉理解
+
+    整页索引/以图搜图，docs/M14-CONTRACTS.md）：①新增外部数据源端点（登记/列表/手动同步/对象明细/
+
+    编辑/连通性测试/移除，新增 `ext-source` tag 与 `ExtSource`/`ExtSourceItem` schema，secret 恒
+
+    脱敏返回 `******`、更新传空=保留旧值）；②`IndexConfig` 增 `metadata_rules`（常量/正则/词表
+
+    三类抽取规则，新增 `MetadataRule` schema）、`split_separator`/`split_separator_is_regex`/
+
+    `split_heading_level`（配合 `SplitStrategy` 扩展的 separator/heading/page 三策略）、
+
+    `multimodal_enabled`（KB 级多模态整页索引开关）；③`SearchRequest` 增 `images`（以图搜图，裸
+
+    base64、≤3 张）、`rerank_mode`（semantic 默认/hybrid）、`rerank_w_semantic`（hybrid 语义权重，
+
+    默认 0.7）、`MetadataFilter.custom`（抽取键等值过滤）；④`DegradedReason` 补
+
+    `mm_route_skipped`/`mm_route_unavailable`；⑤`ModelStatus` 补 multimodal_configured/provider/
+
+    model。全部纯新增、缺省即现状（详见 M14-CONTRACTS.md §0 兼容红线）。
+
     '
-  version: 0.13.0-m12
+  version: 0.14.0-m14
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -176,6 +199,8 @@ tags:
   description: 内容治理：审核发布/有效期/回收站（M11，docs/M11-CONTRACTS.md §2.2）
 - name: web-source
   description: 数据接入：URL 登记导入与增量同步（M12，docs/M12-CONTRACTS.md §3.4）
+- name: ext-source
+  description: 外部数据源连接器：S3/OSS 兼容对象存储登记、扫描与增量同步（M14，docs/M14-CONTRACTS.md §2）
 - name: app-center
   description: 应用中心：应用/版本/发布门禁与控制台 chat 预览（M4c，docs/M4c-CONTRACTS.md §2）
 - name: api-key
@@ -1050,6 +1075,242 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/kb/{kbId}/ext-sources:
+    parameters:
+    - $ref: '#/components/parameters/KbId'
+    post:
+      tags:
+      - ext-source
+      summary: 登记外部数据源并异步触发首同步
+      description: 'M14-CONTRACTS.md §2.3：落行后异步受理首次扫描（对象数不可控，不同步阻塞登记，
+        与 M12 登记即抓的差异点）；同 KB 重名 INVALID_PARAM。secret_key 明文落库、读 API 恒脱敏。'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [source_type, name, endpoint, bucket, access_key, secret_key]
+              properties:
+                source_type:
+                  type: string
+                  maxLength: 16
+                  description: 连接器类型路由键，本期仅 s3
+                name:
+                  type: string
+                  maxLength: 128
+                endpoint:
+                  type: string
+                  maxLength: 512
+                  description: 对象存储服务端点，不过 UrlGuard（管理员配置项，合法场景即内网 MinIO/OSS）
+                region:
+                  type: string
+                  maxLength: 64
+                bucket:
+                  type: string
+                  maxLength: 128
+                prefix:
+                  type: string
+                  maxLength: 512
+                access_key:
+                  type: string
+                  maxLength: 256
+                secret_key:
+                  type: string
+                  maxLength: 512
+                sync_enabled:
+                  type: boolean
+                  default: true
+      responses:
+        '200':
+          description: 登记行（首同步结果异步回填）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtSourceResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    get:
+      tags:
+      - ext-source
+      summary: 外部数据源列表（secret 恒脱敏）
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtSourceListResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/ext-sources/{sourceId}/sync:
+    parameters:
+    - name: sourceId
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      tags:
+      - ext-source
+      summary: 手动触发一次同步（异步受理）
+      description: 'M14-CONTRACTS.md §2.3：异步受理返回 {accepted:true}，结果落在源与对象明细的
+        状态上。etag 未变 UNCHANGED、绑定文档在回收站 SKIPPED、对象消失 SKIPPED；单对象失败不中断
+        本源其余对象。'
+      responses:
+        '200':
+          description: 受理确认
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtSourceSyncAcceptedResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/ext-sources/{sourceId}/items:
+    parameters:
+    - name: sourceId
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      tags:
+      - ext-source
+      summary: 对象明细（逐对象同步结果可见）
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtSourceItemListResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/ext-sources/{sourceId}:
+    parameters:
+    - name: sourceId
+      in: path
+      required: true
+      schema:
+        type: string
+    put:
+      tags:
+      - ext-source
+      summary: 编辑源（secret 传空=保留旧值）
+      description: 'M14-CONTRACTS.md §2.3：可改 name/endpoint/region/bucket/prefix/access_key/
+        secret_key(空=保留)/sync_enabled。'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, endpoint, bucket, access_key]
+              properties:
+                name:
+                  type: string
+                  maxLength: 128
+                endpoint:
+                  type: string
+                  maxLength: 512
+                region:
+                  type: string
+                  maxLength: 64
+                bucket:
+                  type: string
+                  maxLength: 128
+                prefix:
+                  type: string
+                  maxLength: 512
+                access_key:
+                  type: string
+                  maxLength: 256
+                secret_key:
+                  type: string
+                  maxLength: 512
+                  description: 空或缺省=保留已存储的 secret
+                sync_enabled:
+                  type: boolean
+      responses:
+        '200':
+          description: 更新后的源（secret 脱敏）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtSourceResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+      - ext-source
+      summary: 移除源（硬删源行与对象明细，不动文档）
+      description: 'M14-CONTRACTS.md §2.3：硬删源行 + items 行；它喂过的文档保留在知识库。'
+      responses:
+        '200':
+          description: 已移除
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyResult'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/ext-sources/{sourceId}/test:
+    parameters:
+    - name: sourceId
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      tags:
+      - ext-source
+      summary: 连通性测试（同步执行）
+      description: 'M14-CONTRACTS.md §2.3：同步探测连通性与凭证，返回 HealthStatus，不触碰任何对象。'
+      responses:
+        '200':
+          description: 探测结果
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtSourceTestResult'
         '404':
           $ref: '#/components/responses/NotFound'
   /api/v1/kb/{kbId}/graph/config:
@@ -3404,6 +3665,193 @@ components:
                 type: integer
               total:
                 type: integer
+    MetadataRule:
+      type: object
+      description: 'M14-CONTRACTS.md §3.1：一条配置化元数据抽取规则。key 须符合 ^[a-z][a-z0-9_]{1,31}$
+
+        且不得与保留键冲突；type=constant 固定值（value，截 256）；type=regex 取第一个捕获组/无
+
+        捕获组取整体（pattern ≤64，编译失败 INVALID_PARAM）；type=keyword_match 取命中子集
+
+        （keywords ≤50 词/每词 ≤32）。'
+      required:
+      - key
+      - type
+      properties:
+        key:
+          type: string
+          pattern: '^[a-z][a-z0-9_]{1,31}$'
+        type:
+          type: string
+          enum:
+          - constant
+          - regex
+          - keyword_match
+        value:
+          type: string
+          nullable: true
+          maxLength: 256
+          description: constant 规则的固定值
+        pattern:
+          type: string
+          nullable: true
+          maxLength: 64
+          description: regex 规则的 Java 正则源
+        keywords:
+          type: array
+          nullable: true
+          maxItems: 50
+          items:
+            type: string
+            maxLength: 32
+          description: keyword_match 规则的词表
+    ExtSource:
+      type: object
+      description: '外部数据源登记行（M14-CONTRACTS.md §2.3）。secret_key 恒返回掩码 ******，从不
+
+        下发真实值；登记与文档弱绑定，移除源不删文档。'
+      properties:
+        source_id:
+          type: string
+        kb_id:
+          type: string
+        source_type:
+          type: string
+          description: 连接器类型路由键，本期仅 s3
+        name:
+          type: string
+        endpoint:
+          type: string
+        region:
+          type: string
+          nullable: true
+        bucket:
+          type: string
+        prefix:
+          type: string
+          nullable: true
+        access_key:
+          type: string
+        secret_key:
+          type: string
+          description: 恒为掩码 ******，从不下发真实值
+        sync_enabled:
+          type: boolean
+        last_sync_status:
+          type: string
+          nullable: true
+          enum:
+          - SUCCESS
+          - PARTIAL
+          - FAILED
+          description: 首次同步前为 null
+        last_sync_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_error:
+          type: string
+          nullable: true
+          maxLength: 512
+        created_at:
+          type: string
+          format: date-time
+    ExtSourceItem:
+      type: object
+      description: 外部数据源逐对象同步结果行（M14-CONTRACTS.md §2.3）
+      properties:
+        object_key:
+          type: string
+        etag:
+          type: string
+          nullable: true
+        doc_id:
+          type: string
+          nullable: true
+          description: 首次成功入库前为 null
+        last_status:
+          type: string
+          nullable: true
+          enum:
+          - SUCCESS
+          - UNCHANGED
+          - SKIPPED
+          - FAILED
+        last_error:
+          type: string
+          nullable: true
+          maxLength: 512
+        last_sync_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+    ExtSourceResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            $ref: '#/components/schemas/ExtSource'
+    ExtSourceListResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            type: object
+            properties:
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExtSource'
+              page:
+                type: integer
+              total:
+                type: integer
+    ExtSourceItemListResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            type: object
+            properties:
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExtSourceItem'
+              page:
+                type: integer
+              total:
+                type: integer
+    ExtSourceTestResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            type: object
+            properties:
+              up:
+                type: boolean
+                description: 对象存储应答且 bucket 存在时 true
+              detail:
+                type: string
+                description: 探测详情
+    ExtSourceSyncAcceptedResult:
+      allOf:
+      - $ref: '#/components/schemas/ResultEnvelope'
+      - type: object
+        properties:
+          data:
+            type: object
+            properties:
+              accepted:
+                type: boolean
+                description: 异步受理恒为 true，结果看列表状态
     EmbeddingStatus:
       type: string
       enum:
@@ -3477,6 +3925,17 @@ components:
       properties:
         query:
           type: string
+        images:
+          type: array
+          nullable: true
+          maxItems: 3
+          description: '以图搜图（M14-CONTRACTS.md §7）：裸 base64（无 data: 前缀），≤3 张/单张 5MB/
+
+            总量 10MB（以服务端为权威，超限 INVALID_PARAM）；query 仍必填。多模态可用时直接嵌入多模态
+
+            空间检索，否则回落 VLM 转写。'
+          items:
+            type: string
         recall_top_k:
           type: integer
           default: 50
@@ -3505,6 +3964,27 @@ components:
           type: boolean
           nullable: true
           description: 默认 true（仅当 RERANK_MODEL 已配置生效），显式传 false 可关闭。
+        rerank_mode:
+          type: string
+          nullable: true
+          enum:
+          - semantic
+          - hybrid
+          description: 'M14-CONTRACTS.md §5：semantic（默认）=纯语义重排分排序；hybrid=语义重排分与
+
+            归一化 BM25 分线性加权决定排序。五层优先级照旧（请求 > KB > 部署默认
+
+            kb.retrieval.rerank-mode=semantic）。hybrid 只影响排序，不改变 score_threshold 的纯语义
+
+            分阈值语义（min-max 归一化分跨查询不可比，不入阈值）。'
+        rerank_w_semantic:
+          type: number
+          format: float
+          nullable: true
+          minimum: 0
+          maximum: 1
+          description: 仅 rerank_mode=hybrid 时生效，默认 0.7；排序分 = w * rerankScore + (1-w) *
+            minmax(bm25Score)。
         rewrite_enabled:
           type: boolean
           default: false
@@ -3564,6 +4044,14 @@ components:
 
         实时别名路径，但那是历史数据形态而非故障，不记该标记，M6-CONTRACTS.md §0.4/§0.5）。
 
+        M14 新增（docs/M14-CONTRACTS.md §6.4）：mm_route_skipped（多模态开启但本次融合权重为 0，
+
+        多模态召回路被跳过）、mm_route_unavailable（多模态 provider 未配置或调用失败，其余召回路
+
+        照常应答）。rerank 混合模式（hybrid）复用既有 rerank_unavailable/rerank_timeout/rerank_error
+
+        降级码，不新增。
+
         '
       enum:
       - vector_route_unavailable
@@ -3578,6 +4066,8 @@ components:
       - snapshot_index_missing
       - graph_route_unavailable
       - image_understanding_unavailable
+      - mm_route_skipped
+      - mm_route_unavailable
     GraphSummary:
       type: object
       description: M7 图谱概览（GraphSummaryResponse）
@@ -3812,6 +4302,16 @@ components:
           type: string
           format: date-time
           nullable: true
+        custom:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+          description: 'M14-CONTRACTS.md §3.3：对管理员配置化元数据抽取键的等值过滤（AND；
+
+            keyword_match 键按“数组包含”匹配），key 须符合 ^[a-z][a-z0-9_]{1,31}$ 否则
+
+            INVALID_PARAM；映射到引擎 ext_ 前缀字段。'
     AppliedSearchParams:
       type: object
       description: 调试页顶部信息条：本次请求实际生效的改写/融合/阈值作用口径（M2-CONTRACTS.md §1.5）；
@@ -3856,14 +4356,23 @@ components:
           minimum: 0
     SplitStrategy:
       type: string
-      description: '切分策略（server SplitStrategy 枚举，**当前只有这两个成员**——需求文档描述的
-        六种切分方式仅落地这两种，parent_child 是正交的独立开关不属于本枚举）。
-        fixed_length=按 token 长度顺切；llm_semantic=对话模型只输出切割点、结果落库缓存，
-        **要求已配置对话模型**，否则 PUT index-config 返回 INVALID_PARAM。
-        未知取值一律 INVALID_PARAM（校验先于写入，失败不改动既有配置）。'
+      description: '切分策略。fixed_length=按 token 长度顺切（M1 默认）；llm_semantic=对话模型只输出
+
+        切割点、结果落库缓存，**要求已配置对话模型**；separator=按字面量/正则分隔符切段后贪心装包
+
+        （M14，配 split_separator/split_separator_is_regex）；heading=按 markdown 标题层级开新段
+
+        （M14，配 split_heading_level，全文无标题回落 fixed_length）；page=按解析产物分页边界切分
+
+        （M14，无 pages 的格式整文一页）。separator/heading/page 与 parent_child 互斥（INVALID_PARAM）；
+
+        超长段统一回落 fixed_length 二次切分。未知取值一律 INVALID_PARAM（校验先于写入）。'
       enum:
       - fixed_length
       - llm_semantic
+      - separator
+      - heading
+      - page
       default: fixed_length
     IndexConfig:
       type: object
@@ -3881,6 +4390,41 @@ components:
       properties:
         split_strategy:
           $ref: '#/components/schemas/SplitStrategy'
+        split_separator:
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 64
+          description: 'M14 separator 策略分隔符（1-64 字符，默认 \n\n）；split_separator_is_regex=true
+
+            时作为 Java 正则，编译失败 INVALID_PARAM；其余策略忽略此字段。'
+        split_separator_is_regex:
+          type: boolean
+          default: false
+          description: split_separator 是否为正则（M14 separator 策略）。
+        split_heading_level:
+          type: integer
+          minimum: 1
+          maximum: 6
+          default: 2
+          description: 'M14 heading 策略的 markdown 标题层级（1-6，默认 2）；其余策略忽略此字段。'
+        metadata_rules:
+          type: array
+          nullable: true
+          maxItems: 10
+          description: 'M14-CONTRACTS.md §3.1：KB 级配置化元数据抽取规则（≤3 类共 ≤10 条），切分后逐
+
+            chunk 抽取入 metadata 并镜像引擎（ext_ 前缀）；计入 chunk 指纹，改规则 config_stale
+
+            重建后生效。'
+          items:
+            $ref: '#/components/schemas/MetadataRule'
+        multimodal_enabled:
+          type: boolean
+          default: false
+          description: 'M14-CONTRACTS.md §6.2：KB 级多模态整页索引开关，默认关。开启且多模态 provider 已
+
+            配置时，IMAGE chunk（含扫描页整页渲染）额外产多模态向量，检索新增第三召回路；计入指纹。'
         embedding_model:
           type: string
           nullable: true
@@ -4198,6 +4742,15 @@ components:
           type: string
           nullable: true
         vision_model:
+          type: string
+          nullable: true
+        multimodal_configured:
+          type: boolean
+          description: M14-CONTRACTS.md §6：多模态嵌入 provider（DashScope multimodal-embedding-v1）是否已配置；false 时管理台置灰 KB 级多模态整页索引开关
+        multimodal_provider:
+          type: string
+          nullable: true
+        multimodal_model:
           type: string
           nullable: true
     ModelStatusResult:

--- a/kb-rag-parser/CHANGELOG.md
+++ b/kb-rag-parser/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式。
 
+## [未发布] - M14
+
+### 修复
+
+- **pdf 乱码页不再入库**（M3-CONTRACTS.md §2.1 乱码页判定）：内嵌子集字体缺失/损坏 ToUnicode CMap 的 pdf，`page.get_text()` 抽出的是错码位"字形汤"（中文变缅甸文/方块，数字与英文往往仍正常），文本长度达标故躲过扫描页阈值，垃圾文本被直接切分入库。现按可识别字符（ASCII/CJK/假名/中日标点等区段）占比判定：低于 `GARBLED_PAGE_VALID_CHAR_RATIO_PCT`（新环境变量，默认 50）即置空该页文本并复用扫描页路径（`scanned=true` + `page_render` 渲染交 OCR/VLM 兜底），同时在 `data.warnings[]` 记录一条说明，不失败整篇。
+- pytest 新增（`tests/test_parse_pdf_garbled.py`）：乱码判定正例、正常中英文与空输入的负例、乱码页端到端降级为 `page_render` 且文本置空并带 warning。
+
 ## [未发布] - M12
 
 ### 新增

--- a/kb-rag-parser/README.md
+++ b/kb-rag-parser/README.md
@@ -52,6 +52,7 @@ python3 -m venv .venv
 | 变量 | 默认值 | 说明 |
 |---|---|---|
 | `SCANNED_PAGE_TEXT_THRESHOLD` | `20` | pdf 页面文本层短于此长度即判定为扫描页 |
+| `GARBLED_PAGE_VALID_CHAR_RATIO_PCT` | `50` | pdf 页面文本层可识别字符（ASCII/CJK/假名/中日标点等）占比低于此百分比即判定为乱码页，降级走扫描页路径 |
 | `MAX_IMAGES_PER_DOC` | `100` | 单文档图片数量上限 |
 | `MAX_IMAGE_BYTES` | `10485760`（10MB） | 单张图片字节数上限 |
 | `OCR_ENGINE` | `none` | `none`\|`paddle`；`paddle` 但未装 `requirements-ocr.txt` 时启动 fast-fail（M8-CONTRACTS.md §0.4） |
@@ -98,9 +99,10 @@ python3 -m venv .venv
 ```
 
 - `pages[].scanned`：该页文本去空白后长度 < `SCANNED_PAGE_TEXT_THRESHOLD`（默认 20，环境变量可配）即为 `true`，此时该页按 150dpi 渲染为 PNG（`kind=page_render`）替代文本层；只有 pdf 页面可能为扫描页，其余格式恒为 `false`。
+- **乱码页降级**（pdf）：文本层长度达标但可识别字符占比 < `GARBLED_PAGE_VALID_CHAR_RATIO_PCT`（默认 50%）时，判定该页文本层不可用——常见于内嵌子集字体的 ToUnicode CMap 缺失/损坏，中文被抽成错码位的"字形汤"（数字/英文往往仍正常）。此时该页 `text` 置空、`scanned=true`、产出 `page_render` 图片交 OCR/VLM 兜底，并在 `warnings[]` 记录一条说明，乱码文本不会进入切分与索引。
 - `pages[].ocr_source`（M8-CONTRACTS.md §0.4）：扫描页被本服务 PaddleOCR 兜底成功识别出文本时为 `"paddle"`（此时 `pages[].text` 已回填为 OCR 结果），否则为 `null`（`OCR_ENGINE=none` 默认状态 / 非扫描页 / OCR 超时或失败按页跳过）。kb-rag-server 对带 `ocr_source` 的页不应再走自己的 VLM。
 - `images[].kind`：`embedded`（pdf/docx 内嵌图片）或 `page_render`（扫描页整页渲染）；图片的 VLM 文本代理生成仍属于 kb-rag-server 侧职责（§4.2），本服务默认不做任何模型调用，`ocr_source` 是唯一例外且默认关闭。
-- `warnings[]`：单文档图片数上限（默认 100，`MAX_IMAGES_PER_DOC`）或单图字节上限（默认 10MB，`MAX_IMAGE_BYTES`）超限时，该图被跳过并在此记录说明，不影响文档其余部分正常返回。
+- `warnings[]`：单文档图片数上限（默认 100，`MAX_IMAGES_PER_DOC`）或单图字节上限（默认 10MB，`MAX_IMAGE_BYTES`）超限时，该图被跳过并在此记录说明，不影响文档其余部分正常返回；pdf 乱码页降级也在此记录（见上）。
 
 ### `POST /api/v1/parse/chat`
 
@@ -153,7 +155,7 @@ html（M8-CONTRACTS.md §0.2，DOM 选择器）：
 
 | file_ext | 解析库 | 说明 |
 |---|---|---|
-| `pdf` | PyMuPDF (`pymupdf`/`fitz`) | 按页抽取文本层；无文本层的页面（扫描页）渲染为 PNG，默认交由 kb-rag-server 侧 VLM OCR（M3-CONTRACTS.md §0），`OCR_ENGINE=paddle` 时本服务自行用 PaddleOCR 兜底出文本（M8-CONTRACTS.md §0.4） |
+| `pdf` | PyMuPDF (`pymupdf`/`fitz`) | 按页抽取文本层；无文本层的页面（扫描页）或文本层为乱码的页面（ToUnicode CMap 损坏）渲染为 PNG，默认交由 kb-rag-server 侧 VLM OCR（M3-CONTRACTS.md §0），`OCR_ENGINE=paddle` 时本服务自行用 PaddleOCR 兜底出文本（M8-CONTRACTS.md §0.4） |
 | `docx` | python-docx | 按文档原始顺序抽取段落+表格+内嵌图片；docx 无可靠页码概念，整篇作为 `page_no=1` 返回 |
 | `txt` | 标准库 | 尽力探测编码（utf-8-sig/utf-8/gbk），原样返回 |
 | `md` | 标准库 | 原样透传，本身已是 markdown |
@@ -223,6 +225,7 @@ M1：
 M3（M3-CONTRACTS.md §2）：
 
 - 扫描页判定为 `true` 时，不再额外抽取该页的内嵌图片（整页已作为一张 `page_render` 图片产出，避免同一内容被计两次）。
+- 契约只定义了"无文本层"的扫描页判定；实测存在文本层长度达标但内容为错码位乱码的 pdf（内嵌子集字体缺失/损坏 ToUnicode CMap），故补充可识别字符占比判定（`GARBLED_PAGE_VALID_CHAR_RATIO_PCT`，默认 50%），命中即置空该页文本并复用扫描页渲染路径，同时写一条 `warnings[]`——否则错码位文本会被直接切分入库，产生整段不可检索的垃圾分片。M3-CONTRACTS.md §2.1 已同步该判定。
 - docx 内嵌图片的占位符位置：能从段落 XML 匹配到 `r:embed` 引用时按原文顺序在该段落后插入占位符；无法匹配到具体段落的图片（如表格单元格、页眉页脚内的图片）统一追加在文档末尾，仍计入 `images[]`，不会丢失。
 - `memotrace` 映射档案与 WeChat 数值 `msg_type` 编码依据公开约定编写，尚未用真实 MemoTrace 导出样例校准（契约本身也标注了这一点）；`content` 列是唯一的硬性 fast-fail 条件，其余字段缺失时优雅降级而非整篇失败。
 

--- a/kb-rag-parser/app/config.py
+++ b/kb-rag-parser/app/config.py
@@ -33,7 +33,7 @@ PARSER_EXECUTOR_MAX_WORKERS = 4
 
 # Supported file extensions (registry keys), kept in one place to avoid
 # scattering the whitelist across modules.
-SUPPORTED_FILE_EXTENSIONS = frozenset({"pdf", "docx", "txt", "md", "xlsx", "csv"})
+SUPPORTED_FILE_EXTENSIONS = frozenset({"pdf", "docx", "txt", "md", "sql", "xlsx", "csv"})
 
 # Zip-based formats that must go through the zip safety precheck before
 # being handed to python-docx / openpyxl.
@@ -68,6 +68,16 @@ SCANNED_PAGE_TEXT_THRESHOLD = _read_int_env("SCANNED_PAGE_TEXT_THRESHOLD", 20)
 # DPI used to render a scanned page to PNG. Fixed by the contract, not
 # environment-configurable (only the threshold above is).
 SCANNED_PAGE_RENDER_DPI = 150
+
+# A page whose text layer *exists* but decodes mostly to unrecognizable
+# code points (typical of an embedded subset font with a missing/broken
+# ToUnicode CMap: CJK content surfaces as e.g. Myanmar/box glyph soup) is
+# treated as garbled. When fewer than this percentage of its
+# non-whitespace characters fall in recognizable Unicode ranges
+# (ASCII/CJK/kana/CJK punctuation, see app/parsers/pdf.py), the page
+# falls back to the scanned-page path (page render + OCR/VLM) instead of
+# indexing the glyph soup.
+GARBLED_PAGE_VALID_CHAR_RATIO_PCT = _read_int_env("GARBLED_PAGE_VALID_CHAR_RATIO_PCT", 50)
 
 # Per-document image-count cap and per-image byte-size cap. Exceeding
 # either just skips that one image and records a warning (see

--- a/kb-rag-parser/app/parsers/pdf.py
+++ b/kb-rag-parser/app/parsers/pdf.py
@@ -22,6 +22,38 @@ logger = logging.getLogger(__name__)
 # page renders; kept as a constant to avoid repeating the literal.
 _PAGE_RENDER_MEDIA_TYPE = "image/png"
 
+# Unicode ranges whose characters count as "recognizable" when deciding
+# whether an extracted text layer is garbled (see _is_garbled_text).
+# Covers ASCII, general punctuation, CJK punctuation, kana, CJK
+# ideographs (base + extension A), and half/fullwidth forms.
+_RECOGNIZABLE_CHAR_RANGES: Tuple[Tuple[int, int], ...] = (
+    (0x0020, 0x007E),  # ASCII printable
+    (0x2000, 0x206F),  # general punctuation (dashes, quotes, ellipsis)
+    (0x3000, 0x303F),  # CJK symbols and punctuation
+    (0x3040, 0x30FF),  # hiragana + katakana
+    (0x3400, 0x4DBF),  # CJK unified ideographs extension A
+    (0x4E00, 0x9FFF),  # CJK unified ideographs
+    (0xFF00, 0xFFEF),  # halfwidth/fullwidth forms
+)
+
+
+def _is_garbled_text(text: str) -> bool:
+    """Heuristic for a broken text layer: a PDF whose embedded subset font
+    lacks a usable ToUnicode CMap extracts as wrong-codepoint "glyph soup"
+    (e.g. CJK content surfacing as Myanmar/box-drawing glyphs while ASCII
+    digits survive). Such a page has plenty of characters, so the
+    scanned-page length threshold never catches it; instead, the page is
+    declared garbled when the share of characters inside recognizable
+    Unicode ranges falls below GARBLED_PAGE_VALID_CHAR_RATIO_PCT."""
+    meaningful = [char for char in text if not char.isspace()]
+    if not meaningful:
+        return False
+    recognizable = sum(
+        1 for char in meaningful if any(low <= ord(char) <= high for low, high in _RECOGNIZABLE_CHAR_RANGES)
+    )
+    # Integer comparison of recognizable/len(meaningful) < pct/100.
+    return recognizable * 100 < config.GARBLED_PAGE_VALID_CHAR_RATIO_PCT * len(meaningful)
+
 
 class PdfParser(BaseParser):
     """Extracts per-page plain text, embedded images, and scanned-page
@@ -38,6 +70,11 @@ class PdfParser(BaseParser):
     A scanned page's embedded images are not separately extracted: the
     whole page is already captured as one page_render image, so extracting
     its raw embedded images too would just double-count the same content.
+
+    A page whose text layer extracts as garbled glyph soup (broken/missing
+    ToUnicode CMap, see _is_garbled_text) is downgraded to the same
+    scanned-page path: its unusable text is dropped, the page is rendered,
+    and a warning is recorded.
 
     M8 (M8-CONTRACTS.md §0.4) adds an optional local OCR fallback: when
     OCR_ENGINE=paddle is configured (and the optional paddleocr dependency
@@ -65,10 +102,26 @@ class PdfParser(BaseParser):
             collector = ImageAssetCollector()
             pages: List[PageContent] = []
             markdown_parts: List[str] = []
+            page_warnings: List[str] = []
             for page_index in range(document.page_count):
                 page = document.load_page(page_index)
                 text = page.get_text()
                 page_no = page_index + 1
+                if len(text.strip()) >= SCANNED_PAGE_TEXT_THRESHOLD and _is_garbled_text(text):
+                    # Wrong-codepoint glyph soup must never reach chunking/
+                    # indexing; blank it so this page is handled exactly
+                    # like a scanned one below (page_render + OCR/VLM
+                    # becomes its only text source).
+                    logger.info(
+                        "pdf page text garbled, falling back to page render, pageNo=%d, filename=%s",
+                        page_no,
+                        filename,
+                    )
+                    page_warnings.append(
+                        f"page {page_no} text layer is garbled (likely a missing/broken ToUnicode CMap in an "
+                        "embedded font); fell back to page render"
+                    )
+                    text = ""
                 scanned = len(text.strip()) < SCANNED_PAGE_TEXT_THRESHOLD
                 ocr_source: Optional[str] = None
 
@@ -90,7 +143,7 @@ class PdfParser(BaseParser):
                 markdown="\n\n".join(markdown_parts),
                 pages=pages,
                 images=collector.images,
-                warnings=collector.warnings,
+                warnings=collector.warnings + page_warnings,
             )
         except Exception as exc:
             logger.error(

--- a/kb-rag-parser/app/parsers/registry.py
+++ b/kb-rag-parser/app/parsers/registry.py
@@ -32,6 +32,7 @@ _REGISTRY: dict[str, BaseParser] = {
     "docx": _docx_parser,
     "txt": _text_parser,
     "md": _text_parser,
+    "sql": _text_parser,
     "xlsx": _excel_parser,
     "csv": _csv_parser,
     "html": _html_parser,

--- a/kb-rag-parser/app/parsers/text.py
+++ b/kb-rag-parser/app/parsers/text.py
@@ -1,10 +1,11 @@
-"""Plain-text parser for .txt and .md files.
+"""Plain-text parser for .txt, .md and .sql files.
 
 No XML, no zip, no external resources are involved, so none of the
 security guardrails in app/security.py apply beyond the upload size cap
 already enforced by the API layer. Markdown files are passed through
 as-is since they already are the target "markdown" representation; plain
-text files are wrapped verbatim (no synthetic markdown syntax is invented).
+text files (including .sql scripts) are wrapped verbatim (no synthetic
+markdown syntax is invented).
 
 Author: owlzhangfq@gmail.com
 """
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class TextParser(BaseParser):
-    """Handles both .txt and .md — markdown needs no transformation."""
+    """Handles .txt, .md and .sql — plain text needs no transformation."""
 
     def parse(self, content: bytes, filename: str) -> ParseData:
         try:

--- a/kb-rag-parser/tests/test_parse_pdf_garbled.py
+++ b/kb-rag-parser/tests/test_parse_pdf_garbled.py
@@ -1,0 +1,49 @@
+"""Garbled text-layer fallback tests (M3-CONTRACTS.md §2.1 扫描页判定
+extension): a PDF page whose embedded subset font lacks a usable ToUnicode
+CMap extracts as wrong-codepoint glyph soup; such a page must fall back to
+the scanned-page path (page render + OCR/VLM) instead of chunking/indexing
+the garbage.
+"""
+
+import pymupdf
+
+from app.parsers.pdf import _is_garbled_text
+from tests.conftest import make_pdf_bytes, post_parse
+
+# Representative of a broken ToUnicode extraction of a Chinese document:
+# mostly Myanmar-block and box-drawing glyphs, with a few surviving ASCII
+# digits/percent signs (standard-encoded in the original font).
+_GARBLED_TEXT = "ဢၽာ ▓▓▓ ၥၦၧ 5551 ▓ ၬၭၮ 0.3% ▓▓ ၯၰၱၲၳ ၴၵၶၷ ▓▓ ၸၹၺ 365 ၻၼၽ ▓▓▓ ၾၿ"
+
+
+def test_is_garbled_text_detects_wrong_codepoint_glyph_soup():
+    assert _is_garbled_text(_GARBLED_TEXT) is True
+
+
+def test_is_garbled_text_accepts_normal_text_and_edge_inputs():
+    # Normal Chinese (with fullwidth/CJK punctuation) and English pages
+    # must never be misclassified, nor must empty/whitespace-only input.
+    assert _is_garbled_text("京东云工厂架构文档：容量 24 核，费率 0.3%，期限 365 天。") is False
+    assert _is_garbled_text("Hello kb-rag PDF, this page has a normal text layer.") is False
+    assert _is_garbled_text("") is False
+    assert _is_garbled_text("   \n\t ") is False
+
+
+def test_garbled_pdf_page_falls_back_to_page_render(client, monkeypatch):
+    # A PDF with a genuinely broken ToUnicode CMap cannot be fabricated
+    # via pymupdf's own writer (it always emits a valid CMap), so the
+    # broken extraction result is simulated at the get_text() boundary.
+    monkeypatch.setattr(pymupdf.Page, "get_text", lambda self, *args, **kwargs: _GARBLED_TEXT)
+
+    response = post_parse(client, "garbled.pdf", make_pdf_bytes(), "pdf")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] == "OK"
+    data = body["data"]
+    page = data["pages"][0]
+    assert page["scanned"] is True
+    assert page["text"] == ""  # glyph soup never reaches chunking
+    assert len(data["images"]) == 1
+    assert data["images"][0]["kind"] == "page_render"
+    assert any("garbled" in warning for warning in data["warnings"])

--- a/kb-rag-parser/tests/test_parse_text.py
+++ b/kb-rag-parser/tests/test_parse_text.py
@@ -28,3 +28,18 @@ def test_parse_md_returns_expected_structure(client):
     assert "# Heading" in data["markdown"]
     assert "Hello kb-rag MD" in data["markdown"]
     assert data["images"] == []
+
+
+def test_parse_sql_returns_expected_structure(client):
+    content = "SELECT id, name FROM t_kb\nWHERE status = 'READY';".encode("utf-8")
+
+    response = post_parse(client, "schema.sql", content, "sql")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] == "OK"
+    data = body["data"]
+    assert data["markdown"] == "SELECT id, name FROM t_kb\nWHERE status = 'READY';"
+    assert len(data["pages"]) == 1
+    assert data["pages"][0]["page_no"] == 1
+    assert data["images"] == []

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/ExtSourceController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/ExtSourceController.java
@@ -1,0 +1,181 @@
+package io.kbrag.api.controller;
+
+import io.kbrag.api.dto.ExtSourceItemResponse;
+import io.kbrag.api.dto.ExtSourceResponse;
+import io.kbrag.api.dto.ExtSourceSyncAcceptedResponse;
+import io.kbrag.api.dto.ExtSourceTestResponse;
+import io.kbrag.api.dto.PageResponse;
+import io.kbrag.api.dto.RegisterExtSourceRequest;
+import io.kbrag.api.dto.UpdateExtSourceRequest;
+import io.kbrag.app.extsource.ExtSourceCommand;
+import io.kbrag.app.extsource.ExtSourceService;
+import io.kbrag.common.api.Result;
+import io.kbrag.domain.entity.ExtSource;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * External data source endpoints of the console, the M14 contract section 2.3: register a source,
+ * watch its sync outcomes down to the object, trigger a scan, test the connection, edit, remove.
+ *
+ * <p>Register and manual sync hand the scan to the executor and return at once - a bucket holds an
+ * unbounded number of objects, so unlike the single page fetch of the web import there is no
+ * outcome a console request could reasonably wait for.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequiredArgsConstructor
+public class ExtSourceController {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 200;
+
+    private final ExtSourceService extSourceService;
+
+    /**
+     * Registers an external source and triggers its first scan asynchronously.
+     *
+     * @param kbId    knowledge base business id
+     * @param request connection details and the optional sync switch, on by default
+     * @return registration row; the first scan's outcome appears on it once the scan finishes
+     */
+    @PostMapping("/api/v1/kb/{kbId}/ext-sources")
+    public Result<ExtSourceResponse> register(@PathVariable String kbId,
+                                              @Valid @RequestBody RegisterExtSourceRequest request) {
+        ExtSource source = extSourceService.register(kbId, new ExtSourceCommand(
+                request.sourceType().trim(),
+                request.name().trim(),
+                request.endpoint().trim(),
+                trimToNull(request.region()),
+                request.bucket().trim(),
+                trimToNull(request.prefix()),
+                request.accessKey().trim(),
+                request.secretKey(),
+                request.syncEnabled()));
+        extSourceService.syncAsync(source.getSourceId());
+        return Result.success(ExtSourceResponse.from(source));
+    }
+
+    /**
+     * Lists the sources of a knowledge base, most recently registered first.
+     *
+     * @param kbId knowledge base business id
+     * @param page one based page number
+     * @param size page size
+     * @return paged sources, secret always masked
+     */
+    @GetMapping("/api/v1/kb/{kbId}/ext-sources")
+    public Result<PageResponse<ExtSourceResponse>> list(
+            @PathVariable String kbId,
+            @RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) long page,
+            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) long size) {
+        return Result.success(PageResponse.from(
+                extSourceService.list(kbId, normalizePage(page), normalizeSize(size)),
+                ExtSourceResponse::from));
+    }
+
+    /**
+     * Accepts one scan of one source; the outcome lands on the source and item rows.
+     *
+     * @param sourceId source business id
+     * @return acceptance acknowledgement
+     */
+    @PostMapping("/api/v1/ext-sources/{sourceId}/sync")
+    public Result<ExtSourceSyncAcceptedResponse> sync(@PathVariable String sourceId) {
+        extSourceService.ensureExists(sourceId);
+        extSourceService.syncAsync(sourceId);
+        return Result.success(ExtSourceSyncAcceptedResponse.of());
+    }
+
+    /**
+     * Lists the per object sync outcomes of one source.
+     *
+     * @param sourceId source business id
+     * @param page     one based page number
+     * @param size     page size
+     * @return paged item rows
+     */
+    @GetMapping("/api/v1/ext-sources/{sourceId}/items")
+    public Result<PageResponse<ExtSourceItemResponse>> items(
+            @PathVariable String sourceId,
+            @RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) long page,
+            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) long size) {
+        return Result.success(PageResponse.from(
+                extSourceService.listItems(sourceId, normalizePage(page), normalizeSize(size)),
+                ExtSourceItemResponse::from));
+    }
+
+    /**
+     * Updates the connection details of one source; a blank secret keeps the stored one.
+     *
+     * @param sourceId source business id
+     * @param request  new values
+     * @return updated source, secret masked
+     */
+    @PutMapping("/api/v1/ext-sources/{sourceId}")
+    public Result<ExtSourceResponse> update(@PathVariable String sourceId,
+                                            @Valid @RequestBody UpdateExtSourceRequest request) {
+        return Result.success(ExtSourceResponse.from(extSourceService.update(sourceId, new ExtSourceCommand(
+                null,
+                request.name().trim(),
+                request.endpoint().trim(),
+                trimToNull(request.region()),
+                request.bucket().trim(),
+                trimToNull(request.prefix()),
+                request.accessKey().trim(),
+                request.secretKey(),
+                request.syncEnabled()))));
+    }
+
+    /**
+     * Probes connectivity and credentials of one source without touching any object.
+     *
+     * @param sourceId source business id
+     * @return probe outcome
+     */
+    @PostMapping("/api/v1/ext-sources/{sourceId}/test")
+    public Result<ExtSourceTestResponse> test(@PathVariable String sourceId) {
+        return Result.success(ExtSourceTestResponse.from(extSourceService.testConnection(sourceId)));
+    }
+
+    /**
+     * Removes a source and its item rows; the documents they fed stay in the knowledge base.
+     *
+     * @param sourceId source business id
+     * @return empty success envelope
+     */
+    @DeleteMapping("/api/v1/ext-sources/{sourceId}")
+    public Result<Void> remove(@PathVariable String sourceId) {
+        extSourceService.remove(sourceId);
+        return Result.success(null);
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private long normalizePage(long page) {
+        return page < DEFAULT_PAGE ? DEFAULT_PAGE : page;
+    }
+
+    private long normalizeSize(long size) {
+        if (size < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceItemResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceItemResponse.java
@@ -1,0 +1,50 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kbrag.domain.entity.ExtSourceItem;
+
+import java.time.LocalDateTime;
+
+/**
+ * Per object sync outcome view of one external source, the M14 contract section 2.3.
+ *
+ * @param objectKey  object key inside the bucket
+ * @param etag       change marker of the last ingested body, {@code null} before the first ingest
+ * @param docId      document the object feeds, {@code null} until the first successful ingest
+ * @param lastStatus outcome of the last sync visit, {@code null} before the first one
+ * @param lastError  why the last visit failed or was skipped, {@code null} on success
+ * @param lastSyncAt ISO instant of the last sync visit
+ * @param createdAt  ISO instant the object was first discovered
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ExtSourceItemResponse(
+        @JsonProperty("object_key") String objectKey,
+        String etag,
+        @JsonProperty("doc_id") String docId,
+        @JsonProperty("last_status") String lastStatus,
+        @JsonProperty("last_error") String lastError,
+        @JsonProperty("last_sync_at") String lastSyncAt,
+        @JsonProperty("created_at") String createdAt) {
+
+    /**
+     * Maps an entity onto its view.
+     *
+     * @param entity item entity
+     * @return view
+     */
+    public static ExtSourceItemResponse from(ExtSourceItem entity) {
+        return new ExtSourceItemResponse(
+                entity.getObjectKey(),
+                entity.getEtag(),
+                entity.getDocId(),
+                entity.getLastStatus() == null ? null : entity.getLastStatus().name(),
+                entity.getLastError(),
+                iso(entity.getLastSyncAt()),
+                iso(entity.getCreatedAt()));
+    }
+
+    private static String iso(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceResponse.java
@@ -1,0 +1,83 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kbrag.domain.entity.ExtSource;
+
+import java.time.LocalDateTime;
+
+/**
+ * External source registration view, the M14 contract section 2.3.
+ *
+ * <p>The secret never leaves the server: the field always carries the fixed mask, and the update
+ * endpoint treats a blank secret as "keep the stored one" so this view can round trip through an
+ * edit form without destroying the credential.
+ *
+ * @param sourceId       business identifier
+ * @param kbId           knowledge base the fetched objects land in
+ * @param sourceType     connector type routing key
+ * @param name           operator facing display name
+ * @param endpoint       service endpoint of the object store
+ * @param region         optional region hint
+ * @param bucket         bucket the scan lists
+ * @param prefix         optional key prefix narrowing the scan
+ * @param accessKey      access key of the credentials
+ * @param secretKey      fixed mask, never the stored value
+ * @param syncEnabled    whether the scheduled pass includes this source
+ * @param lastSyncStatus outcome of the last sync pass, {@code null} before the first one
+ * @param lastSyncAt     ISO instant of the last sync attempt
+ * @param lastError      why the last sync failed or was partial, {@code null} on success
+ * @param createdAt      ISO registration timestamp
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ExtSourceResponse(
+        @JsonProperty("source_id") String sourceId,
+        @JsonProperty("kb_id") String kbId,
+        @JsonProperty("source_type") String sourceType,
+        String name,
+        String endpoint,
+        String region,
+        String bucket,
+        String prefix,
+        @JsonProperty("access_key") String accessKey,
+        @JsonProperty("secret_key") String secretKey,
+        @JsonProperty("sync_enabled") boolean syncEnabled,
+        @JsonProperty("last_sync_status") String lastSyncStatus,
+        @JsonProperty("last_sync_at") String lastSyncAt,
+        @JsonProperty("last_error") String lastError,
+        @JsonProperty("created_at") String createdAt) {
+
+    /** The only value the secret field ever carries on the way out. */
+    public static final String SECRET_MASK = "******";
+
+    private static final int SYNC_ON = 1;
+
+    /**
+     * Maps an entity onto its view, masking the secret.
+     *
+     * @param entity source entity
+     * @return view
+     */
+    public static ExtSourceResponse from(ExtSource entity) {
+        return new ExtSourceResponse(
+                entity.getSourceId(),
+                entity.getKbId(),
+                entity.getSourceType(),
+                entity.getName(),
+                entity.getEndpoint(),
+                entity.getRegion(),
+                entity.getBucket(),
+                entity.getPrefix(),
+                entity.getAccessKey(),
+                SECRET_MASK,
+                entity.getSyncEnabled() != null && entity.getSyncEnabled() == SYNC_ON,
+                entity.getLastSyncStatus() == null ? null : entity.getLastSyncStatus().name(),
+                iso(entity.getLastSyncAt()),
+                entity.getLastError(),
+                iso(entity.getCreatedAt()));
+    }
+
+    private static String iso(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceSyncAcceptedResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceSyncAcceptedResponse.java
@@ -1,0 +1,21 @@
+package io.kbrag.api.dto;
+
+/**
+ * Acknowledgement of an asynchronously accepted external source sync, the M14 contract
+ * section 2.3: the scan runs off the request thread, its outcome lands on the source row.
+ *
+ * @param accepted always {@code true}; a sync that cannot be accepted fails the request instead
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ExtSourceSyncAcceptedResponse(boolean accepted) {
+
+    /**
+     * Builds the single accepted acknowledgement.
+     *
+     * @return accepted acknowledgement
+     */
+    public static ExtSourceSyncAcceptedResponse of() {
+        return new ExtSourceSyncAcceptedResponse(true);
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceTestResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ExtSourceTestResponse.java
@@ -1,0 +1,24 @@
+package io.kbrag.api.dto;
+
+import io.kbrag.domain.model.HealthStatus;
+
+/**
+ * Connection probe view of one external source, the M14 contract section 2.3.
+ *
+ * @param up     {@code true} when the store answered and the bucket exists
+ * @param detail short probe detail shown in the console
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ExtSourceTestResponse(boolean up, String detail) {
+
+    /**
+     * Maps a probe outcome onto its view.
+     *
+     * @param status probe outcome
+     * @return view
+     */
+    public static ExtSourceTestResponse from(HealthStatus status) {
+        return new ExtSourceTestResponse(status.isUp(), status.getDetail());
+    }
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ModelStatusResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/ModelStatusResponse.java
@@ -20,6 +20,9 @@ import io.kbrag.domain.model.ModelStatus;
  * @param visionConfigured    {@code false} means images are stored without a textual proxy
  * @param visionProvider      vision provider name, {@code none} when unconfigured
  * @param visionModel         vision model name, {@code none} when unconfigured
+ * @param multimodalConfigured {@code false} disables the multimodal page index switch
+ * @param multimodalProvider  multimodal embedding provider name, {@code none} when unconfigured
+ * @param multimodalModel     multimodal embedding model name, {@code none} when unconfigured
  *
  * @author owlzhangfq@gmail.com
  */
@@ -37,7 +40,10 @@ public record ModelStatusResponse(
         @JsonProperty("chat_model") String chatModel,
         @JsonProperty("vision_configured") boolean visionConfigured,
         @JsonProperty("vision_provider") String visionProvider,
-        @JsonProperty("vision_model") String visionModel) {
+        @JsonProperty("vision_model") String visionModel,
+        @JsonProperty("multimodal_configured") boolean multimodalConfigured,
+        @JsonProperty("multimodal_provider") String multimodalProvider,
+        @JsonProperty("multimodal_model") String multimodalModel) {
 
     /**
      * Maps a domain snapshot onto the transport shape.
@@ -60,6 +66,9 @@ public record ModelStatusResponse(
                 status.getChatModel(),
                 status.isVisionConfigured(),
                 status.getVisionProvider(),
-                status.getVisionModel());
+                status.getVisionModel(),
+                status.isMultimodalConfigured(),
+                status.getMultimodalProvider(),
+                status.getMultimodalModel());
     }
 }

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RegisterExtSourceRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RegisterExtSourceRequest.java
@@ -1,0 +1,44 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Payload of {@code POST /api/v1/kb/{kbId}/ext-sources}: registers one external object store
+ * source, the M14 contract section 2.3.
+ *
+ * @param sourceType  connector type routing key, {@code s3} in this milestone
+ * @param name        operator facing display name, unique per knowledge base
+ * @param endpoint    service endpoint of the object store
+ * @param region      optional region hint of the object store
+ * @param bucket      bucket the scan lists
+ * @param prefix      optional key prefix narrowing the scan
+ * @param accessKey   access key of the bucket credentials
+ * @param secretKey   secret key of the bucket credentials
+ * @param syncEnabled whether the scheduled pass should keep this source fresh, defaults to on
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record RegisterExtSourceRequest(
+        @JsonProperty("source_type")
+        @NotBlank(message = "must not be blank") @Size(max = 16, message = "must be at most 16 characters")
+        String sourceType,
+        @NotBlank(message = "must not be blank") @Size(max = 128, message = "must be at most 128 characters")
+        String name,
+        @NotBlank(message = "must not be blank") @Size(max = 512, message = "must be at most 512 characters")
+        String endpoint,
+        @Size(max = 64, message = "must be at most 64 characters")
+        String region,
+        @NotBlank(message = "must not be blank") @Size(max = 128, message = "must be at most 128 characters")
+        String bucket,
+        @Size(max = 512, message = "must be at most 512 characters")
+        String prefix,
+        @JsonProperty("access_key")
+        @NotBlank(message = "must not be blank") @Size(max = 256, message = "must be at most 256 characters")
+        String accessKey,
+        @JsonProperty("secret_key")
+        @NotBlank(message = "must not be blank") @Size(max = 512, message = "must be at most 512 characters")
+        String secretKey,
+        @JsonProperty("sync_enabled") Boolean syncEnabled) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/SearchRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/SearchRequest.java
@@ -5,15 +5,18 @@ import io.kbrag.app.retrieval.RetrievalCommand;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.domain.model.ChatMessage;
 import io.kbrag.domain.model.MetadataFilter;
+import io.kbrag.domain.model.MetadataRule;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Retrieval payload.
@@ -24,11 +27,15 @@ import java.util.List;
  * defaults; it never means "off".
  *
  * @param query          user query
+ * @param images         base64 encoded images attached to the query, bounded and validated by the one
+ *                       image gate, the M14 contract section 7
  * @param recallTopK     candidates recalled per route
  * @param topN           number of returned nodes
  * @param scoreThreshold absolute score threshold, only honoured when a comparable score exists
  * @param fusion         fusion strategy and its parameters
  * @param rerankEnabled  rerank switch, defaults to on when a rerank model is configured
+ * @param rerankMode     rerank ordering mode, {@code semantic} or {@code hybrid}, the M14 contract section 5
+ * @param rerankWSemantic semantic weight of the {@code hybrid} rerank mode, within {@code [0,1]}
  * @param rewriteEnabled query rewrite switch, defaults to off
  * @param messages       conversation used to resolve references during the rewrite
  * @param metadataFilter narrowing predicate pushed down to the engines
@@ -37,6 +44,7 @@ import java.util.List;
  */
 public record SearchRequest(
         @NotBlank(message = "must not be blank") String query,
+        List<String> images,
         @JsonProperty("recall_top_k") Integer recallTopK,
         @JsonProperty("top_n") Integer topN,
         @JsonProperty("score_threshold")
@@ -44,6 +52,10 @@ public record SearchRequest(
         @DecimalMax(value = "1.0", message = "must be at most 1.0") Double scoreThreshold,
         @Valid FusionRequest fusion,
         @JsonProperty("rerank_enabled") Boolean rerankEnabled,
+        @JsonProperty("rerank_mode") String rerankMode,
+        @JsonProperty("rerank_w_semantic")
+        @DecimalMin(value = "0.0", message = "must be at least 0")
+        @DecimalMax(value = "1.0", message = "must be at most 1") Double rerankWSemantic,
         @JsonProperty("rewrite_enabled") Boolean rewriteEnabled,
         List<MessageRequest> messages,
         @JsonProperty("metadata_filter") MetadataFilterRequest metadataFilter) {
@@ -80,13 +92,15 @@ public record SearchRequest(
      * @param sender      chat message sender
      * @param msgTimeFrom inclusive lower bound of the message timestamp in epoch milliseconds
      * @param msgTimeTo   inclusive upper bound of the message timestamp in epoch milliseconds
+     * @param custom      equality predicates on operator extracted metadata, keyed by the raw rule key
      */
     public record MetadataFilterRequest(
             @JsonProperty("tag_ids") List<String> tagIds,
             @JsonProperty("session_id") String sessionId,
             String sender,
             @JsonProperty("msg_time_from") Long msgTimeFrom,
-            @JsonProperty("msg_time_to") Long msgTimeTo) {
+            @JsonProperty("msg_time_to") Long msgTimeTo,
+            Map<String, String> custom) {
 
         /**
          * Maps the transport shape onto the domain predicate.
@@ -107,8 +121,26 @@ public record SearchRequest(
                     .sender(sender())
                     .msgTimeFrom(msgTimeFrom())
                     .msgTimeTo(msgTimeTo())
+                    .custom(validatedCustom())
                     .build();
             return filter.isEmpty() ? null : filter;
+        }
+
+        /**
+         * Checks every custom filter key against the metadata key shape, the M14 contract section 3.3.
+         *
+         * @return custom map, {@code null} when none was supplied
+         */
+        private Map<String, String> validatedCustom() {
+            if (MapUtils.isEmpty(custom())) {
+                return null;
+            }
+            for (String key : custom().keySet()) {
+                if (key == null || !MetadataRule.KEY_PATTERN.matcher(key).matches()) {
+                    throw BizException.invalidParam("invalid custom metadata filter key: " + key);
+                }
+            }
+            return custom();
         }
     }
 
@@ -123,6 +155,7 @@ public record SearchRequest(
     public RetrievalCommand toCommand() {
         return RetrievalCommand.builder()
                 .query(query)
+                .images(images)
                 .recallTopK(recallTopK)
                 .topN(topN)
                 .scoreThreshold(scoreThreshold)
@@ -130,6 +163,8 @@ public record SearchRequest(
                 .wVec(fusion == null ? null : fusion.wVec())
                 .rrfK(fusion == null ? null : fusion.rrfK())
                 .rerankEnabled(rerankEnabled)
+                .rerankMode(rerankMode)
+                .rerankWSemantic(rerankWSemantic)
                 .rewriteEnabled(rewriteEnabled)
                 .messages(toMessages())
                 .metadataFilter(toMetadataFilter())

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateExtSourceRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateExtSourceRequest.java
@@ -1,0 +1,43 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Payload of {@code PUT /api/v1/ext-sources/{sourceId}}: updates the connection details of one
+ * source, the M14 contract section 2.3.
+ *
+ * <p>The secret is the one optional credential: the read API always masks it, so an edit form has
+ * nothing real to echo back - a blank value means "keep the stored secret".
+ *
+ * @param name        operator facing display name, unique per knowledge base
+ * @param endpoint    service endpoint of the object store
+ * @param region      optional region hint of the object store
+ * @param bucket      bucket the scan lists
+ * @param prefix      optional key prefix narrowing the scan
+ * @param accessKey   access key of the bucket credentials
+ * @param secretKey   new secret key, blank or absent keeps the stored one
+ * @param syncEnabled whether the scheduled pass includes this source, absent keeps current
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record UpdateExtSourceRequest(
+        @NotBlank(message = "must not be blank") @Size(max = 128, message = "must be at most 128 characters")
+        String name,
+        @NotBlank(message = "must not be blank") @Size(max = 512, message = "must be at most 512 characters")
+        String endpoint,
+        @Size(max = 64, message = "must be at most 64 characters")
+        String region,
+        @NotBlank(message = "must not be blank") @Size(max = 128, message = "must be at most 128 characters")
+        String bucket,
+        @Size(max = 512, message = "must be at most 512 characters")
+        String prefix,
+        @JsonProperty("access_key")
+        @NotBlank(message = "must not be blank") @Size(max = 256, message = "must be at most 256 characters")
+        String accessKey,
+        @JsonProperty("secret_key")
+        @Size(max = 512, message = "must be at most 512 characters")
+        String secretKey,
+        @JsonProperty("sync_enabled") Boolean syncEnabled) {
+}

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateIndexConfigRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateIndexConfigRequest.java
@@ -2,15 +2,23 @@ package io.kbrag.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.constant.ChunkMetadataKeys;
 import io.kbrag.domain.model.ChatAggregationParams;
 import io.kbrag.domain.model.CleanRules;
 import io.kbrag.domain.model.KbIndexConfig;
 import io.kbrag.domain.model.KbRetrievalConfig;
+import io.kbrag.domain.model.MetadataRule;
 import io.kbrag.domain.model.ParentChildParams;
 import io.kbrag.domain.service.FixedLengthTextSplitter;
+import io.kbrag.domain.service.HeadingTextSplitter;
+import io.kbrag.domain.service.LlmSemanticTextSplitter;
+import io.kbrag.domain.service.SeparatorTextSplitter;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -39,6 +47,17 @@ import java.util.regex.PatternSyntaxException;
  * @param chatAggregation      chat import window, {@code null} keeps the stored one
  * @param hideParentWithDisabledChild parent suppression switch, {@code null} keeps the stored value
  * @param inheritDisableAnnotation    disable inheritance switch, {@code null} keeps the stored value
+ * @param metadataRules        operator declared metadata extraction rules, {@code null} keeps the
+ *                             stored ones, an empty list clears them
+ * @param splitSeparator       block delimiter of the {@code separator} strategy, {@code null} keeps the
+ *                             stored one
+ * @param splitSeparatorIsRegex whether the separator is a regular expression, {@code null} keeps the
+ *                             stored value
+ * @param splitHeadingLevel    markdown heading depth of the {@code heading} strategy, {@code null}
+ *                             keeps the stored value
+ * @param multimodalEnabled    multimodal page index switch, {@code null} keeps the stored value; the
+ *                             switch is stored whatever the provider state is, the pipeline decides
+ *                             at build time whether the vectors can be produced (M14 contract 6.2)
  * @param retrievalConfig      knowledge base level retrieval defaults, optional
  *
  * @author owlzhangfq@gmail.com
@@ -53,7 +72,15 @@ public record UpdateIndexConfigRequest(
         @JsonProperty("chat_aggregation") ChatAggregationParams chatAggregation,
         @JsonProperty("hide_parent_with_disabled_child") Boolean hideParentWithDisabledChild,
         @JsonProperty("inherit_disable_annotation") Boolean inheritDisableAnnotation,
+        @JsonProperty("metadata_rules") List<MetadataRule> metadataRules,
+        @JsonProperty("split_separator") String splitSeparator,
+        @JsonProperty("split_separator_is_regex") Boolean splitSeparatorIsRegex,
+        @JsonProperty("split_heading_level") Integer splitHeadingLevel,
+        @JsonProperty("multimodal_enabled") Boolean multimodalEnabled,
         @JsonProperty("retrieval_config") KbRetrievalConfig retrievalConfig) {
+
+    /** Longest separator an operator may configure, the M14 contract section 4. */
+    private static final int MAX_SEPARATOR_LENGTH = 64;
 
     /**
      * Two level splitting parameters.
@@ -103,6 +130,14 @@ public record UpdateIndexConfigRequest(
                 ? current.isHideParentWithDisabledChild() : hideParentWithDisabledChild);
         config.setInheritDisableAnnotation(inheritDisableAnnotation == null
                 ? current.isInheritDisableAnnotation() : inheritDisableAnnotation);
+        config.setMetadataRules(metadataRules == null ? current.metadataRulesOrEmpty() : metadataRules);
+        config.setSplitSeparator(splitSeparator == null ? current.getSplitSeparator() : splitSeparator);
+        config.setSplitSeparatorIsRegex(splitSeparatorIsRegex == null
+                ? current.isSplitSeparatorIsRegex() : splitSeparatorIsRegex);
+        config.setSplitHeadingLevel(splitHeadingLevel == null
+                ? current.getSplitHeadingLevel() : splitHeadingLevel);
+        config.setMultimodalEnabled(multimodalEnabled == null
+                ? current.isMultimodalEnabled() : multimodalEnabled);
         validate(config);
         return config;
     }
@@ -131,6 +166,8 @@ public record UpdateIndexConfigRequest(
         // aggregation apply whatever the splitter does, so running them inside the parent child branch
         // left an uncompilable pattern and an impossible window reachable through a single level base.
         validateCleaning(config);
+        validateMetadataRules(config);
+        validateSplitStrategy(config);
         ParentChildParams params = config.parentChildOrDisabled();
         if (!params.isEnabled()) {
             return;
@@ -174,6 +211,57 @@ public record UpdateIndexConfigRequest(
         }
     }
 
+    /**
+     * Rejects the split strategy combinations the annotations cannot express, the M14 contract section 4:
+     * the only fast-fail gate for the new strategies, so every splitter can trust the parameters it reads.
+     *
+     * <p>A two level base is confined to {@code fixed_length} and {@code llm_semantic}: the three new
+     * strategies cut on a boundary the parent child pass cannot honour without losing that boundary, so
+     * the combination is refused rather than silently degraded. The separator and heading parameters are
+     * range checked here so a splitter never meets a length or a depth it would have to clamp.
+     *
+     * @param config configuration being written
+     */
+    private void validateSplitStrategy(KbIndexConfig config) {
+        String strategy = config.getSplitStrategy();
+        if (config.parentChildOrDisabled().isEnabled()
+                && !FixedLengthTextSplitter.STRATEGY_CODE.equals(strategy)
+                && !LlmSemanticTextSplitter.STRATEGY_CODE.equals(strategy)) {
+            throw BizException.invalidParam("parent_child splitting supports only fixed_length and "
+                    + "llm_semantic strategies, not " + strategy);
+        }
+        if (SeparatorTextSplitter.STRATEGY_CODE.equals(strategy)) {
+            validateSeparator(config);
+        } else if (HeadingTextSplitter.STRATEGY_CODE.equals(strategy)) {
+            validateHeadingLevel(config);
+        }
+    }
+
+    private void validateSeparator(KbIndexConfig config) {
+        String separator = config.getSplitSeparator();
+        if (separator == null || separator.isEmpty()) {
+            return;
+        }
+        if (separator.length() > MAX_SEPARATOR_LENGTH) {
+            throw BizException.invalidParam("split_separator must be 1 to " + MAX_SEPARATOR_LENGTH
+                    + " characters");
+        }
+        if (config.isSplitSeparatorIsRegex()) {
+            requireCompilable(separator, "split_separator");
+        }
+    }
+
+    private void validateHeadingLevel(KbIndexConfig config) {
+        int level = config.getSplitHeadingLevel();
+        if (level == 0) {
+            return;
+        }
+        if (level < HeadingTextSplitter.MIN_HEADING_LEVEL || level > HeadingTextSplitter.MAX_HEADING_LEVEL) {
+            throw BizException.invalidParam("split_heading_level must be "
+                    + HeadingTextSplitter.MIN_HEADING_LEVEL + " to " + HeadingTextSplitter.MAX_HEADING_LEVEL);
+        }
+    }
+
     private void requireCompilable(String pattern, String field) {
         if (pattern == null || pattern.isBlank()) {
             return;
@@ -182,6 +270,77 @@ public record UpdateIndexConfigRequest(
             Pattern.compile(pattern);
         } catch (PatternSyntaxException e) {
             throw BizException.invalidParam("invalid regular expression in " + field + ": " + pattern);
+        }
+    }
+
+    /**
+     * Rejects a malformed metadata rule set, the M14 contract section 3.1: the only fast-fail gate for
+     * these rules, so the pipeline can extract with them without re-checking anything.
+     *
+     * @param config configuration being written
+     */
+    private void validateMetadataRules(KbIndexConfig config) {
+        List<MetadataRule> rules = config.metadataRulesOrEmpty();
+        if (rules.isEmpty()) {
+            return;
+        }
+        if (rules.size() > MetadataRule.MAX_RULES) {
+            throw BizException.invalidParam("metadata_rules must not exceed " + MetadataRule.MAX_RULES);
+        }
+        Set<String> seen = new HashSet<>();
+        for (MetadataRule rule : rules) {
+            validateMetadataRule(rule);
+            if (!seen.add(rule.getKey())) {
+                throw BizException.invalidParam("duplicate metadata_rules key: " + rule.getKey());
+            }
+        }
+    }
+
+    private void validateMetadataRule(MetadataRule rule) {
+        String key = rule.getKey();
+        if (key == null || !MetadataRule.KEY_PATTERN.matcher(key).matches()) {
+            throw BizException.invalidParam("invalid metadata_rules key: " + key);
+        }
+        if (ChunkMetadataKeys.RESERVED.contains(key)) {
+            throw BizException.invalidParam("metadata_rules key conflicts with a reserved key: " + key);
+        }
+        if (MetadataRule.TYPE_CONSTANT.equals(rule.getType())) {
+            if (rule.getValue() == null || rule.getValue().isBlank()) {
+                throw BizException.invalidParam("constant metadata rule requires a value, key: " + key);
+            }
+        } else if (MetadataRule.TYPE_REGEX.equals(rule.getType())) {
+            validateRegexRule(rule);
+        } else if (MetadataRule.TYPE_KEYWORD_MATCH.equals(rule.getType())) {
+            validateKeywordRule(rule);
+        } else {
+            throw BizException.invalidParam("unsupported metadata rule type: " + rule.getType());
+        }
+    }
+
+    private void validateRegexRule(MetadataRule rule) {
+        String pattern = rule.getPattern();
+        if (pattern == null || pattern.isBlank() || pattern.length() > MetadataRule.MAX_PATTERN_LENGTH) {
+            throw BizException.invalidParam("regex metadata rule requires a pattern of at most "
+                    + MetadataRule.MAX_PATTERN_LENGTH + " characters, key: " + rule.getKey());
+        }
+        try {
+            Pattern.compile(pattern);
+        } catch (PatternSyntaxException e) {
+            throw BizException.invalidParam("invalid regex metadata rule pattern, key: " + rule.getKey());
+        }
+    }
+
+    private void validateKeywordRule(MetadataRule rule) {
+        List<String> keywords = rule.getKeywords();
+        if (keywords == null || keywords.isEmpty() || keywords.size() > MetadataRule.MAX_KEYWORDS) {
+            throw BizException.invalidParam("keyword_match metadata rule requires 1 to "
+                    + MetadataRule.MAX_KEYWORDS + " keywords, key: " + rule.getKey());
+        }
+        for (String keyword : keywords) {
+            if (keyword == null || keyword.isBlank() || keyword.length() > MetadataRule.MAX_KEYWORD_LENGTH) {
+                throw BizException.invalidParam("each keyword_match keyword must be 1 to "
+                        + MetadataRule.MAX_KEYWORD_LENGTH + " characters, key: " + rule.getKey());
+            }
         }
     }
 

--- a/kb-rag-server/kb-api/src/main/resources/application.yml
+++ b/kb-rag-server/kb-api/src/main/resources/application.yml
@@ -88,6 +88,17 @@ kb:
     base-url: ${EMBEDDING_BASE_URL:https://dashscope.aliyuncs.com/compatible-mode/v1}
     batch-size: ${EMBEDDING_BATCH_SIZE:10}
     timeout-ms: ${EMBEDDING_TIMEOUT_MS:30000}
+  multimodal-embedding:
+    provider: ${MULTIMODAL_EMBEDDING_PROVIDER:dashscope}
+    model: ${MULTIMODAL_EMBEDDING_MODEL:multimodal-embedding-v1}
+    dimension: ${MULTIMODAL_EMBEDDING_DIM:1024}
+    # Blank switches the whole multimodal capability off; inherits the shared DashScope key by default,
+    # so setting DASHSCOPE_API_KEY alone turns image indexing/search on (M14 contract section 6.1).
+    api-key: ${MULTIMODAL_EMBEDDING_API_KEY:${DASHSCOPE_API_KEY:}}
+    # DashScope exposes multimodal embedding outside the OpenAI compatible surface, so this is a full URL.
+    url: ${MULTIMODAL_EMBEDDING_URL:https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding}
+    batch-size: ${MULTIMODAL_EMBEDDING_BATCH_SIZE:8}
+    timeout-ms: ${MULTIMODAL_EMBEDDING_TIMEOUT_MS:30000}
   rerank:
     provider: ${RERANK_PROVIDER:dashscope}
     model: ${RERANK_MODEL:gte-rerank-v2}
@@ -186,6 +197,10 @@ kb:
     rewrite-max-history-turns: ${RETRIEVAL_REWRITE_MAX_HISTORY_TURNS:6}
     # On by default, but only takes effect when a rerank model is configured.
     rerank-enabled: ${RETRIEVAL_RERANK_ENABLED:true}
+    # M14 contract section 5: semantic keeps the pre-M14 pure-rerank ordering; hybrid blends the
+    # normalized BM25 score in at weight (1 - rerank-w-semantic). Only the ordering changes.
+    rerank-mode: ${RETRIEVAL_RERANK_MODE:semantic}
+    rerank-w-semantic: ${RETRIEVAL_RERANK_W_SEMANTIC:0.7}
     parent-candidate-factor: ${RETRIEVAL_PARENT_CANDIDATE_FACTOR:3}
     parent-candidate-floor: ${RETRIEVAL_PARENT_CANDIDATE_FLOOR:20}
     max-linked-kb: ${RETRIEVAL_MAX_LINKED_KB:15}
@@ -278,6 +293,15 @@ kb:
     sync-enabled: ${WEB_IMPORT_SYNC_ENABLED:true}
     # Sources per scheduled pass; fetches are slow network calls, so a pass drains a bounded slice.
     sync-batch-size: ${WEB_IMPORT_SYNC_BATCH_SIZE:50}
+  ext-source:
+    sync-cron: ${EXT_SOURCE_SYNC_CRON:0 0 3 * * *}
+    sync-enabled: ${EXT_SOURCE_SYNC_ENABLED:true}
+    # Sources per scheduled pass; each source scans a whole bucket, hence the smaller slice.
+    sync-batch-size: ${EXT_SOURCE_SYNC_BATCH_SIZE:10}
+    # Objects ingested per scan; a longer listing marks the sync PARTIAL instead of running away.
+    max-objects-per-source: ${EXT_SOURCE_MAX_OBJECTS_PER_SOURCE:500}
+    # Per call budget against the object store, connect and read alike.
+    fetch-timeout-ms: ${EXT_SOURCE_FETCH_TIMEOUT_MS:30000}
   app:
     # Retired application versions per application whose index snapshot is kept. Every snapshot is a full copy
     # of the corpus of every linked knowledge base, so this is the rollback depth traded against disk.

--- a/kb-rag-server/kb-api/src/main/resources/application.yml
+++ b/kb-rag-server/kb-api/src/main/resources/application.yml
@@ -166,7 +166,7 @@ kb:
     bootstrap-username: ${AUTH_BOOTSTRAP_USERNAME:admin}
   upload:
     max-file-size-mb: ${UPLOAD_MAX_FILE_SIZE_MB:100}
-    allowed-extensions: ${UPLOAD_ALLOWED_EXTENSIONS:pdf,docx,txt,md,xlsx,csv,html,png,jpg,jpeg,webp,bmp,gif}
+    allowed-extensions: ${UPLOAD_ALLOWED_EXTENSIONS:pdf,docx,txt,md,sql,xlsx,csv,html,png,jpg,jpeg,webp,bmp,gif}
   doc:
     version:
       # Non active READY versions kept per document; the older ones are archived and lose their chunks,

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V15__ext_source.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V15__ext_source.sql
@@ -1,0 +1,60 @@
+-- M14: external data source connectors. A registered source describes one S3/OSS compatible
+-- bucket whose objects are scanned and funnelled into the ordinary upload chain; the item table
+-- records the per-object binding and the outcome of its last sync, mirroring the weak binding of
+-- the web source table - removing a registration never touches the documents it produced.
+
+CREATE TABLE t_kb_ext_source
+(
+    id               BIGINT       NOT NULL AUTO_INCREMENT,
+    source_id        VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the console',
+    kb_id            VARCHAR(64)  NOT NULL COMMENT 'knowledge base the fetched objects land in',
+    source_type      VARCHAR(16)  NOT NULL COMMENT 'connector type routing key, s3 in this milestone',
+    name             VARCHAR(128) NOT NULL COMMENT 'operator facing display name, unique per knowledge base',
+    endpoint         VARCHAR(512) NOT NULL COMMENT 'service endpoint of the object store',
+    region           VARCHAR(64)           DEFAULT NULL COMMENT 'optional region hint of the object store',
+    bucket           VARCHAR(128) NOT NULL COMMENT 'bucket the scan lists',
+    prefix           VARCHAR(512)          DEFAULT NULL COMMENT 'optional key prefix narrowing the scan',
+    access_key       VARCHAR(256) NOT NULL COMMENT 'access key of the bucket credentials',
+    -- Stored in clear on purpose: single admin console behind network isolation, the D17 premise.
+    -- The read API never returns this column; envelope encryption belongs to the RBAC milestone.
+    secret_key       VARCHAR(512) NOT NULL COMMENT 'secret key of the bucket credentials, never returned by the API',
+    sync_enabled     TINYINT      NOT NULL DEFAULT 1 COMMENT '1 includes the source in the scheduled sync pass',
+    last_sync_at     DATETIME              DEFAULT NULL COMMENT 'when the last sync attempt ran',
+    last_sync_status VARCHAR(16)           DEFAULT NULL COMMENT 'SUCCESS/PARTIAL/FAILED',
+    last_error       VARCHAR(512)          DEFAULT NULL COMMENT 'why the last sync failed or was partial, null on success',
+    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    lock_version     INT          NOT NULL DEFAULT 0,
+    deleted          TINYINT      NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_source_id (source_id),
+    -- One name per knowledge base; the name is what the operator recognises a source by.
+    UNIQUE KEY uk_kb_name (kb_id, name),
+    KEY idx_kb (kb_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_general_ci COMMENT ='registered external object store sources feeding documents';
+
+CREATE TABLE t_kb_ext_source_item
+(
+    id              BIGINT        NOT NULL AUTO_INCREMENT,
+    source_id       VARCHAR(64)   NOT NULL COMMENT 'owning external source business id',
+    object_key      VARCHAR(1024) NOT NULL COMMENT 'object key inside the bucket',
+    -- The equality key: a VARCHAR(1024) cannot carry a unique index, the digest of it can.
+    object_key_hash CHAR(64)      NOT NULL COMMENT 'SHA-256 of the object key, the dedup and lookup key',
+    etag            VARCHAR(128)           DEFAULT NULL COMMENT 'etag of the last ingested object body, the unchanged check',
+    doc_id          VARCHAR(64)            DEFAULT NULL COMMENT 'document the object feeds, null until the first success',
+    last_status     VARCHAR(16)            DEFAULT NULL COMMENT 'SUCCESS/UNCHANGED/SKIPPED/FAILED',
+    last_error      VARCHAR(512)           DEFAULT NULL COMMENT 'why the last sync failed or was skipped, null on success',
+    last_sync_at    DATETIME               DEFAULT NULL COMMENT 'when this object was last visited by a sync',
+    created_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    lock_version    INT           NOT NULL DEFAULT 0,
+    deleted         TINYINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    -- One row per object per source; re-listing the same key updates the row instead of adding one.
+    UNIQUE KEY uk_source_object (source_id, object_key_hash),
+    KEY idx_source (source_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_general_ci COMMENT ='per object sync outcome of an external source';

--- a/kb-rag-server/kb-api/src/test/java/io/kbrag/api/dto/UpdateIndexConfigRequestTest.java
+++ b/kb-rag-server/kb-api/src/test/java/io/kbrag/api/dto/UpdateIndexConfigRequestTest.java
@@ -70,6 +70,26 @@ class UpdateIndexConfigRequestTest {
         assertEquals(5, config.chatAggregationOrDefaults().getWindowOverlap());
     }
 
+    @Test
+    void shouldSetTheMultimodalSwitchFromThePayload() {
+        KbIndexConfig config = multimodalRequest(true).toIndexConfig(new KbIndexConfig());
+
+        // The switch is stored whatever the provider state is: the build stage, not this gate, decides
+        // whether the vectors can be produced.
+        assertEquals(true, config.isMultimodalEnabled());
+    }
+
+    @Test
+    void shouldKeepTheStoredMultimodalSwitchWhenThePayloadCarriesNone() {
+        KbIndexConfig current = new KbIndexConfig();
+        current.setMultimodalEnabled(true);
+
+        // A save that never mentions the switch must not silently turn the capability off.
+        KbIndexConfig config = multimodalRequest(null).toIndexConfig(current);
+
+        assertEquals(true, config.isMultimodalEnabled());
+    }
+
     private ChatAggregationParams aggregation(int windowMinutes, int maxMessages, int windowOverlap) {
         ChatAggregationParams params = new ChatAggregationParams();
         params.setWindowMinutes(windowMinutes);
@@ -80,6 +100,11 @@ class UpdateIndexConfigRequestTest {
 
     private UpdateIndexConfigRequest request(ChatAggregationParams aggregation) {
         return new UpdateIndexConfigRequest("fixed_length", 600, 100, null, null, null,
-                aggregation, null, null, null);
+                aggregation, null, null, null, null, null, null, null, null);
+    }
+
+    private UpdateIndexConfigRequest multimodalRequest(Boolean multimodalEnabled) {
+        return new UpdateIndexConfigRequest("fixed_length", 600, 100, null, null, null,
+                null, null, null, null, null, null, null, multimodalEnabled, null);
     }
 }

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/config/AsyncConfig.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/config/AsyncConfig.java
@@ -46,6 +46,9 @@ public class AsyncConfig {
     /** Bean name of the pool a streamed chat generation runs on. */
     public static final String CHAT_STREAM_EXECUTOR = "chatStreamTaskExecutor";
 
+    /** Bean name of the pool an external source scan runs on. */
+    public static final String EXT_SOURCE_EXECUTOR = "extSourceTaskExecutor";
+
     private static final int CORE_POOL_SIZE = 2;
     private static final int MAX_POOL_SIZE = 4;
     private static final int QUEUE_CAPACITY = 200;
@@ -89,6 +92,16 @@ public class AsyncConfig {
     private static final int CHAT_STREAM_MAX_POOL_SIZE = 16;
     private static final int CHAT_STREAM_QUEUE_CAPACITY = 0;
     private static final String CHAT_STREAM_THREAD_PREFIX = "kb-chat-stream-";
+
+    /**
+     * One scan lists and fetches many objects over slow outbound I/O, so the pool is small and the
+     * queue generous: a registration or a manual sync only hands over a task and returns, and a
+     * burst of triggers should wait in line rather than fan out into parallel bucket scans.
+     */
+    private static final int EXT_SOURCE_CORE_POOL_SIZE = 1;
+    private static final int EXT_SOURCE_MAX_POOL_SIZE = 2;
+    private static final int EXT_SOURCE_QUEUE_CAPACITY = 100;
+    private static final String EXT_SOURCE_THREAD_PREFIX = "kb-ext-source-";
 
     /**
      * Creates the indexing executor.
@@ -194,6 +207,23 @@ public class AsyncConfig {
         executor.setMaxPoolSize(CHAT_STREAM_MAX_POOL_SIZE);
         executor.setQueueCapacity(CHAT_STREAM_QUEUE_CAPACITY);
         executor.setThreadNamePrefix(CHAT_STREAM_THREAD_PREFIX);
+        executor.setTaskDecorator(requestIdPropagatingDecorator());
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Creates the executor an external source scan runs on.
+     *
+     * @return executor used by the asynchronous ext source sync
+     */
+    @Bean(EXT_SOURCE_EXECUTOR)
+    public Executor extSourceTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(EXT_SOURCE_CORE_POOL_SIZE);
+        executor.setMaxPoolSize(EXT_SOURCE_MAX_POOL_SIZE);
+        executor.setQueueCapacity(EXT_SOURCE_QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(EXT_SOURCE_THREAD_PREFIX);
         executor.setTaskDecorator(requestIdPropagatingDecorator());
         executor.initialize();
         return executor;

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/extsource/ExtSourceCommand.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/extsource/ExtSourceCommand.java
@@ -1,0 +1,29 @@
+package io.kbrag.app.extsource;
+
+/**
+ * Application layer value carrying the writable fields of one external source, used by both
+ * register and update so the two endpoints share one shape.
+ *
+ * @param sourceType connector type routing key, {@code s3} in this milestone; ignored on update
+ * @param name       operator facing display name, unique per knowledge base
+ * @param endpoint   service endpoint of the object store
+ * @param region     optional region hint, {@code null} when the store does not need one
+ * @param bucket     bucket the scan lists
+ * @param prefix     optional key prefix narrowing the scan
+ * @param accessKey  access key of the credentials
+ * @param secretKey  secret key of the credentials; blank on update keeps the stored one
+ * @param syncEnabled whether the scheduled pass includes this source, {@code null} keeps current
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ExtSourceCommand(
+        String sourceType,
+        String name,
+        String endpoint,
+        String region,
+        String bucket,
+        String prefix,
+        String accessKey,
+        String secretKey,
+        Boolean syncEnabled) {
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/extsource/ExtSourceService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/extsource/ExtSourceService.java
@@ -1,0 +1,531 @@
+package io.kbrag.app.extsource;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.kbrag.app.config.AsyncConfig;
+import io.kbrag.app.document.DocumentService;
+import io.kbrag.app.document.UploadOutcome;
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.app.metrics.KbMetrics;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.common.util.HashUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.ExtSource;
+import io.kbrag.domain.entity.ExtSourceItem;
+import io.kbrag.domain.enums.ExtSourceItemStatus;
+import io.kbrag.domain.enums.ExtSourceSyncStatus;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.ExtSourceItemMapper;
+import io.kbrag.domain.mapper.ExtSourceMapper;
+import io.kbrag.domain.model.ExtSourceConfig;
+import io.kbrag.domain.model.HealthStatus;
+import io.kbrag.domain.port.ExternalConnector;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.ConnectorRouter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * External data source registration and incremental sync, the M14 contract section 2.
+ *
+ * <p><b>Everything a scan produces goes through {@link DocumentService#upload}</b>, the M12 rule
+ * kept intact: the derived file name is stable per object key, so a changed object lands on the
+ * "same name adds a version" path, and governance, retention and the index pipeline apply to
+ * connector content for free because there is no second intake path to keep honest.
+ *
+ * <p><b>A sync runs off the request thread.</b> One scan visits an unbounded number of objects
+ * over slow outbound I/O, so registration and manual sync only hand the scan to the executor -
+ * the M12 register-fetches-inline shape would let one large bucket park a console request.
+ *
+ * <p><b>One scan never throws.</b> The source level outcome - SUCCESS, PARTIAL or FAILED - is
+ * written onto the source row and each visited object writes its own item row, so the operator
+ * reads exactly what one pass did and the next pass simply tries again.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExtSourceService {
+
+    /** Value of {@code trashed} inside the recycle bin. */
+    private static final int TRASHED = 1;
+
+    /** {@code sync_enabled} value that includes a source in the scheduled pass. */
+    private static final int SYNC_ON = 1;
+
+    /** {@code sync_enabled} value that excludes a source from the scheduled pass. */
+    private static final int SYNC_OFF = 0;
+
+    /** Column limit of {@code last_error}; longer causes are truncated, not lost to an SQL error. */
+    private static final int MAX_ERROR_LENGTH = 512;
+
+    /** Upper bound of the derived file name, kept well under the 500 char column. */
+    private static final int MAX_FILE_NAME_LENGTH = 200;
+
+    /** Key hash prefix appended to the file name so two keys with alike names never merge. */
+    private static final int FILE_NAME_HASH_LENGTH = 8;
+
+    private final ExtSourceMapper extSourceMapper;
+    private final ExtSourceItemMapper extSourceItemMapper;
+    private final DocumentMapper documentMapper;
+    private final DocumentService documentService;
+    private final KnowledgeBaseService knowledgeBaseService;
+    private final ConnectorRouter connectorRouter;
+    private final BizIdGenerator bizIdGenerator;
+    private final KbProperties properties;
+    private final KbMetrics kbMetrics;
+
+    /**
+     * Registers an external source. The first scan is not run here: the caller hands the fresh
+     * source id to {@link #syncAsync} so the console gets its response before the bucket is walked.
+     *
+     * @param kbId    knowledge base business id
+     * @param command connection details and the sync switch
+     * @return persisted source row, secret included - the caller's view layer masks it
+     */
+    public ExtSource register(String kbId, ExtSourceCommand command) {
+        knowledgeBaseService.require(kbId);
+        // Resolving up front rejects an unknown type at registration time instead of on the first
+        // scan, when the operator is no longer looking.
+        connectorRouter.resolve(command.sourceType());
+        requireNameFree(kbId, command.name(), null);
+        ExtSource source = new ExtSource();
+        source.setSourceId(bizIdGenerator.extSourceId());
+        source.setKbId(kbId);
+        source.setSourceType(command.sourceType().toLowerCase(Locale.ROOT));
+        source.setName(command.name());
+        source.setEndpoint(command.endpoint());
+        source.setRegion(command.region());
+        source.setBucket(command.bucket());
+        source.setPrefix(command.prefix());
+        source.setAccessKey(command.accessKey());
+        source.setSecretKey(command.secretKey());
+        source.setSyncEnabled(Boolean.FALSE.equals(command.syncEnabled()) ? SYNC_OFF : SYNC_ON);
+        extSourceMapper.insert(source);
+        log.info("ext source registered, sourceId={}, kbId={}, type={}, bucket={}",
+                source.getSourceId(), kbId, source.getSourceType(), source.getBucket());
+        return source;
+    }
+
+    /**
+     * Lists the sources of a knowledge base, most recently registered first.
+     *
+     * @param kbId knowledge base business id
+     * @param page one based page number
+     * @param size page size
+     * @return page of sources
+     */
+    public IPage<ExtSource> list(String kbId, long page, long size) {
+        return extSourceMapper.selectPage(new Page<>(page, size), new LambdaQueryWrapper<ExtSource>()
+                .eq(ExtSource::getKbId, kbId)
+                .orderByDesc(ExtSource::getId));
+    }
+
+    /**
+     * Lists the per object sync outcomes of one source, most recently discovered first.
+     *
+     * @param sourceId source business id
+     * @param page     one based page number
+     * @param size     page size
+     * @return page of item rows
+     */
+    public IPage<ExtSourceItem> listItems(String sourceId, long page, long size) {
+        require(sourceId);
+        return extSourceItemMapper.selectPage(new Page<>(page, size), new LambdaQueryWrapper<ExtSourceItem>()
+                .eq(ExtSourceItem::getSourceId, sourceId)
+                .orderByDesc(ExtSourceItem::getId));
+    }
+
+    /**
+     * Updates the connection details of one source.
+     *
+     * <p>A blank secret keeps the stored one: the read API never returns the secret, so an edit
+     * form that echoes what it was given would otherwise overwrite the credential with the mask.
+     *
+     * @param sourceId source business id
+     * @param command  new values; {@code null} sync switch keeps the current one
+     * @return updated source row
+     */
+    public ExtSource update(String sourceId, ExtSourceCommand command) {
+        ExtSource source = require(sourceId);
+        if (!source.getName().equals(command.name())) {
+            requireNameFree(source.getKbId(), command.name(), source.getId());
+        }
+        source.setName(command.name());
+        source.setEndpoint(command.endpoint());
+        source.setRegion(command.region());
+        source.setBucket(command.bucket());
+        source.setPrefix(command.prefix());
+        source.setAccessKey(command.accessKey());
+        if (command.secretKey() != null && !command.secretKey().isBlank()) {
+            source.setSecretKey(command.secretKey());
+        }
+        if (command.syncEnabled() != null) {
+            source.setSyncEnabled(command.syncEnabled() ? SYNC_ON : SYNC_OFF);
+        }
+        extSourceMapper.updateById(source);
+        log.info("ext source updated, sourceId={}, bucket={}, syncEnabled={}",
+                sourceId, source.getBucket(), source.getSyncEnabled());
+        return source;
+    }
+
+    /**
+     * Probes connectivity and credentials of one source without touching any object.
+     *
+     * @param sourceId source business id
+     * @return probe outcome
+     */
+    public HealthStatus testConnection(String sourceId) {
+        ExtSource source = require(sourceId);
+        ExternalConnector connector = connectorRouter.resolve(source.getSourceType());
+        return connector.testConnection(configOf(source));
+    }
+
+    /**
+     * Removes a source and its item rows; the documents they fed stay untouched.
+     *
+     * <p>Hard delete, not the soft flag: a soft-deleted row would hold {@code uk_kb_name} hostage
+     * and make the same name unregisterable forever.
+     *
+     * @param sourceId source business id
+     */
+    public void remove(String sourceId) {
+        ExtSource source = require(sourceId);
+        extSourceItemMapper.hardDeleteBySourceId(sourceId);
+        extSourceMapper.hardDeleteById(source.getId());
+        log.info("ext source removed, sourceId={}, kbId={}", sourceId, source.getKbId());
+    }
+
+    /**
+     * Asserts a source exists, used by the sync endpoint before the scan is accepted: an unknown
+     * id must fail the request, not disappear into an executor that has no caller to tell.
+     *
+     * @param sourceId source business id
+     */
+    public void ensureExists(String sourceId) {
+        require(sourceId);
+    }
+
+    /**
+     * Runs one scan of one source on the dedicated executor.
+     *
+     * <p>Never throws: an asynchronous scan has no caller to report to, and {@link #syncSource}
+     * already confines every failure to the rows the operator reads.
+     *
+     * @param sourceId source business id
+     */
+    @Async(AsyncConfig.EXT_SOURCE_EXECUTOR)
+    public void syncAsync(String sourceId) {
+        try {
+            syncSource(require(sourceId));
+        } catch (Exception e) {
+            log.error("ext source async sync failed, errorCode={}, sourceId={}",
+                    ErrorCode.INTERNAL_ERROR, sourceId, e);
+        }
+    }
+
+    /**
+     * Nightly sync pass over every source whose switch is on.
+     */
+    @Scheduled(cron = "${kb.ext-source.sync-cron:0 0 3 * * *}")
+    public void scheduledSync() {
+        if (!properties.getExtSource().isSyncEnabled()) {
+            return;
+        }
+        try {
+            int synced = syncEnabledSources();
+            if (synced > 0) {
+                log.info("ext source sync pass finished, sources={}", synced);
+            }
+        } catch (Exception e) {
+            log.error("ext source sync pass failed, errorCode={}", ErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+
+    /**
+     * Syncs one bounded batch of enabled sources, oldest registration first.
+     *
+     * <p>The bound is smaller than the web import one because one source here is a whole bucket
+     * scan, not a single page fetch.
+     *
+     * @return sources attempted by this pass
+     */
+    public int syncEnabledSources() {
+        int batchSize = Math.max(1, properties.getExtSource().getSyncBatchSize());
+        List<ExtSource> batch = extSourceMapper.selectList(new LambdaQueryWrapper<ExtSource>()
+                .eq(ExtSource::getSyncEnabled, SYNC_ON)
+                .orderByAsc(ExtSource::getId)
+                .last("limit " + batchSize));
+        if (CollectionUtils.isEmpty(batch)) {
+            return 0;
+        }
+        for (ExtSource source : batch) {
+            syncSource(source);
+        }
+        return batch.size();
+    }
+
+    /**
+     * Runs one scan of one source and records its outcome on the row. Never throws.
+     *
+     * <p>The contract steps: probe the connection first (a dead store fails the source, not five
+     * hundred objects), list, visit each object through {@link #syncObject}, mark the item rows
+     * whose objects vanished from the bucket, then fold the visit outcomes into the source status.
+     *
+     * @param source source row, mutated in place with the outcome
+     */
+    public void syncSource(ExtSource source) {
+        source.setLastSyncAt(LocalDateTime.now());
+        try {
+            ExternalConnector connector = connectorRouter.resolve(source.getSourceType());
+            ExtSourceConfig config = configOf(source);
+            HealthStatus health = connector.testConnection(config);
+            if (!health.isUp()) {
+                recordSource(source, ExtSourceSyncStatus.FAILED, health.getDetail());
+                return;
+            }
+            List<ExternalConnector.RemoteObject> listed = connector.listObjects(config);
+            int cap = config.maxObjects();
+            boolean truncated = listed.size() > cap;
+            List<ExternalConnector.RemoteObject> objects = truncated ? listed.subList(0, cap) : listed;
+            List<String> allowedExtensions = properties.getUpload().getAllowedExtensions();
+            Set<String> seenKeyHashes = new HashSet<>();
+            int failures = 0;
+            for (ExternalConnector.RemoteObject object : objects) {
+                // Seen before the whitelist filter: an object that exists but is not ingestible
+                // must not be reported as vanished below.
+                seenKeyHashes.add(HashUtil.sha256Hex(object.key()));
+                String extension = extensionOf(object.key());
+                if (extension == null || !allowedExtensions.contains(extension)) {
+                    continue;
+                }
+                if (!syncObject(source, connector, config, object, extension)) {
+                    failures++;
+                }
+            }
+            if (!truncated) {
+                // A truncated listing proves nothing about what it did not show, so vanished
+                // objects are only marked when the listing was complete.
+                markVanishedItems(source, seenKeyHashes);
+            }
+            recordSource(source,
+                    failures > 0 || truncated ? ExtSourceSyncStatus.PARTIAL : ExtSourceSyncStatus.SUCCESS,
+                    partialError(failures, truncated, cap));
+            log.info("ext source synced, sourceId={}, objects={}, failures={}, truncated={}",
+                    source.getSourceId(), objects.size(), failures, truncated);
+        } catch (Exception e) {
+            log.warn("ext source sync failed, sourceId={}, bucket={}, error={}",
+                    source.getSourceId(), source.getBucket(), e.getMessage());
+            recordSource(source, ExtSourceSyncStatus.FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * Visits one listed object; its outcome lands on the item row. Returns {@code false} only for
+     * FAILED - unchanged and skipped are successes of a kind, the M12 reading.
+     */
+    private boolean syncObject(ExtSource source, ExternalConnector connector, ExtSourceConfig config,
+                               ExternalConnector.RemoteObject object, String extension) {
+        String keyHash = HashUtil.sha256Hex(object.key());
+        ExtSourceItem item = findItem(source.getSourceId(), keyHash);
+        if (item == null) {
+            item = new ExtSourceItem();
+            item.setSourceId(source.getSourceId());
+            item.setObjectKey(object.key());
+            item.setObjectKeyHash(keyHash);
+        }
+        item.setLastSyncAt(LocalDateTime.now());
+        try {
+            if (object.etag() != null && object.etag().equals(item.getEtag())) {
+                recordItem(item, ExtSourceItemStatus.UNCHANGED, null);
+                return true;
+            }
+            Document bound = findBoundDocument(item);
+            if (bound != null && inTrash(bound)) {
+                // Writing a version into a trashed document would silently resurrect content the
+                // operator chose to remove; the object waits until they restore or purge it.
+                recordItem(item, ExtSourceItemStatus.SKIPPED, "绑定的文档在回收站中，本次同步已跳过");
+                return true;
+            }
+            byte[] body = connector.fetchObject(config, object.key());
+            String fileName = deriveFileName(object.key(), keyHash, extension);
+            UploadOutcome outcome = documentService.upload(source.getKbId(), fileName, body);
+            // A purge breaks the binding; the upload above then created a fresh document and the
+            // item follows it, the same weak binding semantics as the web source contract.
+            item.setDocId(outcome.document().getDocId());
+            item.setEtag(object.etag());
+            recordItem(item, ExtSourceItemStatus.SUCCESS, null);
+            return true;
+        } catch (Exception e) {
+            log.warn("ext source object sync failed, sourceId={}, object={}, error={}",
+                    source.getSourceId(), object.key(), e.getMessage());
+            recordItem(item, ExtSourceItemStatus.FAILED, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Marks the item rows whose objects a complete listing no longer contains.
+     *
+     * <p>The binding is weak on purpose: the document stays, only the item row says the bucket
+     * side is gone, so the operator learns it from the console instead of from a silent no-op.
+     */
+    private void markVanishedItems(ExtSource source, Set<String> seenKeyHashes) {
+        List<ExtSourceItem> items = extSourceItemMapper.selectList(new LambdaQueryWrapper<ExtSourceItem>()
+                .eq(ExtSourceItem::getSourceId, source.getSourceId()));
+        if (CollectionUtils.isEmpty(items)) {
+            return;
+        }
+        for (ExtSourceItem item : items) {
+            if (seenKeyHashes.contains(item.getObjectKeyHash())
+                    || item.getLastStatus() == ExtSourceItemStatus.SKIPPED) {
+                continue;
+            }
+            item.setLastSyncAt(LocalDateTime.now());
+            recordItem(item, ExtSourceItemStatus.SKIPPED, "对象已不存在，绑定的文档保持不变");
+        }
+    }
+
+    private void recordSource(ExtSource source, ExtSourceSyncStatus status, String error) {
+        source.setLastSyncStatus(status);
+        source.setLastError(truncate(error));
+        extSourceMapper.updateById(source);
+        // The one funnel every outcome passes, the same spot the M13 counter sits for web sources.
+        kbMetrics.recordExtSourceSync(status);
+    }
+
+    private void recordItem(ExtSourceItem item, ExtSourceItemStatus status, String error) {
+        item.setLastStatus(status);
+        item.setLastError(truncate(error));
+        if (item.getId() == null) {
+            extSourceItemMapper.insert(item);
+        } else {
+            extSourceItemMapper.updateById(item);
+        }
+    }
+
+    private ExtSource require(String sourceId) {
+        ExtSource source = extSourceMapper.selectOne(new LambdaQueryWrapper<ExtSource>()
+                .eq(ExtSource::getSourceId, sourceId));
+        if (source == null) {
+            throw BizException.notFound("外部数据源不存在：" + sourceId);
+        }
+        return source;
+    }
+
+    private void requireNameFree(String kbId, String name, Long selfId) {
+        Long count = extSourceMapper.selectCount(new LambdaQueryWrapper<ExtSource>()
+                .eq(ExtSource::getKbId, kbId)
+                .eq(ExtSource::getName, name)
+                .ne(selfId != null, ExtSource::getId, selfId));
+        if (count != null && count > 0) {
+            throw BizException.invalidParam("该名称已在此知识库使用，请换一个名称");
+        }
+    }
+
+    private ExtSourceItem findItem(String sourceId, String keyHash) {
+        return extSourceItemMapper.selectOne(new LambdaQueryWrapper<ExtSourceItem>()
+                .eq(ExtSourceItem::getSourceId, sourceId)
+                .eq(ExtSourceItem::getObjectKeyHash, keyHash));
+    }
+
+    /**
+     * Bound document of an item, {@code null} when never bound or when a purge removed it.
+     */
+    private Document findBoundDocument(ExtSourceItem item) {
+        if (item.getDocId() == null) {
+            return null;
+        }
+        return documentMapper.selectOne(new LambdaQueryWrapper<Document>()
+                .eq(Document::getDocId, item.getDocId()));
+    }
+
+    private boolean inTrash(Document document) {
+        return document.getTrashed() != null && document.getTrashed() == TRASHED;
+    }
+
+    private ExtSourceConfig configOf(ExtSource source) {
+        KbProperties.ExtSource policy = properties.getExtSource();
+        return new ExtSourceConfig(
+                source.getEndpoint(),
+                source.getRegion(),
+                source.getBucket(),
+                source.getPrefix(),
+                source.getAccessKey(),
+                source.getSecretKey(),
+                policy.getMaxObjectsPerSource(),
+                policy.getFetchTimeoutMs());
+    }
+
+    private String partialError(int failures, boolean truncated, int cap) {
+        if (failures == 0 && !truncated) {
+            return null;
+        }
+        StringBuilder message = new StringBuilder();
+        if (truncated) {
+            message.append("对象数超过上限 ").append(cap).append("，本次仅同步前 ").append(cap).append(" 个");
+        }
+        if (failures > 0) {
+            if (message.length() > 0) {
+                message.append("；");
+            }
+            message.append(failures).append(" 个对象同步失败，详见对象明细");
+        }
+        return message.toString();
+    }
+
+    /** Lower case extension of an object key, {@code null} when the key has none. */
+    static String extensionOf(String objectKey) {
+        int slash = objectKey.lastIndexOf('/');
+        String name = slash < 0 ? objectKey : objectKey.substring(slash + 1);
+        int dot = name.lastIndexOf('.');
+        if (dot <= 0 || dot == name.length() - 1) {
+            return null;
+        }
+        return name.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Derives the stable file name an object uploads under: a slug of the object's base name and a
+     * hash prefix that keeps two different keys with alike names from merging into one document.
+     */
+    static String deriveFileName(String objectKey, String keyHash, String extension) {
+        int slash = objectKey.lastIndexOf('/');
+        String name = slash < 0 ? objectKey : objectKey.substring(slash + 1);
+        int dot = name.lastIndexOf('.');
+        String base = slugOf(dot <= 0 ? name : name.substring(0, dot));
+        String suffix = "-" + keyHash.substring(0, FILE_NAME_HASH_LENGTH) + "." + extension;
+        int room = MAX_FILE_NAME_LENGTH - suffix.length();
+        if (base.length() > room) {
+            base = base.substring(0, room);
+        }
+        return base + suffix;
+    }
+
+    /** Lower-cases a name and collapses every non-alphanumeric run into a single dash. */
+    private static String slugOf(String name) {
+        String slug = name.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9\\u4e00-\\u9fa5]+", "-");
+        return slug.replaceAll("^-+|-+$", "");
+    }
+
+    private String truncate(String message) {
+        if (message == null) {
+            return null;
+        }
+        return message.length() <= MAX_ERROR_LENGTH ? message : message.substring(0, MAX_ERROR_LENGTH);
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/ChunkIndexWriter.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/ChunkIndexWriter.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.kbrag.common.util.JsonUtil;
 import io.kbrag.domain.constant.ChunkMetadataKeys;
+import io.kbrag.domain.constant.IndexFields;
 import io.kbrag.domain.entity.Chunk;
 import io.kbrag.domain.entity.ChunkIndexSync;
 import io.kbrag.domain.enums.IndexSyncStatus;
@@ -15,6 +16,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -120,6 +122,10 @@ public class ChunkIndexWriter {
      * everything else stays in MySQL. A key that is absent simply leaves its engine field empty, so a
      * document without chat metadata is indexed exactly as before rather than being rejected.
      *
+     * <p>The one exception is the operator extracted metadata of the M14 contract section 3.2: every
+     * key outside the reserved set is mirrored under the {@code ext_} namespace so the retrieval side
+     * can filter on it, while MySQL keeps the raw key name.
+     *
      * @param chunk  fact source row
      * @param vector embedding, {@code null} when the target declares no vector field
      * @return engine document
@@ -138,10 +144,38 @@ public class ChunkIndexWriter {
                 .sessionId(text(metadata.get(ChunkMetadataKeys.SESSION_ID)))
                 .sender(text(metadata.get(ChunkMetadataKeys.SENDER)))
                 .msgTime(epochMillis(metadata.get(ChunkMetadataKeys.MSG_TIME)))
+                .extMetadata(extMetadataOf(metadata))
                 .chunkSeq(chunk.getSeq())
                 .content(chunk.getContent())
                 .vector(vector)
                 .build();
+    }
+
+    /**
+     * Collects the operator extracted keys under the engine side {@code ext_} namespace.
+     *
+     * <p>Only strings and string lists cross over - those are the two shapes the metadata rules
+     * produce, and anything else in the column is a platform structure that has no engine field.
+     *
+     * @param metadata parsed metadata document
+     * @return prefixed extracted values, empty when the chunk carries none
+     */
+    private Map<String, Object> extMetadataOf(Map<String, Object> metadata) {
+        Map<String, Object> ext = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+            if (ChunkMetadataKeys.RESERVED.contains(entry.getKey())) {
+                continue;
+            }
+            if (entry.getValue() instanceof String value && !value.isBlank()) {
+                ext.put(IndexFields.EXT_PREFIX + entry.getKey(), value);
+            } else if (entry.getValue() instanceof List<?>) {
+                List<String> values = stringList(entry.getValue());
+                if (!values.isEmpty()) {
+                    ext.put(IndexFields.EXT_PREFIX + entry.getKey(), values);
+                }
+            }
+        }
+        return ext;
     }
 
     /**

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/IndexPipelineService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/IndexPipelineService.java
@@ -45,6 +45,8 @@ import io.kbrag.domain.service.DocumentCleaner;
 import io.kbrag.domain.service.DocumentVersionPlanner;
 import io.kbrag.domain.service.ImageChunkLinker;
 import io.kbrag.domain.service.ImagePlaceholderResolver;
+import io.kbrag.domain.service.MetadataRuleExtractor;
+import io.kbrag.domain.service.PageSplitter;
 import io.kbrag.domain.service.ParentChildSplitter;
 import io.kbrag.domain.service.SplitterRouter;
 import io.kbrag.domain.service.VersionFingerprintFactory;
@@ -116,11 +118,13 @@ public class IndexPipelineService {
     private final DocumentParserClient parserClient;
     private final SplitterRouter splitterRouter;
     private final ParentChildSplitter parentChildSplitter;
+    private final PageSplitter pageSplitter;
     private final ChunkTextHasher chunkTextHasher;
     private final EmbeddingProvider embeddingProvider;
     private final ChunkEmbedder chunkEmbedder;
     private final VisionProvider visionProvider;
     private final ChunkIndexWriter chunkIndexWriter;
+    private final MultimodalIndexManager multimodalIndexManager;
     private final KnowledgeBaseService knowledgeBaseService;
     private final BizIdGenerator bizIdGenerator;
     private final VersionFingerprintFactory fingerprintFactory;
@@ -128,6 +132,7 @@ public class IndexPipelineService {
     private final DocumentCleaner documentCleaner;
     private final ImagePlaceholderResolver placeholderResolver;
     private final ImageChunkLinker imageChunkLinker;
+    private final MetadataRuleExtractor metadataRuleExtractor;
     private final DocumentVersionActivator versionActivator;
     private final VersionArtifactReuser versionArtifactReuser;
     private final VersionRetentionService versionRetentionService;
@@ -349,7 +354,7 @@ public class IndexPipelineService {
                     .stream().map(Chunk::getChunkId).toList();
 
             List<Chunk> chunks = split(document, version, staged, config, task);
-            index(document, chunks, task);
+            index(document, version, chunks, config, task);
             removeObsolete(document.getKbId(), versionId, obsolete);
 
             if (activate) {
@@ -420,7 +425,7 @@ public class IndexPipelineService {
         version.setEmbeddingVersion(embeddingProvider.model());
         documentVersionMapper.updateById(version);
         updateProgress(task, PROGRESS_CHUNKED);
-        index(document, copied, task);
+        index(document, version, copied, config, task);
         activateAndFollowUp(document, version);
         completeTask(task);
         return true;
@@ -570,7 +575,7 @@ public class IndexPipelineService {
         updateProcessStatus(document, ProcessStatus.INDEXING, null);
         deleteExistingChunks(document.getKbId(), version.getVersionId());
         List<Chunk> chunks = split(document, version, staged, config, task);
-        index(document, chunks, task);
+        index(document, version, chunks, config, task);
         activateAndFollowUp(document, version);
         completeTask(task);
     }
@@ -750,19 +755,41 @@ public class IndexPipelineService {
     private List<Chunk> splitSingleLevel(Document document, DocumentVersion version, StagedContent staged,
                                          KbIndexConfig config, boolean embeddingConfigured,
                                          boolean standaloneImage) {
-        List<SplitChunk> splitChunks = splitterRouter.resolve(config.getSplitStrategy())
-                .split(staged.proxied().getMarkdown(), config.splitParams(cacheContextOf(document, version)));
+        List<SplitChunk> splitChunks = splitPage(config, standaloneImage)
+                ? pageSplitter.split(readParsedQuietly(document, version), staged.proxied().getMarkdown(),
+                        config.splitParams(cacheContextOf(document, version)))
+                : splitterRouter.resolve(config.getSplitStrategy())
+                        .split(staged.proxied().getMarkdown(),
+                                config.splitParams(cacheContextOf(document, version)));
         Map<Integer, List<String>> imagesByChunk = imageChunkLinker.link(staged.proxied().getMarkdown(),
                 staged.proxied().getPlacements(), splitChunks.stream().map(SplitChunk::getContent).toList());
+        List<MetadataRuleExtractor.PreparedRule> rules =
+                metadataRuleExtractor.prepare(config.metadataRulesOrEmpty());
         List<Chunk> chunks = new ArrayList<>(splitChunks.size());
         for (int index = 0; index < splitChunks.size(); index++) {
             List<String> imageKeys = imagesByChunk.get(index);
-            Chunk chunk = persistChunk(document, version, splitChunks.get(index), null, embeddingConfigured,
+            SplitChunk splitChunk = splitChunks.get(index);
+            Chunk chunk = persistChunk(document, version, splitChunk, null, embeddingConfigured,
                     standaloneImage ? ChunkType.IMAGE : ChunkType.TEXT,
-                    metadataOf(imageKeys, splitChunks.get(index)));
+                    metadataOf(imageKeys, splitChunk,
+                            metadataRuleExtractor.extract(rules, splitChunk.getContent())));
             chunks.add(chunk);
         }
         return chunks;
+    }
+
+    /**
+     * Tells whether the single level split should route through the page strategy.
+     *
+     * <p>A standalone image is never page split: it has no parse artifact and its whole text comes from
+     * the vision model, so the page strategy would find nothing and drop the one chunk the image needs.
+     *
+     * @param config          knowledge base index configuration
+     * @param standaloneImage {@code true} when the document is one uploaded image
+     * @return {@code true} when the page strategy applies
+     */
+    private boolean splitPage(KbIndexConfig config, boolean standaloneImage) {
+        return !standaloneImage && PageSplitter.STRATEGY_CODE.equals(config.getSplitStrategy());
     }
 
     /**
@@ -791,6 +818,8 @@ public class IndexPipelineService {
         }
         Map<Integer, List<String>> imagesByChunk = imageChunkLinker.link(staged.proxied().getMarkdown(),
                 staged.proxied().getPlacements(), childContents);
+        List<MetadataRuleExtractor.PreparedRule> rules =
+                metadataRuleExtractor.prepare(config.metadataRulesOrEmpty());
 
         List<Chunk> children = new ArrayList<>();
         int childIndex = 0;
@@ -799,7 +828,8 @@ public class IndexPipelineService {
                     ChunkType.TEXT, null);
             for (SplitChunk child : group.getChildren()) {
                 children.add(persistChunk(document, version, child, parent.getChunkId(), embeddingConfigured,
-                        ChunkType.TEXT, metadataOf(imagesByChunk.get(childIndex++), child)));
+                        ChunkType.TEXT, metadataOf(imagesByChunk.get(childIndex++), child,
+                                metadataRuleExtractor.extract(rules, child.getContent()))));
             }
         }
         return children;
@@ -807,14 +837,20 @@ public class IndexPipelineService {
 
     /**
      * Merges the image links a chunk carries with the title/summary/keywords the LLM semantic
-     * splitter attaches to it, requirement section 4.3.
+     * splitter attaches to it, requirement section 4.3, and with the operator extracted metadata of
+     * the M14 contract section 3.2.
+     *
+     * <p>The extracted values go in first so a reserved key wins any collision: the platform written
+     * semantics of {@code title} or {@code image_urls} must never be silently replaced by a rule an
+     * operator happened to name the same way.
      *
      * @param imageKeys  object storage keys of the images this chunk contains, may be empty
      * @param splitChunk splitter output, {@code null} metadata for every strategy but the LLM one
+     * @param extracted  metadata rule output for this chunk, may be empty
      * @return JSON metadata document, {@code null} when there is nothing to store
      */
-    private String metadataOf(List<String> imageKeys, SplitChunk splitChunk) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
+    private String metadataOf(List<String> imageKeys, SplitChunk splitChunk, Map<String, Object> extracted) {
+        Map<String, Object> metadata = new LinkedHashMap<>(extracted);
         if (CollectionUtils.isNotEmpty(imageKeys)) {
             metadata.put(ChunkMetadataKeys.IMAGE_URLS, imageKeys);
         }
@@ -863,12 +899,23 @@ public class IndexPipelineService {
         return chunk;
     }
 
-    private void index(Document document, List<Chunk> chunks, KbTask task) {
+    /**
+     * Writes the chunks of a version to the main indexes and, when enabled, to the multimodal one.
+     *
+     * @param document document record
+     * @param version  version being built, source of the multimodal image media types
+     * @param chunks   indexable chunks of the version
+     * @param config   knowledge base index configuration
+     * @param task     running task
+     */
+    private void index(Document document, DocumentVersion version, List<Chunk> chunks,
+                       KbIndexConfig config, KbTask task) {
         if (CollectionUtils.isEmpty(chunks)) {
             updateProgress(task, PROGRESS_INDEXED);
             return;
         }
         chunkIndexWriter.write(document.getKbId(), chunks, chunkEmbedder.embed(chunks));
+        multimodalIndexManager.index(document.getKbId(), version.getVersionId(), chunks, config);
         updateProgress(task, PROGRESS_INDEXED);
     }
 

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/MultimodalIndexManager.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/MultimodalIndexManager.java
@@ -1,0 +1,263 @@
+package io.kbrag.app.index;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.constant.KbConstants;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.constant.ChunkMetadataKeys;
+import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.entity.ImageAsset;
+import io.kbrag.domain.entity.IndexRegistry;
+import io.kbrag.domain.enums.IndexRegistryStatus;
+import io.kbrag.domain.enums.VectorEngine;
+import io.kbrag.domain.mapper.IndexRegistryMapper;
+import io.kbrag.domain.model.ImageInput;
+import io.kbrag.domain.model.IndexSpec;
+import io.kbrag.domain.model.KbIndexConfig;
+import io.kbrag.domain.port.FulltextStore;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
+import io.kbrag.domain.port.ObjectStorage;
+import io.kbrag.domain.port.VectorStore;
+import io.kbrag.domain.service.IndexNaming;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Owns the multimodal index of a knowledge base, the M14 contract section 6.2.
+ *
+ * <p>A second, parallel index rather than a field on the text one: the multimodal vectors live in a
+ * different embedding space and carry a different dimension, so mixing them into the text index would
+ * force a rebuild of the text vectors on every multimodal model switch and vice versa. The multimodal
+ * marker in the physical name keeps the two apart while the deployment engine stays the same - a
+ * Qdrant collection in full mode, an Elasticsearch dense_vector index in lite mode.
+ *
+ * <p><b>What gets a vector.</b> Every chunk that carries {@code image_urls} - a standalone upload, a
+ * scanned page render or a chunk that inlined an embedded illustration - is embedded from its original
+ * image bytes, keyed by chunk id so the multimodal hit is the very same chunk the main index holds and
+ * the fusion stage deduplicates on chunk id alone. The vision text proxy path is untouched: the
+ * multimodal route is added on top, not swapped in.
+ *
+ * <p>The switch and the provider gate this together: a disabled switch or a blank credential skips the
+ * whole index exactly like a zero key deployment skips embedding, which keeps every collaborator free
+ * of null checks. The synchronization rows reuse {@code t_kb_chunk_index_sync} keyed by the physical
+ * index name, so the compensation scan needs no change.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MultimodalIndexManager {
+
+    private static final int CURRENT = 1;
+
+    private final KbProperties properties;
+    private final IndexNaming indexNaming;
+    private final MultimodalEmbeddingProvider multimodalEmbeddingProvider;
+    private final FulltextStore fulltextStore;
+    private final VectorStore vectorStore;
+    private final IndexRegistryMapper indexRegistryMapper;
+    private final ObjectStorage objectStorage;
+    private final ImageAssetService imageAssetService;
+    private final ChunkIndexWriter chunkIndexWriter;
+
+    /**
+     * Produces the multimodal vectors of a version and writes them to the multimodal index.
+     *
+     * <p>A no-op unless the switch is on and the provider holds a credential, so the indexing pipeline
+     * can call it unconditionally. An image that cannot be read is dropped from the batch rather than
+     * failing the version, mirroring the "an image never fails a document" rule of the vision stage.
+     *
+     * @param kbId      knowledge base business id
+     * @param versionId document version business id, source of the image media types
+     * @param chunks    indexable chunks of the version
+     * @param config    knowledge base index configuration
+     */
+    public void index(String kbId, String versionId, List<Chunk> chunks, KbIndexConfig config) {
+        if (config == null || !config.isMultimodalEnabled()) {
+            return;
+        }
+        if (!multimodalEmbeddingProvider.isConfigured()) {
+            log.info("multimodal embedding provider not configured, multimodal index skipped, kbId={}", kbId);
+            return;
+        }
+        if (CollectionUtils.isEmpty(chunks)) {
+            return;
+        }
+        Map<String, String> mediaTypes = mediaTypesByKey(versionId);
+        List<Chunk> imageChunks = new ArrayList<>();
+        List<ImageInput> inputs = new ArrayList<>();
+        for (Chunk chunk : chunks) {
+            String objectKey = firstImageKey(chunk.getMetadata());
+            if (objectKey == null) {
+                continue;
+            }
+            byte[] content = read(objectKey);
+            if (content == null || content.length == 0) {
+                continue;
+            }
+            imageChunks.add(chunk);
+            inputs.add(new ImageInput(content, mediaTypes.get(objectKey)));
+        }
+        if (imageChunks.isEmpty()) {
+            return;
+        }
+        Map<String, float[]> vectors = embed(imageChunks, inputs);
+        IndexTarget target = ensureIndex(kbId);
+        chunkIndexWriter.writeTarget(target, imageChunks, vectors);
+        log.info("multimodal index written, kbId={}, index={}, chunks={}",
+                kbId, target.physicalIndexName(), imageChunks.size());
+    }
+
+    /**
+     * Alias the multimodal retrieval route reads through, {@code null} when the capability is off.
+     *
+     * @param kbId   knowledge base business id
+     * @param config knowledge base index configuration
+     * @return multimodal alias, or {@code null} when the switch is off or the provider is unconfigured
+     */
+    public String multimodalAlias(String kbId, KbIndexConfig config) {
+        if (config == null || !config.isMultimodalEnabled() || !multimodalEmbeddingProvider.isConfigured()) {
+            return null;
+        }
+        return indexNaming.multimodalAlias(kbId);
+    }
+
+    /**
+     * Embeds the images of each chunk in provider sized batches, keyed by chunk id.
+     *
+     * @param imageChunks chunks carrying an image, aligned with {@code inputs}
+     * @param inputs      image bytes to embed, one per chunk
+     * @return vector per chunk id, in submitted order
+     */
+    private Map<String, float[]> embed(List<Chunk> imageChunks, List<ImageInput> inputs) {
+        int batchSize = Math.max(1, multimodalEmbeddingProvider.maxBatchSize());
+        Map<String, float[]> vectors = new LinkedHashMap<>();
+        for (int start = 0; start < inputs.size(); start += batchSize) {
+            List<ImageInput> slice = inputs.subList(start, Math.min(inputs.size(), start + batchSize));
+            List<float[]> embedded = multimodalEmbeddingProvider.embedImages(slice);
+            for (int offset = 0; offset < embedded.size(); offset++) {
+                vectors.put(imageChunks.get(start + offset).getChunkId(), embedded.get(offset));
+            }
+        }
+        return vectors;
+    }
+
+    /**
+     * Creates the multimodal physical index, binds its alias and registers the row. Idempotent.
+     *
+     * @param kbId knowledge base business id
+     * @return the multimodal write target
+     */
+    private IndexTarget ensureIndex(String kbId) {
+        VectorEngine engine = properties.getVector().resolved();
+        String embeddingSegment = indexNaming.embeddingSegment(multimodalEmbeddingProvider.model());
+        String physicalName = indexNaming.multimodalPhysicalName(kbId, embeddingSegment);
+        String alias = indexNaming.multimodalAlias(kbId);
+        int dimension = multimodalEmbeddingProvider.dimension();
+        IndexSpec spec = IndexSpec.builder()
+                .physicalIndexName(physicalName)
+                .aliasName(alias)
+                .dimension(dimension)
+                .schemaVersion(KbConstants.INDEX_SCHEMA_VERSION)
+                .build();
+        if (engine == VectorEngine.ES) {
+            fulltextStore.ensureIndex(spec);
+        } else {
+            vectorStore.ensureIndex(spec);
+        }
+        register(kbId, engine, physicalName, alias, embeddingSegment);
+        return new IndexTarget(engine, physicalName, alias, embeddingSegment, true, dimension);
+    }
+
+    private void register(String kbId, VectorEngine engine, String physicalName, String alias,
+                          String embeddingSegment) {
+        IndexRegistry existing = indexRegistryMapper.selectOne(new LambdaQueryWrapper<IndexRegistry>()
+                .eq(IndexRegistry::getPhysicalIndexName, physicalName)
+                .last("limit 1"));
+        if (existing != null) {
+            return;
+        }
+        IndexRegistry registry = new IndexRegistry();
+        registry.setKbId(kbId);
+        registry.setEngine(engine.code());
+        registry.setPhysicalIndexName(physicalName);
+        registry.setAliasName(alias);
+        registry.setIsCurrent(CURRENT);
+        registry.setEmbeddingProvider(multimodalEmbeddingProvider.providerName());
+        registry.setEmbeddingModel(multimodalEmbeddingProvider.model());
+        registry.setEmbeddingVersion(embeddingSegment);
+        registry.setSnapshotVersion(KbConstants.SNAPSHOT_SEGMENT_V1);
+        registry.setSchemaVersion(KbConstants.INDEX_SCHEMA_VERSION);
+        registry.setStatus(IndexRegistryStatus.ACTIVE);
+        indexRegistryMapper.insert(registry);
+        log.info("multimodal index registered, kbId={}, engine={}, index={}, alias={}",
+                kbId, engine.code(), physicalName, alias);
+    }
+
+    /**
+     * Maps each stored object key to the media type recorded for it, so the provider request declares
+     * the correct MIME type instead of guessing from the bytes.
+     *
+     * @param versionId document version business id
+     * @return media type per object key, empty when the version holds no image
+     */
+    private Map<String, String> mediaTypesByKey(String versionId) {
+        List<ImageAsset> assets = imageAssetService.findByVersion(versionId);
+        if (CollectionUtils.isEmpty(assets)) {
+            return Map.of();
+        }
+        Map<String, String> mediaTypes = new LinkedHashMap<>(assets.size());
+        for (ImageAsset asset : assets) {
+            mediaTypes.put(asset.getObjectKey(), asset.getMediaType());
+        }
+        return mediaTypes;
+    }
+
+    /**
+     * Reads the first image object key a chunk carries, {@code null} when it carries none.
+     *
+     * @param metadataJson raw chunk metadata document
+     * @return first image object key, or {@code null}
+     */
+    private String firstImageKey(String metadataJson) {
+        if (metadataJson == null || metadataJson.isBlank()) {
+            return null;
+        }
+        Map<String, Object> metadata = JsonUtil.parse(metadataJson, new TypeReference<Map<String, Object>>() {
+        });
+        if (metadata == null || !(metadata.get(ChunkMetadataKeys.IMAGE_URLS) instanceof List<?> keys)
+                || keys.isEmpty()) {
+            return null;
+        }
+        Object first = keys.get(0);
+        return first == null ? null : String.valueOf(first);
+    }
+
+    /**
+     * Reads an object's bytes, returning {@code null} on any failure so a single unreadable image is
+     * dropped from the multimodal batch instead of failing the version.
+     *
+     * @param objectKey object storage key
+     * @return image bytes, or {@code null} when the object cannot be read
+     */
+    private byte[] read(String objectKey) {
+        try (InputStream in = objectStorage.get(objectKey)) {
+            return in.readAllBytes();
+        } catch (Exception e) {
+            log.error("multimodal image unreadable, errorCode={}, objectKey={}",
+                    ErrorCode.INTERNAL_ERROR, objectKey, e);
+            return null;
+        }
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/metrics/KbMetrics.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/metrics/KbMetrics.java
@@ -1,5 +1,6 @@
 package io.kbrag.app.metrics;
 
+import io.kbrag.domain.enums.ExtSourceSyncStatus;
 import io.kbrag.domain.enums.InsightSource;
 import io.kbrag.domain.enums.TaskType;
 import io.kbrag.domain.enums.WebSourceFetchStatus;
@@ -42,6 +43,9 @@ public class KbMetrics {
 
     /** Counter of one web source sync outcome, the M12 four state result. */
     static final String WEBSOURCE_SYNC = "kb.websource.sync";
+
+    /** Counter of one external source sync pass outcome, the M14 three state result. */
+    static final String EXTSOURCE_SYNC = "kb.extsource.sync";
 
     static final String TAG_SOURCE = "source";
     static final String TAG_ZERO_HIT = "zero_hit";
@@ -121,6 +125,21 @@ public class KbMetrics {
             return;
         }
         Counter.builder(WEBSOURCE_SYNC)
+                .tag(TAG_STATUS, lower(status.name()))
+                .register(registry)
+                .increment();
+    }
+
+    /**
+     * Records the outcome of one external source sync pass.
+     *
+     * @param status three state outcome written onto the source row
+     */
+    public void recordExtSourceSync(ExtSourceSyncStatus status) {
+        if (status == null) {
+            return;
+        }
+        Counter.builder(EXTSOURCE_SYNC)
                 .tag(TAG_STATUS, lower(status.name()))
                 .register(registry)
                 .increment();

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/openapi/KnowledgeApiService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/openapi/KnowledgeApiService.java
@@ -5,7 +5,6 @@ import io.kbrag.app.appcenter.AppVersionService;
 import io.kbrag.app.config.AsyncConfig;
 import io.kbrag.app.insight.SearchInsightService;
 import io.kbrag.app.metrics.KbMetrics;
-import io.kbrag.app.retrieval.ImageQueryService;
 import io.kbrag.app.retrieval.RetrievalCommand;
 import io.kbrag.app.retrieval.RetrievalIndexOverride;
 import io.kbrag.app.retrieval.RetrievalNodeView;
@@ -75,7 +74,6 @@ public class KnowledgeApiService {
     private final RequestOverridePolicy requestOverridePolicy;
     private final ApiAuditService apiAuditService;
     private final SearchInsightService searchInsightService;
-    private final ImageQueryService imageQueryService;
     private final KbMetrics kbMetrics;
 
     /**
@@ -87,16 +85,14 @@ public class KnowledgeApiService {
      */
     public KnowledgeCallResult search(ApiKeyPrincipal principal, KnowledgeCallCommand command) {
         long startedAt = System.currentTimeMillis();
-        EnrichedCall call = EnrichedCall.of(command);
         try {
             ResolvedTarget target = resolve(principal, command);
-            call = enrich(command);
-            KnowledgeCallResult result = retrieve(target, call);
-            insight(call, result, startedAt);
-            audit(principal, call.command(), target, result, startedAt, ApiAuditService.ENDPOINT_SEARCH);
+            KnowledgeCallResult result = retrieve(target, command);
+            insight(command, result, startedAt);
+            audit(principal, command, target, result, startedAt, ApiAuditService.ENDPOINT_SEARCH);
             return result;
         } catch (BizException e) {
-            auditRejection(principal, call.command(), startedAt, e, ApiAuditService.ENDPOINT_SEARCH);
+            auditRejection(principal, command, startedAt, e, ApiAuditService.ENDPOINT_SEARCH);
             throw e;
         }
     }
@@ -110,18 +106,16 @@ public class KnowledgeApiService {
      */
     public KnowledgeCallResult chat(ApiKeyPrincipal principal, KnowledgeCallCommand command) {
         long startedAt = System.currentTimeMillis();
-        EnrichedCall call = EnrichedCall.of(command);
         try {
             ResolvedTarget target = resolve(principal, command);
-            call = enrich(command);
-            KnowledgeCallResult retrieved = retrieve(target, call);
-            insight(call, retrieved, startedAt);
-            String answer = generate(target, call.command(), retrieved.getNodes());
+            KnowledgeCallResult retrieved = retrieve(target, command);
+            insight(command, retrieved, startedAt);
+            String answer = generate(target, command, retrieved.getNodes());
             KnowledgeCallResult result = withAnswer(retrieved, answer);
-            audit(principal, call.command(), target, result, startedAt, ApiAuditService.ENDPOINT_CHAT);
+            audit(principal, command, target, result, startedAt, ApiAuditService.ENDPOINT_CHAT);
             return result;
         } catch (BizException e) {
-            auditRejection(principal, call.command(), startedAt, e, ApiAuditService.ENDPOINT_CHAT);
+            auditRejection(principal, command, startedAt, e, ApiAuditService.ENDPOINT_CHAT);
             throw e;
         }
     }
@@ -140,27 +134,25 @@ public class KnowledgeApiService {
     public void chatStream(ApiKeyPrincipal principal, KnowledgeCallCommand command,
                            ChatStreamListener listener) {
         long startedAt = System.currentTimeMillis();
-        EnrichedCall call = EnrichedCall.of(command);
         try {
             ResolvedTarget target = resolve(principal, command);
-            call = enrich(command);
-            KnowledgeCallResult retrieved = retrieve(target, call);
-            insight(call, retrieved, startedAt);
+            KnowledgeCallResult retrieved = retrieve(target, command);
+            insight(command, retrieved, startedAt);
             StringBuilder answer = new StringBuilder();
-            streamGenerate(target, call.command(), retrieved.getNodes(), delta -> {
+            streamGenerate(target, command, retrieved.getNodes(), delta -> {
                 answer.append(delta);
                 listener.onDelta(delta);
             });
             listener.onReferences(retrieved.getNodes());
             listener.onDone(RequestIdHolder.get(), retrieved.getDegraded(), retrieved.routedKbIds());
-            audit(principal, call.command(), target, retrieved, startedAt, ApiAuditService.ENDPOINT_CHAT);
+            audit(principal, command, target, retrieved, startedAt, ApiAuditService.ENDPOINT_CHAT);
         } catch (BizException e) {
-            auditRejection(principal, call.command(), startedAt, e, ApiAuditService.ENDPOINT_CHAT);
+            auditRejection(principal, command, startedAt, e, ApiAuditService.ENDPOINT_CHAT);
             listener.onError(e.getErrorCode().name(), e.getMessage());
         } catch (Exception e) {
             log.error("open chat stream failed, errorCode={}, appId={}",
                     ErrorCode.INTERNAL_ERROR, command.getAppId(), e);
-            auditRejection(principal, call.command(), startedAt,
+            auditRejection(principal, command, startedAt,
                     new BizException(ErrorCode.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getDefaultMessage()),
                     ApiAuditService.ENDPOINT_CHAT);
             listener.onError(ErrorCode.INTERNAL_ERROR.name(), ErrorCode.INTERNAL_ERROR.getDefaultMessage());
@@ -233,12 +225,11 @@ public class KnowledgeApiService {
         ResolvedTarget target = new ResolvedTarget(version, appVersionService.parseConfig(version),
                 TargetStage.of(version.getStatus()), false);
         requestOverridePolicy.validate(forbiddenKeysOf(command));
-        EnrichedCall call = enrich(command);
-        KnowledgeCallResult retrieved = retrieve(target, call);
+        KnowledgeCallResult retrieved = retrieve(target, command);
         if (listener == null) {
-            return withAnswer(retrieved, generate(target, call.command(), retrieved.getNodes()));
+            return withAnswer(retrieved, generate(target, command, retrieved.getNodes()));
         }
-        streamGenerate(target, call.command(), retrieved.getNodes(), listener::onDelta);
+        streamGenerate(target, command, retrieved.getNodes(), listener::onDelta);
         listener.onReferences(retrieved.getNodes());
         listener.onDone(RequestIdHolder.get(), retrieved.getDegraded(), retrieved.routedKbIds());
         return retrieved;
@@ -281,31 +272,17 @@ public class KnowledgeApiService {
     }
 
     /**
-     * Folds the attached images into the question before anything else reads it, requirement section 4.8.
-     *
-     * <p>Runs after the authorisation check and before the retrieval, which is what makes the image text
-     * reach the rewrite stage, the recall routes, the generation prompt and the audit digest as one single
-     * question. Every consumer downstream therefore sees the same string and none of them has to know that
-     * an image was involved.
-     *
-     * @param command call parameters as the caller expressed them
-     * @return the same call with an enriched query, plus whatever the image stage degraded
-     */
-    private EnrichedCall enrich(KnowledgeCallCommand command) {
-        ImageQueryService.ImageQueryOutcome outcome =
-                imageQueryService.enrich(command.getQuery(), command.getImages());
-        return new EnrichedCall(command.toBuilder().query(outcome.query()).build(), outcome.degraded());
-    }
-
-    /**
      * Runs the retrieval stage of one call against the frozen configuration.
      *
-     * @param target resolved application version
-     * @param call   call parameters with the image text already folded into the query
+     * <p>The attached images travel raw into the retrieval command; {@code RetrievalService} owns the single
+     * dispatch point that either embeds them into the multimodal route or folds their transcription into the
+     * query, so the image degradation markers arrive inside the search outcome like any other route's.
+     *
+     * @param target  resolved application version
+     * @param command call parameters, images included
      * @return result without an answer
      */
-    private KnowledgeCallResult retrieve(ResolvedTarget target, EnrichedCall call) {
-        KnowledgeCallCommand command = call.command();
+    private KnowledgeCallResult retrieve(ResolvedTarget target, KnowledgeCallCommand command) {
         AppConfigSnapshot snapshot = target.snapshot();
         List<KbRef> kbRefs = snapshot.getKbRefs();
         if (CollectionUtils.isEmpty(kbRefs)) {
@@ -316,33 +293,12 @@ public class KnowledgeApiService {
         List<RetrievalNodeView> nodes = trim(outcome.getNodes(), command.getMaxContentLength());
         return KnowledgeCallResult.builder()
                 .nodes(nodes)
-                .degraded(mergeDegraded(call.imageDegraded(), outcome.getDegraded()))
+                .degraded(outcome.getDegraded())
                 .applied(outcome.getApplied())
                 .appVersionId(target.version().getAppVersionId())
                 .appVersion(target.version().getVersion())
                 .targetStage(target.stage())
                 .build();
-    }
-
-    /**
-     * Joins the markers of the image stage with the ones the pipeline produced.
-     *
-     * <p>The image stage runs outside {@code RetrievalService}, so its marker cannot travel in the search
-     * outcome; joining here keeps the caller with one flat {@code degraded} array whatever produced it.
-     *
-     * @param imageDegraded markers of the image stage
-     * @param pipeline      markers of the retrieval pipeline
-     * @return degradation markers of the whole call, without duplicates
-     */
-    private List<String> mergeDegraded(List<String> imageDegraded, List<String> pipeline) {
-        if (CollectionUtils.isEmpty(imageDegraded)) {
-            return pipeline;
-        }
-        Set<String> merged = new LinkedHashSet<>(imageDegraded);
-        if (CollectionUtils.isNotEmpty(pipeline)) {
-            merged.addAll(pipeline);
-        }
-        return List.copyOf(merged);
     }
 
     /**
@@ -368,6 +324,7 @@ public class KnowledgeApiService {
                 .routingEnabled(routing.isEnabled())
                 .routingPrompt(routing.getPrompt())
                 .query(command.getQuery())
+                .images(command.getImages())
                 .messages(command.getMessages() == null ? List.of() : command.getMessages())
                 .recallTopK(retrieval.getRecallTopK())
                 .topN(command.getTopN() != null ? command.getTopN() : retrieval.getTopN())
@@ -543,7 +500,7 @@ public class KnowledgeApiService {
                 .appVersionId(target == null ? null : target.version().getAppVersionId())
                 .targetStage(target == null ? null : target.stage())
                 .endpoint(endpoint)
-                .query(command.getQuery())
+                .query(digestQuery(command, result))
                 .hitDocIds(result == null ? List.of() : docIdsOf(result.getNodes()))
                 .latencyMs((int) (System.currentTimeMillis() - startedAt))
                 .degraded(result == null ? List.of() : result.getDegraded())
@@ -573,20 +530,20 @@ public class KnowledgeApiService {
      * The open API insight recording point, the M10 contract section 2.2.
      *
      * <p>Sits after a successful retrieval only: a rejected call never searched anything, so it belongs
-     * to the audit trail and not to the content gap report. The enriched query is what gets digested -
-     * the same choice the audit row makes - because it is the text the ranking actually came from.
-     * Chat calls record the counts of their retrieval stage; the generated answer changes nothing about
-     * whether the corpus could serve the question.
+     * to the audit trail and not to the content gap report. The query the ranking actually came from is
+     * what gets digested - the same choice the audit row makes - which after the M14 image dispatch may be
+     * an image transcription folded into the question. Chat calls record the counts of their retrieval
+     * stage; the generated answer changes nothing about whether the corpus could serve the question.
      *
      * <p>Also the open API sampling point of the M13 search metric, which shares the insight's boundary
      * reasoning and adds what the insight row does not carry: the wall time since the call entered. For a
      * chat call that is the retrieval stage only, since this runs before the generation starts.
      *
-     * @param call      call parameters with the image text folded into the query
+     * @param command   call parameters as the caller expressed them
      * @param result    retrieval outcome of the call
      * @param startedAt epoch milliseconds the call entered the service at
      */
-    private void insight(EnrichedCall call, KnowledgeCallResult result, long startedAt) {
+    private void insight(KnowledgeCallCommand command, KnowledgeCallResult result, long startedAt) {
         List<RetrievalNodeView> nodes = result.getNodes();
         int resultCount = CollectionUtils.isEmpty(nodes) ? 0 : nodes.size();
         kbMetrics.recordSearch(InsightSource.OPEN_API, System.currentTimeMillis() - startedAt,
@@ -594,12 +551,31 @@ public class KnowledgeApiService {
         searchInsightService.recordAsync(SearchInsightService.InsightRecord.builder()
                 .source(InsightSource.OPEN_API)
                 .kbIds(result.routedKbIds())
-                .query(call.command().getQuery())
+                .query(digestQuery(command, result))
                 .resultCount(resultCount)
                 .topScore(CollectionUtils.isEmpty(nodes) ? null : nodes.get(0).getScore())
                 .degraded(result.getDegraded())
                 .requestId(RequestIdHolder.get())
                 .build());
+    }
+
+    /**
+     * The query to store in the audit and insight rows: the one the ranking actually came from.
+     *
+     * <p>Prefers the effective query the pipeline reports back through the applied summary, since the M14
+     * image dispatch may have folded an image transcription into it or the rewrite stage may have reshaped
+     * it; falls back to the raw call query when no retrieval ran or the pipeline reported nothing.
+     *
+     * @param command call parameters as the caller expressed them
+     * @param result  retrieval outcome, {@code null} when nothing was retrieved
+     * @return query text for the trail
+     */
+    private String digestQuery(KnowledgeCallCommand command, KnowledgeCallResult result) {
+        if (result != null && result.getApplied() != null
+                && result.getApplied().getRewriteUsedQuery() != null) {
+            return result.getApplied().getRewriteUsedQuery();
+        }
+        return command.getQuery();
     }
 
     private List<String> docIdsOf(List<RetrievalNodeView> nodes) {
@@ -626,28 +602,5 @@ public class KnowledgeApiService {
      */
     private record ResolvedTarget(AppVersion version, AppConfigSnapshot snapshot, TargetStage stage,
                                   boolean snapshotBound) {
-    }
-
-    /**
-     * One call after the image stage, carrying the question every later stage works on.
-     *
-     * <p>Exists so the audit row digests the question that was actually searched with rather than the raw
-     * one: an operator reading the trail has to see the text the ranking came from, and an image only call
-     * would otherwise store an empty digest.
-     *
-     * @param command      call parameters with the image text folded into the query
-     * @param imageDegraded degradation markers the image stage produced, empty on success
-     */
-    private record EnrichedCall(KnowledgeCallCommand command, List<String> imageDegraded) {
-
-        /**
-         * The call before the image stage ran, used while auditing a rejection that happened earlier.
-         *
-         * @param command call parameters as the caller expressed them
-         * @return untouched call
-         */
-        static EnrichedCall of(KnowledgeCallCommand command) {
-            return new EnrichedCall(command, List.of());
-        }
     }
 }

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/ImageQueryService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/ImageQueryService.java
@@ -4,6 +4,7 @@ import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.enums.DegradedReason;
+import io.kbrag.domain.model.ImageInput;
 import io.kbrag.domain.port.VisionProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -109,6 +110,27 @@ public class ImageQueryService {
         log.info("image query enriched, images={}, queryLength={}, enrichedLength={}",
                 decoded.size(), text.length(), enriched.length());
         return new ImageQueryOutcome(enriched.toString(), List.of());
+    }
+
+    /**
+     * Validates the attached images and decodes them into labelled inputs the multimodal route can embed,
+     * the M14 contract section 7.
+     *
+     * <p>Reuses the exact count and size gate of {@link #enrich(String, List)}, so the image constraints
+     * live in one place whether the pictures are transcribed into the query or embedded into the multimodal
+     * space. The media type is derived from the bytes for the same reason the vision fallback derives it -
+     * the wire format is bare base64 and a mislabelled data URL is rejected by some gateways.
+     *
+     * @param images base64 encoded images as the caller sent them, must not be empty
+     * @return decoded inputs in the order they arrived
+     */
+    public List<ImageInput> decodeForEmbedding(List<String> images) {
+        List<byte[]> decoded = decodeAll(images);
+        List<ImageInput> inputs = new ArrayList<>(decoded.size());
+        for (byte[] content : decoded) {
+            inputs.add(new ImageInput(content, mediaTypeOf(content)));
+        }
+        return inputs;
     }
 
     /**

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/MultimodalRouteOutcome.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/MultimodalRouteOutcome.java
@@ -1,0 +1,64 @@
+package io.kbrag.app.retrieval;
+
+import io.kbrag.domain.model.ScoredChunk;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * What the multimodal route contributed to one knowledge base of one call, the M14 contract section 6.3.
+ *
+ * <p>Modelled on {@code GraphRouteOutcome}: the candidates join the in base fusion exactly like the other
+ * routes and are deduplicated on chunk id, so nothing downstream knows a route embedded a query into the
+ * multimodal space rather than the text one. Unlike the graph route it carries no evidence - a multimodal
+ * hit is the same chunk the text index holds, so the debug page has nothing extra to show for it.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@ToString
+public final class MultimodalRouteOutcome {
+
+    private static final MultimodalRouteOutcome SKIPPED = new MultimodalRouteOutcome(List.of(), null);
+
+    /** Multimodal route candidates, ordered by descending relevance. */
+    private final List<ScoredChunk> candidates;
+
+    /** Degradation marker, {@code null} when the route ran or was never asked to. */
+    private final String degradedReason;
+
+    private MultimodalRouteOutcome(List<ScoredChunk> candidates, String degradedReason) {
+        this.candidates = candidates;
+        this.degradedReason = degradedReason;
+    }
+
+    /**
+     * Outcome of a route that was not asked to run, or ran and found nothing.
+     *
+     * @return empty outcome carrying no marker
+     */
+    public static MultimodalRouteOutcome skipped() {
+        return SKIPPED;
+    }
+
+    /**
+     * Outcome of a route that ran.
+     *
+     * @param candidates candidates ordered by descending relevance
+     * @return populated outcome
+     */
+    public static MultimodalRouteOutcome of(List<ScoredChunk> candidates) {
+        return new MultimodalRouteOutcome(candidates, null);
+    }
+
+    /**
+     * Outcome of a route the knowledge base asked for but the call could not run or refused to run.
+     *
+     * @param degradedReason marker reported to the caller
+     * @return empty outcome carrying the marker
+     */
+    public static MultimodalRouteOutcome degraded(String degradedReason) {
+        return new MultimodalRouteOutcome(List.of(), degradedReason);
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalCandidate.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalCandidate.java
@@ -1,6 +1,7 @@
 package io.kbrag.app.retrieval;
 
 import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.enums.RetrievalSource;
 import io.kbrag.domain.model.FusedChunk;
 import io.kbrag.domain.model.GraphChunkRelevance;
 import lombok.Getter;
@@ -30,6 +31,23 @@ public final class RetrievalCandidate {
     private Double rerankScore;
 
     /**
+     * Raw BM25 route score of this candidate, {@code null} when only the vector route recalled it, the
+     * M14 contract section 5.
+     *
+     * <p>Captured at construction from the fusion evidence so the hybrid rerank mode can blend it in
+     * without re-reading the route map: a pure vector hit has no keyword score and counts as zero in
+     * the blend rather than being dropped.
+     */
+    private final Double bm25Score;
+
+    /**
+     * Blended ordering score of the {@code hybrid} rerank mode, {@code null} unless that mode ran, the
+     * M14 contract section 5. Kept apart from {@link #rerankScore} because the threshold must still act
+     * on the pure semantic score while the ordering follows this blend.
+     */
+    private Double hybridScore;
+
+    /**
      * How the graph route reached this chunk, {@code null} when it did not, requirement section 4.9.
      *
      * <p>Kept next to the fusion evidence rather than folded into it: the fusion score is one number per
@@ -41,6 +59,7 @@ public final class RetrievalCandidate {
     public RetrievalCandidate(FusedChunk fused, Chunk chunk) {
         this.fused = fused;
         this.chunk = chunk;
+        this.bm25Score = fused == null ? null : fused.routeScore(RetrievalSource.BM25);
     }
 
     /**
@@ -62,6 +81,15 @@ public final class RetrievalCandidate {
     }
 
     /**
+     * Attaches the blended ordering score computed by the {@code hybrid} rerank mode.
+     *
+     * @param score blend of the semantic relevance and the normalised BM25 score
+     */
+    public void applyHybridScore(double score) {
+        this.hybridScore = score;
+    }
+
+    /**
      * Attaches the graph route evidence of this chunk.
      *
      * @param evidence relevance detail, {@code null} when the graph route did not reach this chunk
@@ -71,13 +99,16 @@ public final class RetrievalCandidate {
     }
 
     /**
-     * Score the final ordering is based on: the cross encoder score once it exists, the fusion score
-     * otherwise. Defining it here is what makes a rerank degradation a pure fallback rather than a
-     * different code path.
+     * Score the final ordering is based on: the hybrid blend once the hybrid mode produced it, the cross
+     * encoder score once it exists, the fusion score otherwise. Defining it here is what makes a rerank
+     * degradation and the hybrid blend pure ordering choices rather than different code paths.
      *
      * @return ordering score
      */
     public double orderingScore() {
+        if (hybridScore != null) {
+            return hybridScore;
+        }
         return rerankScore != null ? rerankScore : fused.getFusedScore();
     }
 

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalCommand.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalCommand.java
@@ -27,6 +27,15 @@ public class RetrievalCommand {
     /** User query, mandatory. */
     private final String query;
 
+    /**
+     * Images attached to the query, base64 encoded, the M14 contract section 7.
+     *
+     * <p>Left for the retrieval service to dispatch: when the searched base can embed them they steer the
+     * multimodal route directly (image to image), otherwise they are transcribed into the query by the
+     * vision fallback. Either way the count and size are bounded by the one image validation gate.
+     */
+    private final List<String> images;
+
     /** Candidates recalled per route. */
     private final Integer recallTopK;
 
@@ -47,6 +56,12 @@ public class RetrievalCommand {
 
     /** Rerank switch. */
     private final Boolean rerankEnabled;
+
+    /** Rerank ordering mode literal, {@code null} keeps the resolved default, the M14 contract section 5. */
+    private final String rerankMode;
+
+    /** Semantic weight of the {@code hybrid} rerank mode, {@code null} keeps the resolved default. */
+    private final Double rerankWSemantic;
 
     /** Query rewrite switch. */
     private final Boolean rewriteEnabled;

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalService.java
@@ -6,7 +6,9 @@ import io.kbrag.app.alert.RetrievalDegradeMonitor;
 import io.kbrag.app.graph.GraphRetrievalService;
 import io.kbrag.app.graph.GraphRouteOutcome;
 import io.kbrag.app.index.EngineChunkCleaner;
+import io.kbrag.app.index.MultimodalIndexManager;
 import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.common.util.JsonUtil;
 import io.kbrag.domain.config.KbProperties;
@@ -15,11 +17,13 @@ import io.kbrag.domain.entity.Chunk;
 import io.kbrag.domain.entity.KnowledgeBase;
 import io.kbrag.domain.enums.DegradedReason;
 import io.kbrag.domain.enums.FusionMode;
+import io.kbrag.domain.enums.RerankMode;
 import io.kbrag.domain.enums.RetrievalSource;
 import io.kbrag.domain.mapper.ChunkMapper;
 import io.kbrag.domain.model.FulltextQuery;
 import io.kbrag.domain.model.FusedChunk;
 import io.kbrag.domain.model.GraphChunkRelevance;
+import io.kbrag.domain.model.ImageInput;
 import io.kbrag.domain.model.KbIndexConfig;
 import io.kbrag.domain.model.KbRef;
 import io.kbrag.domain.model.KbRetrievalConfig;
@@ -28,6 +32,7 @@ import io.kbrag.domain.model.ScoredChunk;
 import io.kbrag.domain.model.VectorQuery;
 import io.kbrag.domain.port.EmbeddingProvider;
 import io.kbrag.domain.port.FulltextStore;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
 import io.kbrag.domain.port.ObjectStorage;
 import io.kbrag.domain.port.VectorStore;
 import io.kbrag.domain.service.CrossKbRrfFusion;
@@ -37,6 +42,7 @@ import io.kbrag.domain.service.ParentTextRedactor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -150,6 +156,9 @@ public class RetrievalService {
 
     private static final int ENABLED = 1;
 
+    /** Below this spread the BM25 route is treated as constant scored in the hybrid blend. */
+    private static final double SCORE_SPREAD_EPSILON = 1e-9d;
+
     /** Index of the first declared knowledge base, whose settings complete an unset parameter. */
     private static final int PRIMARY = 0;
 
@@ -163,6 +172,9 @@ public class RetrievalService {
     private final CrossKbRrfFusion crossKbRrfFusion;
     private final KbQuotaAllocator kbQuotaAllocator;
     private final GraphRetrievalService graphRetrievalService;
+    private final MultimodalIndexManager multimodalIndexManager;
+    private final MultimodalEmbeddingProvider multimodalEmbeddingProvider;
+    private final ImageQueryService imageQueryService;
     private final RoutingService routingService;
     private final RewriteService rewriteService;
     private final RerankService rerankService;
@@ -214,7 +226,10 @@ public class RetrievalService {
                 properties.getRetrieval());
 
         List<String> degraded = new ArrayList<>();
-        RewriteOutcome rewrite = rewriteService.rewrite(command.getQuery(), command.getMessages(),
+        // F6 image dispatch, the single point that decides between the multimodal image route and the vision
+        // text fallback before any pipeline stage reads the question, the M14 contract section 7.
+        ImageDispatch imageDispatch = dispatchImages(command, targets, degraded);
+        RewriteOutcome rewrite = rewriteService.rewrite(imageDispatch.query(), command.getMessages(),
                 shouldRun(settings.isRewriteEnabled(), rewriteService.isAvailable(),
                         command.getRewriteEnabled(), primary.rewriteEnabled()));
         addMarker(degraded, rewrite.getDegradedReason());
@@ -263,11 +278,11 @@ public class RetrievalService {
             if (context == null) {
                 continue;
             }
-            KbRecall recall = recallWithinKb(target, effectiveQuery, queryVector, context,
-                    settings, command, bm25RouteRequested);
+            KbRecall recall = recallWithinKb(target, effectiveQuery, queryVector,
+                    imageDispatch.imageQueryVectors(), context, settings, command, bm25RouteRequested);
             chunkById.putAll(recall.chunkById());
             graphEvidence.putAll(recall.graphEvidence());
-            addMarker(degraded, recall.degradedReason());
+            recall.degradedReasons().forEach(reason -> addMarker(degraded, reason));
             if (!recall.ranked().isEmpty()) {
                 rankedByKb.put(target.kbId(), recall.ranked());
             }
@@ -289,6 +304,7 @@ public class RetrievalService {
         List<RetrievalCandidate> candidates = selectCandidates(merged, chunkById, parentChildEnabled,
                 settings, graphEvidence);
         applyRerank(effectiveQuery, candidates, settings, command, primary.retrievalConfig(), degraded);
+        applyHybridOrdering(candidates, settings);
 
         candidates.sort(Comparator.comparingDouble(RetrievalCandidate::orderingScore).reversed()
                 .thenComparing(RetrievalCandidate::chunkId));
@@ -356,6 +372,7 @@ public class RetrievalService {
      * @return in base ranking of the live candidates plus their fact source rows
      */
     private KbRecall recallWithinKb(KbTarget target, String query, float[] queryVector,
+                                    List<float[]> imageQueryVectors,
                                     RetrievalIndexContextResolver.IndexContext context,
                                     RetrievalSettings settings, RetrievalCommand command,
                                     boolean bm25RouteRequested) {
@@ -372,11 +389,17 @@ public class RetrievalService {
         if (!graph.getCandidates().isEmpty()) {
             routeResults.put(RetrievalSource.GRAPH, graph.getCandidates());
         }
+        MultimodalRouteOutcome multimodal = recallMultimodal(target, query, imageQueryVectors, filter,
+                context, settings);
+        if (!multimodal.getCandidates().isEmpty()) {
+            routeResults.put(RetrievalSource.MM, multimodal.getCandidates());
+        }
         List<FusedChunk> fused = fusionRouter.fuse(routeResults, settings.getFusion());
         Map<String, Chunk> chunkById = loadChunks(fused);
         List<FusedChunk> live = dropDisabled(
                 dropOrphans(kbId, fused, chunkById, !context.snapshotBound()), chunkById);
-        return new KbRecall(live, chunkById, graph.getEvidenceByChunk(), graph.getDegradedReason());
+        return new KbRecall(live, chunkById, graph.getEvidenceByChunk(),
+                degradedReasons(graph.getDegradedReason(), multimodal.getDegradedReason()));
     }
 
     /**
@@ -405,6 +428,218 @@ public class RetrievalService {
             return GraphRouteOutcome.skipped();
         }
         return graphRetrievalService.recall(query, filter, recallTopK);
+    }
+
+    /**
+     * Runs the multimodal route, the M14 contract section 6.3.
+     *
+     * <p><b>The route is switched off on the snapshot path, and that is not a degradation.</b> Exactly like
+     * the graph route, a released version answers out of a frozen snapshot the multimodal index holds no
+     * frozen copy of, so there is nothing snapshot shaped for it to search and running it would break the
+     * version isolation of requirement section 4.7.
+     *
+     * <p><b>Weighted fusion refuses the route and says so.</b> Weighted fusion blends normalised route
+     * scores, and a multimodal similarity is on a scale the text routes never see; there is no meaningful
+     * weight for it, so the route is skipped and the caller is told through {@code mm_route_skipped},
+     * mirroring the way the graph route is refused under weighted fusion.
+     *
+     * <p><b>A configured but unreachable provider degrades, it never fails the search.</b> Embedding the
+     * query into the multimodal space is the one model call this route makes; when it fails the marker
+     * {@code mm_route_unavailable} is reported and the remaining routes answer.
+     *
+     * @param target            knowledge base being searched
+     * @param query             query the other routes ran with
+     * @param imageQueryVectors images the caller attached, already embedded, empty for a text only call
+     * @param filter            the very predicate the engine side routes were filtered by
+     * @param context           indices and version visibility set this base is searched with
+     * @param settings          effective retrieval parameters, read for the fusion mode and the recall size
+     * @return multimodal route outcome, empty when the route was not asked to run
+     */
+    private MultimodalRouteOutcome recallMultimodal(KbTarget target, String query,
+                                                    List<float[]> imageQueryVectors, RetrievalFilter filter,
+                                                    RetrievalIndexContextResolver.IndexContext context,
+                                                    RetrievalSettings settings) {
+        if (context.snapshotBound()) {
+            return MultimodalRouteOutcome.skipped();
+        }
+        String alias = multimodalIndexManager.multimodalAlias(target.kbId(), target.indexConfig());
+        if (alias == null) {
+            return MultimodalRouteOutcome.skipped();
+        }
+        if (settings.getFusion().getMode() == FusionMode.WEIGHTED) {
+            log.info("multimodal route skipped under weighted fusion, kbId={}", target.kbId());
+            return MultimodalRouteOutcome.degraded(DegradedReason.MM_ROUTE_SKIPPED.code());
+        }
+        List<float[]> queryVectors;
+        if (CollectionUtils.isNotEmpty(imageQueryVectors)) {
+            // F6: the caller attached images and this base can search them, so the route embeds the pictures
+            // rather than the text - image to image and image to rendered page, the M14 contract section 7.
+            queryVectors = imageQueryVectors;
+        } else {
+            try {
+                queryVectors = List.of(multimodalEmbeddingProvider.embedTexts(List.of(query)).get(0));
+            } catch (Exception e) {
+                log.error("multimodal query embedding failed, errorCode={}, kbId={}",
+                        ErrorCode.UPSTREAM_MODEL_ERROR, target.kbId(), e);
+                return MultimodalRouteOutcome.degraded(DegradedReason.MM_ROUTE_UNAVAILABLE.code());
+            }
+        }
+        List<ScoredChunk> candidates = searchMultimodal(alias, queryVectors, filter, settings.getRecallTopK());
+        if (candidates.isEmpty()) {
+            return MultimodalRouteOutcome.skipped();
+        }
+        log.info("multimodal route finished, kbId={}, queries={}, candidates={}",
+                target.kbId(), queryVectors.size(), candidates.size());
+        return MultimodalRouteOutcome.of(candidates);
+    }
+
+    /**
+     * Searches the multimodal alias with every query vector and folds the hits into one ranking.
+     *
+     * <p>A text query issues one vector; an image query issues one per attached image. Overlapping hits are
+     * collapsed on the chunk id keeping the strongest similarity, so a chunk matched by two images is ranked
+     * once on its best score rather than counted twice, and the reciprocal rank fusion downstream sees a
+     * single ordered list exactly like the other routes.
+     *
+     * @param alias        multimodal alias to search
+     * @param queryVectors one or more query vectors
+     * @param filter       the very predicate the engine side routes were filtered by
+     * @param recallTopK   candidates the route contributes at most
+     * @return merged candidates ordered by descending similarity, tagged as the multimodal route
+     */
+    private List<ScoredChunk> searchMultimodal(String alias, List<float[]> queryVectors,
+                                               RetrievalFilter filter, int recallTopK) {
+        Map<String, Double> scoreByChunk = new LinkedHashMap<>();
+        for (float[] queryVector : queryVectors) {
+            List<ScoredChunk> hits = vectorStore.search(alias, VectorQuery.builder()
+                    .queryVector(queryVector).topK(recallTopK).filter(filter).build());
+            if (CollectionUtils.isEmpty(hits)) {
+                continue;
+            }
+            for (ScoredChunk hit : hits) {
+                scoreByChunk.merge(hit.getChunkId(), hit.getScore(), Math::max);
+            }
+        }
+        if (scoreByChunk.isEmpty()) {
+            return List.of();
+        }
+        List<ScoredChunk> candidates = new ArrayList<>(scoreByChunk.size());
+        for (Map.Entry<String, Double> entry : scoreByChunk.entrySet()) {
+            candidates.add(new ScoredChunk(entry.getKey(), entry.getValue(), RetrievalSource.MM));
+        }
+        candidates.sort(Comparator.comparingDouble(ScoredChunk::getScore).reversed()
+                .thenComparing(ScoredChunk::getChunkId));
+        return candidates.size() > recallTopK
+                ? new ArrayList<>(candidates.subList(0, recallTopK)) : candidates;
+    }
+
+    /**
+     * Decides what the attached images do, the single dispatch point of the M14 contract section 7.
+     *
+     * <p>Two outcomes, one of them per call. When the searched corpus can embed images - a multimodal
+     * provider is configured, at least one selected base has the multimodal switch on, the call is not a
+     * frozen release snapshot and a written query is present - the pictures are embedded and steer the
+     * multimodal route directly (image to image, image to rendered page). Otherwise they fall back to the
+     * vision transcription that folds their description into the query, exactly the path the open API used
+     * before this milestone, so a deployment without the multimodal capability keeps its image search.
+     *
+     * <p><b>A written query stays mandatory on the image route.</b> Pure image retrieval is out of scope for
+     * this milestone, so an image only call is never routed to the multimodal space; it takes the vision
+     * fallback, whose own gate rejects a call that has nothing at all to search for.
+     *
+     * <p><b>A release snapshot never takes the image route.</b> The multimodal index holds no frozen copy, so
+     * the per base route is off on the snapshot path anyway; sending images there would embed them for a
+     * route that cannot run, so a snapshot call transcribes them into its query instead.
+     *
+     * @param command call parameters, read for the images and the query
+     * @param targets knowledge bases the call will search
+     * @param degraded running degradation markers, appended in place
+     * @return the query the pipeline runs with and the image vectors the multimodal route embeds
+     */
+    private ImageDispatch dispatchImages(RetrievalCommand command, List<KbTarget> targets,
+                                         List<String> degraded) {
+        List<String> images = command.getImages();
+        if (multimodalUsableForImages(command, images, targets)) {
+            return new ImageDispatch(command.getQuery(), embedQueryImages(images, degraded));
+        }
+        ImageQueryService.ImageQueryOutcome outcome = imageQueryService.enrich(command.getQuery(), images);
+        outcome.degraded().forEach(reason -> addMarker(degraded, reason));
+        return new ImageDispatch(outcome.query(), List.of());
+    }
+
+    /**
+     * Tells whether the attached images can steer the multimodal route rather than the vision fallback.
+     *
+     * @param command call parameters, read for the query and the snapshot binding
+     * @param images  attached images
+     * @param targets knowledge bases the call will search
+     * @return {@code true} when the images are to be embedded into the multimodal space
+     */
+    private boolean multimodalUsableForImages(RetrievalCommand command, List<String> images,
+                                              List<KbTarget> targets) {
+        if (CollectionUtils.isEmpty(images) || !multimodalEmbeddingProvider.isConfigured()) {
+            return false;
+        }
+        if (command.getQuery() == null || command.getQuery().isBlank()) {
+            return false;
+        }
+        if (MapUtils.isNotEmpty(command.getIndexOverride())) {
+            return false;
+        }
+        return targets.stream().anyMatch(target ->
+                multimodalIndexManager.multimodalAlias(target.kbId(), target.indexConfig()) != null);
+    }
+
+    /**
+     * Embeds the attached images into the multimodal space, degrading rather than failing when the provider
+     * call itself breaks.
+     *
+     * <p>The count and size validation runs first and outside the try: an over sized or over counted image
+     * set is a caller error the pipeline rejects, not a degradation. A provider timeout or error, by
+     * contrast, leaves the written query and the other routes to answer, so it is reported through
+     * {@code mm_route_unavailable} and returns no vectors.
+     *
+     * @param images   attached images, already known to be present
+     * @param degraded running degradation markers, appended in place
+     * @return one vector per image, or empty when the provider call failed
+     */
+    private List<float[]> embedQueryImages(List<String> images, List<String> degraded) {
+        List<ImageInput> inputs = imageQueryService.decodeForEmbedding(images);
+        try {
+            return multimodalEmbeddingProvider.embedImages(inputs);
+        } catch (Exception e) {
+            log.error("query image embedding failed, errorCode={}, images={}",
+                    ErrorCode.UPSTREAM_MODEL_ERROR, inputs.size(), e);
+            addMarker(degraded, DegradedReason.MM_ROUTE_UNAVAILABLE.code());
+            return List.of();
+        }
+    }
+
+    /**
+     * What the image dispatch decided: the query every pipeline stage reads and the image vectors, if any,
+     * the multimodal route embeds instead of the text.
+     *
+     * @param query             query the pipeline runs with, enriched by the vision fallback when it ran
+     * @param imageQueryVectors embedded images for the multimodal route, empty on the fallback path
+     */
+    private record ImageDispatch(String query, List<float[]> imageQueryVectors) {
+    }
+
+    /**
+     * Collects the degradation markers of the optional per base routes, dropping the {@code null} of a
+     * route that ran or was never asked to.
+     *
+     * @param reasons per route markers, any of them {@code null}
+     * @return present markers, empty when no route degraded
+     */
+    private List<String> degradedReasons(String... reasons) {
+        List<String> present = new ArrayList<>(reasons.length);
+        for (String reason : reasons) {
+            if (reason != null) {
+                present.add(reason);
+            }
+        }
+        return present;
     }
 
     /**
@@ -527,13 +762,14 @@ public class RetrievalService {
     /**
      * What one knowledge base contributed to a call.
      *
-     * @param ranked         in base ranking of the candidates a fact source row still backs
-     * @param chunkById      fact source rows of this base's candidates
-     * @param graphEvidence  graph route detail per chunk id, empty when the route did not run
-     * @param degradedReason marker of a route this base asked for and could not run, {@code null} otherwise
+     * @param ranked          in base ranking of the candidates a fact source row still backs
+     * @param chunkById       fact source rows of this base's candidates
+     * @param graphEvidence   graph route detail per chunk id, empty when the route did not run
+     * @param degradedReasons markers of the optional routes this base asked for and could not run, empty
+     *                        when every route it wanted ran
      */
     private record KbRecall(List<FusedChunk> ranked, Map<String, Chunk> chunkById,
-                            Map<String, GraphChunkRelevance> graphEvidence, String degradedReason) {
+                            Map<String, GraphChunkRelevance> graphEvidence, List<String> degradedReasons) {
     }
 
     /**
@@ -651,6 +887,47 @@ public class RetrievalService {
         for (int i = 0; i < candidates.size(); i++) {
             candidates.get(i).applyRerankScore(outcome.getScores().get(i));
         }
+    }
+
+    /**
+     * Blends the semantic relevance with the normalised BM25 score to order a {@code hybrid} rerank, the
+     * M14 contract section 5.
+     *
+     * <p>Runs only when the mode is hybrid <em>and</em> the semantic rerank actually produced scores: a
+     * degraded or switched off rerank leaves nothing to blend, so the fusion order stands exactly as it
+     * does for the semantic mode. The BM25 score is min-max normalised inside this candidate set, which
+     * is why it can only feed the ordering and never the threshold - a value normalised per query is not
+     * comparable across queries. A candidate the vector route alone recalled has no BM25 score and
+     * counts as zero rather than being dropped.
+     *
+     * @param candidates rerank ordered candidates, mutated in place with the blended score
+     * @param settings   effective retrieval parameters carrying the mode and the semantic weight
+     */
+    private void applyHybridOrdering(List<RetrievalCandidate> candidates, RetrievalSettings settings) {
+        if (settings.getRerankMode() != RerankMode.HYBRID || candidates.isEmpty()
+                || candidates.get(0).getRerankScore() == null) {
+            return;
+        }
+        double min = Double.MAX_VALUE;
+        double max = -Double.MAX_VALUE;
+        for (RetrievalCandidate candidate : candidates) {
+            double bm25 = bm25OrZero(candidate);
+            min = Math.min(min, bm25);
+            max = Math.max(max, bm25);
+        }
+        double spread = max - min;
+        double wSemantic = settings.getRerankWSemantic();
+        for (RetrievalCandidate candidate : candidates) {
+            double normalized = spread <= SCORE_SPREAD_EPSILON
+                    ? 0.0d : (bm25OrZero(candidate) - min) / spread;
+            candidate.applyHybridScore(wSemantic * candidate.getRerankScore()
+                    + (1.0d - wSemantic) * normalized);
+        }
+        log.info("hybrid rerank ordering applied, wSemantic={}, candidates={}", wSemantic, candidates.size());
+    }
+
+    private double bm25OrZero(RetrievalCandidate candidate) {
+        return candidate.getBm25Score() == null ? 0.0d : candidate.getBm25Score();
     }
 
     /**

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalSettings.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalSettings.java
@@ -2,6 +2,7 @@ package io.kbrag.app.retrieval;
 
 import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.enums.FusionMode;
+import io.kbrag.domain.enums.RerankMode;
 import io.kbrag.domain.model.FusionParams;
 import io.kbrag.domain.model.KbRetrievalConfig;
 import lombok.Getter;
@@ -36,16 +37,25 @@ public final class RetrievalSettings {
     /** {@code true} when the rerank stage should run. */
     private final boolean rerankEnabled;
 
+    /** Resolved rerank ordering mode, the M14 contract section 5. */
+    private final RerankMode rerankMode;
+
+    /** Resolved semantic weight of the {@code hybrid} rerank mode, within {@code [0,1]}. */
+    private final double rerankWSemantic;
+
     /** {@code true} when the query rewrite stage should run. */
     private final boolean rewriteEnabled;
 
     private RetrievalSettings(int recallTopK, int topN, Double scoreThreshold, FusionParams fusion,
-                              boolean rerankEnabled, boolean rewriteEnabled) {
+                              boolean rerankEnabled, RerankMode rerankMode, double rerankWSemantic,
+                              boolean rewriteEnabled) {
         this.recallTopK = recallTopK;
         this.topN = topN;
         this.scoreThreshold = scoreThreshold;
         this.fusion = fusion;
         this.rerankEnabled = rerankEnabled;
+        this.rerankMode = rerankMode;
+        this.rerankWSemantic = rerankWSemantic;
         this.rewriteEnabled = rewriteEnabled;
     }
 
@@ -75,11 +85,15 @@ public final class RetrievalSettings {
 
         boolean rerank = firstNonNull(command.getRerankEnabled(),
                 firstNonNull(kb.getRerankEnabled(), retrievalDefaults.isRerankEnabled()));
+        RerankMode rerankMode = RerankMode.from(firstNonNull(command.getRerankMode(),
+                firstNonNull(kb.getRerankMode(), retrievalDefaults.getRerankMode())));
+        double rerankWSemantic = clampWeight(firstNonNull(command.getRerankWSemantic(),
+                firstNonNull(kb.getRerankWSemantic(), retrievalDefaults.getRerankWSemantic())));
         boolean rewrite = firstNonNull(command.getRewriteEnabled(),
                 firstNonNull(kb.getRewriteEnabled(), retrievalDefaults.isRewriteEnabled()));
 
         return new RetrievalSettings(recallTopK, topN, threshold,
-                FusionParams.of(mode, rrfK, wVec), rerank, rewrite);
+                FusionParams.of(mode, rrfK, wVec), rerank, rerankMode, rerankWSemantic, rewrite);
     }
 
     /**
@@ -95,6 +109,17 @@ public final class RetrievalSettings {
             return fallback;
         }
         return Math.min(requested, maximum);
+    }
+
+    /**
+     * Confines a semantic weight to {@code [0,1]} so a knowledge base column edited out of range cannot
+     * push the hybrid blend outside the unit interval the request annotations already guarantee.
+     *
+     * @param weight resolved weight from any configuration layer
+     * @return weight within {@code [0,1]}
+     */
+    private static double clampWeight(double weight) {
+        return Math.max(0.0d, Math.min(1.0d, weight));
     }
 
     private static <T> T firstNonNull(T preferred, T fallback) {

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/system/ModelStatusService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/system/ModelStatusService.java
@@ -4,6 +4,7 @@ import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.model.ModelStatus;
 import io.kbrag.domain.port.ChatProvider;
 import io.kbrag.domain.port.EmbeddingProvider;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
 import io.kbrag.domain.port.RerankProvider;
 import io.kbrag.domain.port.VisionProvider;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class ModelStatusService {
     private final RerankProvider rerankProvider;
     private final ChatProvider chatProvider;
     private final VisionProvider visionProvider;
+    private final MultimodalEmbeddingProvider multimodalEmbeddingProvider;
     private final KbProperties properties;
 
     /**
@@ -50,6 +52,9 @@ public class ModelStatusService {
                 .visionConfigured(visionProvider.isConfigured())
                 .visionProvider(visionProvider.providerName())
                 .visionModel(visionProvider.model())
+                .multimodalConfigured(multimodalEmbeddingProvider.isConfigured())
+                .multimodalProvider(multimodalEmbeddingProvider.providerName())
+                .multimodalModel(multimodalEmbeddingProvider.model())
                 .build();
     }
 }

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/document/UploadValidatorTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/document/UploadValidatorTest.java
@@ -44,6 +44,12 @@ class UploadValidatorTest {
     }
 
     @Test
+    void shouldAcceptSqlAsTextFormat() {
+        assertEquals("sql",
+                validator.validate("schema.sql", "SELECT 1;".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
     void shouldRejectRenamedFile() {
         BizException e = assertThrows(BizException.class,
                 () -> validator.validate("payload.pdf", ZIP_HEADER));

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/openapi/KnowledgeApiServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/openapi/KnowledgeApiServiceTest.java
@@ -5,7 +5,6 @@ import io.kbrag.app.appcenter.AppVersionService;
 import io.kbrag.app.insight.SearchInsightService;
 import io.kbrag.app.metrics.KbMetrics;
 import io.kbrag.app.retrieval.AppliedInfo;
-import io.kbrag.app.retrieval.ImageQueryService;
 import io.kbrag.app.retrieval.RetrievalCommand;
 import io.kbrag.app.retrieval.RetrievalIndexOverride;
 import io.kbrag.app.retrieval.RetrievalNodeView;
@@ -25,10 +24,8 @@ import io.kbrag.domain.model.AppPromptConfig;
 import io.kbrag.domain.model.ChatMessage;
 import io.kbrag.domain.model.KbRef;
 import io.kbrag.domain.model.KbRetrievalConfig;
-import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.port.ChatProvider;
 import io.kbrag.domain.port.ChatProviderFactory;
-import io.kbrag.domain.port.VisionProvider;
 import io.kbrag.domain.service.ChatPromptAssembler;
 import io.kbrag.domain.service.ContentBudgetTrimmer;
 import io.kbrag.domain.service.RequestOverridePolicy;
@@ -78,7 +75,6 @@ class KnowledgeApiServiceTest {
     private ChatProviderFactory chatProviderFactory;
     private ChatProvider chatProvider;
     private ApiAuditService apiAuditService;
-    private VisionProvider visionProvider;
     private SimpleMeterRegistry meterRegistry;
     private KnowledgeApiService service;
 
@@ -92,12 +88,10 @@ class KnowledgeApiServiceTest {
         apiAuditService = mock(ApiAuditService.class);
         when(appService.require(APP_ID)).thenReturn(new App());
         when(chatProviderFactory.forModel(any())).thenReturn(chatProvider);
-        visionProvider = mock(VisionProvider.class);
         meterRegistry = new SimpleMeterRegistry();
         service = new KnowledgeApiService(appService, appVersionService, retrievalService, chatProviderFactory,
                 new ChatPromptAssembler(), new ContentBudgetTrimmer(), new RequestOverridePolicy(),
-                apiAuditService, mock(SearchInsightService.class),
-                new ImageQueryService(visionProvider, new KbProperties()), new KbMetrics(meterRegistry));
+                apiAuditService, mock(SearchInsightService.class), new KbMetrics(meterRegistry));
     }
 
     @Test
@@ -394,67 +388,61 @@ class KnowledgeApiServiceTest {
     }
 
     @Test
-    void shouldFoldTheImageTextIntoTheQueryBeforeTheRetrievalPipelineRuns() {
+    void shouldPassTheAttachedImagesUntouchedIntoTheRetrievalCommand() {
         stubVersion(AppVersionStatus.RELEASED);
         stubSearch(node("doc_1", "第一段"));
-        when(visionProvider.isConfigured()).thenReturn(true);
-        when(visionProvider.describeImage(any(), anyString())).thenReturn("一个金属法兰盘的照片");
 
-        service.search(principal(List.of()), commandWithImages(List.of(image())));
+        String image = image();
+        service.search(principal(List.of()), commandWithImages(List.of(image)));
 
-        // The rewrite stage lives inside RetrievalService, so a query that already carries the image text
-        // when the command is issued is proof that the concatenation happened before the rewrite.
-        assertEquals("保险条款怎么算\n[图片内容] 一个金属法兰盘的照片", capturedRetrieval().getQuery());
+        // The open API no longer folds images itself: the single dispatch point lives in RetrievalService, so
+        // the raw images and the untouched query are what the pipeline receives.
+        RetrievalCommand issued = capturedRetrieval();
+        assertEquals(List.of(image), issued.getImages());
+        assertEquals("保险条款怎么算", issued.getQuery());
     }
 
     @Test
-    void shouldAuditTheConcatenatedQueryRatherThanTheWrittenOne() {
+    void shouldDigestTheEffectiveQueryTheRankingCameFromIntoTheAuditRow() {
         stubVersion(AppVersionStatus.RELEASED);
         stubSearch(node("doc_1", "第一段"));
-        when(visionProvider.isConfigured()).thenReturn(true);
-        when(visionProvider.describeImage(any(), anyString())).thenReturn("一个金属法兰盘的照片");
 
         service.search(principal(List.of()), commandWithImages(List.of(image())));
 
-        // An operator reading the trail has to see the text the ranking actually came from.
-        assertEquals("保险条款怎么算\n[图片内容] 一个金属法兰盘的照片", capturedAudit().getQuery());
+        // An operator reading the trail has to see the text the ranking actually came from; the pipeline
+        // reports it back through the applied summary, which after an image dispatch or a rewrite may differ
+        // from the written question.
+        assertEquals("q", capturedAudit().getQuery());
     }
 
     @Test
-    void shouldReportTheImageDegradationNextToThePipelineMarkers() {
+    void shouldPassTheImageRouteDegradationThroughFromThePipeline() {
         stubVersion(AppVersionStatus.RELEASED);
         when(retrievalService.search(eq(List.of(KbRef.of(KB_ID))), any())).thenReturn(new SearchOutcome(
                 new ArrayList<>(List.of(node("doc_1", "第一段"))),
-                List.of(DegradedReason.VECTOR_ROUTE_UNAVAILABLE.code()), applied()));
-        when(visionProvider.isConfigured()).thenReturn(false);
+                List.of(DegradedReason.IMAGE_UNDERSTANDING_UNAVAILABLE.code(),
+                        DegradedReason.VECTOR_ROUTE_UNAVAILABLE.code()), applied()));
 
         KnowledgeCallResult result = service.search(principal(List.of()),
                 commandWithImages(List.of(image())));
 
+        // The image stage now runs inside RetrievalService, so its marker travels in the search outcome and
+        // the open API forwards it flat, without a merge step of its own.
         assertEquals(List.of(DegradedReason.IMAGE_UNDERSTANDING_UNAVAILABLE.code(),
                 DegradedReason.VECTOR_ROUTE_UNAVAILABLE.code()), result.getDegraded());
-        // The written question still ran: an unreadable image never costs the caller its text search.
-        assertEquals("保险条款怎么算", capturedRetrieval().getQuery());
     }
 
     @Test
-    void shouldRejectAnImageOnlyCallWhoseImageCouldNotBeUnderstood() {
+    void shouldAuditARejectionTheRetrievalPipelineRaised() {
         stubVersion(AppVersionStatus.RELEASED);
-        when(visionProvider.isConfigured()).thenReturn(false);
-        KnowledgeCallCommand command = KnowledgeCallCommand.builder()
-                .appId(APP_ID)
-                .query("  ")
-                .messages(List.of())
-                .images(List.of(image()))
-                .presentedOverrideKeys(Set.of())
-                .build();
+        when(retrievalService.search(eq(List.of(KbRef.of(KB_ID))), any()))
+                .thenThrow(new BizException(ErrorCode.INVALID_PARAM, "图片无法识别且未提供文字问题"));
 
-        BizException failure =
-                assertThrows(BizException.class, () -> service.search(principal(List.of()), command));
+        BizException failure = assertThrows(BizException.class,
+                () -> service.search(principal(List.of()), commandWithImages(List.of(image()))));
 
         assertEquals(ErrorCode.INVALID_PARAM, failure.getErrorCode());
-        verify(retrievalService, never()).search(anyList(), any());
-        // The rejection is audited like any other: an agent's failed call is part of the trail.
+        // A rejection the dispatch single point raised is audited like any other failed call.
         assertEquals(ErrorCode.INVALID_PARAM.name(), capturedAudit().getErrorCode());
     }
 

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/retrieval/RetrievalServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/retrieval/RetrievalServiceTest.java
@@ -6,6 +6,7 @@ import io.kbrag.app.graph.GraphRouteOutcome;
 import io.kbrag.app.index.ActiveVersionResolver;
 import io.kbrag.app.index.EngineChunkCleaner;
 import io.kbrag.app.index.IndexAliasManager;
+import io.kbrag.app.index.MultimodalIndexManager;
 import io.kbrag.app.kb.KnowledgeBaseService;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.common.util.JsonUtil;
@@ -31,8 +32,10 @@ import io.kbrag.domain.model.RetrievalFilter;
 import io.kbrag.domain.model.ScoredChunk;
 import io.kbrag.domain.port.EmbeddingProvider;
 import io.kbrag.domain.port.FulltextStore;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
 import io.kbrag.domain.port.ObjectStorage;
 import io.kbrag.domain.port.VectorStore;
+import io.kbrag.domain.port.VisionProvider;
 import io.kbrag.domain.service.CrossKbRrfFusion;
 import io.kbrag.domain.service.FusionRouter;
 import io.kbrag.domain.service.KbQuotaAllocator;
@@ -100,6 +103,9 @@ class RetrievalServiceTest {
     private KbProperties properties;
     private RetrievalIndexContextResolver indexContextResolver;
     private GraphRetrievalService graphRetrievalService;
+    private MultimodalIndexManager multimodalIndexManager;
+    private MultimodalEmbeddingProvider multimodalEmbeddingProvider;
+    private VisionProvider visionProvider;
     private RetrievalService retrievalService;
 
     @BeforeEach
@@ -117,6 +123,9 @@ class RetrievalServiceTest {
         engineChunkCleaner = mock(EngineChunkCleaner.class);
         objectStorage = mock(ObjectStorage.class);
         graphRetrievalService = mock(GraphRetrievalService.class);
+        multimodalIndexManager = mock(MultimodalIndexManager.class);
+        multimodalEmbeddingProvider = mock(MultimodalEmbeddingProvider.class);
+        visionProvider = mock(VisionProvider.class);
         properties = new KbProperties();
 
         when(knowledgeBaseService.require(KB_ID)).thenReturn(knowledgeBase(false));
@@ -145,12 +154,88 @@ class RetrievalServiceTest {
         retrievalService = new RetrievalService(knowledgeBaseService, chunkMapper,
                 fulltextStore, vectorStore, embeddingProvider, indexContextResolver,
                 new FusionRouter(List.of(new RrfFusion(), new WeightedFusion())),
-                new CrossKbRrfFusion(), new KbQuotaAllocator(), graphRetrievalService, routingService,
+                new CrossKbRrfFusion(), new KbQuotaAllocator(), graphRetrievalService,
+                multimodalIndexManager, multimodalEmbeddingProvider,
+                new ImageQueryService(visionProvider, properties), routingService,
                 rewriteService, rerankService, new ScoreThresholdPolicy(), new ParentChildMerger(),
                 new NearDuplicateWindowMerger(),
                 new DisabledChildVisibility(chunkMapper), new ParentTextRedactor(),
                 engineChunkCleaner, objectStorage,
                 new RetrievalDegradeMonitor(properties), properties);
+    }
+
+    @Test
+    void shouldEmbedTheAttachedImagesAndSteerTheMultimodalRouteWhenTheBaseCanSearchThem() {
+        givenDualRoute();
+        String mmAlias = "kb_test_mm";
+        when(multimodalIndexManager.multimodalAlias(eq(KB_ID), any())).thenReturn(mmAlias);
+        when(multimodalEmbeddingProvider.isConfigured()).thenReturn(true);
+        when(multimodalEmbeddingProvider.embedImages(anyList()))
+                .thenReturn(List.of(new float[]{0.5f, 0.6f}));
+        when(vectorStore.search(eq(mmAlias), any()))
+                .thenReturn(List.of(new ScoredChunk("ck_img", 0.88d, RetrievalSource.MM)));
+        when(chunkMapper.selectList(any())).thenReturn(List.of(
+                chunk("ck_1", "first chunk", null), chunk("ck_2", "second chunk", null),
+                chunk("ck_img", "image chunk", null)));
+
+        SearchOutcome outcome = retrievalService.search(KB_ID, command().images(List.of(image())).build());
+
+        // The pictures were embedded and steered the multimodal route directly; the text embedding of the
+        // query was never asked for, so this is image to image rather than a transcription.
+        verify(multimodalEmbeddingProvider).embedImages(anyList());
+        verify(multimodalEmbeddingProvider, never()).embedTexts(anyList());
+        verify(vectorStore).search(eq(mmAlias), any());
+        verify(visionProvider, never()).describeImage(any(), anyString());
+        assertTrue(outcome.getNodes().stream().anyMatch(node -> "ck_img".equals(node.getChunkId())));
+        assertTrue(outcome.getDegraded().isEmpty());
+    }
+
+    @Test
+    void shouldFallBackToTheVisionTranscriptionWhenNoBaseCanSearchTheImages() {
+        givenDualRoute();
+        // No multimodal alias, so the corpus cannot embed images and the vision fallback transcribes them.
+        when(multimodalIndexManager.multimodalAlias(eq(KB_ID), any())).thenReturn(null);
+        when(multimodalEmbeddingProvider.isConfigured()).thenReturn(true);
+        when(visionProvider.isConfigured()).thenReturn(true);
+        when(visionProvider.describeImage(any(), anyString())).thenReturn("一张发票的照片");
+        when(chunkMapper.selectList(any())).thenReturn(List.of(
+                chunk("ck_1", "first chunk", null), chunk("ck_2", "second chunk", null)));
+
+        retrievalService.search(KB_ID, command().images(List.of(image())).build());
+
+        // The image text was folded into the query the pipeline ran with, and the multimodal embedding was
+        // never asked for the pictures.
+        verify(multimodalEmbeddingProvider, never()).embedImages(anyList());
+        ArgumentCaptor<String> rewritten = ArgumentCaptor.forClass(String.class);
+        verify(rewriteService).rewrite(rewritten.capture(), any(), eq(false));
+        assertTrue(rewritten.getValue().contains("一张发票的照片"));
+    }
+
+    @Test
+    void shouldRejectAnImageSetThatBreaksTheCountLimitBeforeEmbedding() {
+        givenDualRoute();
+        when(multimodalIndexManager.multimodalAlias(eq(KB_ID), any())).thenReturn("kb_test_mm");
+        when(multimodalEmbeddingProvider.isConfigured()).thenReturn(true);
+        List<String> tooMany = List.of(image(), image(), image(), image());
+
+        // The image count and size gate is the same single point the vision transcription reuses, so an over
+        // counted set is rejected before any embedding call whichever route it was headed for.
+        assertThrows(BizException.class,
+                () -> retrievalService.search(KB_ID, command().images(tooMany).build()));
+        verify(multimodalEmbeddingProvider, never()).embedImages(anyList());
+    }
+
+    @Test
+    void shouldRejectAnImageOnlyCallThatCarriesNoWrittenQuery() {
+        givenDualRoute();
+        when(multimodalIndexManager.multimodalAlias(eq(KB_ID), any())).thenReturn("kb_test_mm");
+        when(multimodalEmbeddingProvider.isConfigured()).thenReturn(true);
+
+        // A written query stays mandatory: a blank query is never routed to the multimodal space, it takes the
+        // vision fallback whose gate rejects a call with nothing at all to search for.
+        assertThrows(BizException.class,
+                () -> retrievalService.search(KB_ID, command().query("  ").images(List.of(image())).build()));
+        verify(multimodalEmbeddingProvider, never()).embedImages(anyList());
     }
 
     @Test
@@ -984,6 +1069,15 @@ class RetrievalServiceTest {
 
     private RetrievalCommand.RetrievalCommandBuilder command() {
         return RetrievalCommand.builder().query("knowledge").messages(List.of());
+    }
+
+    /**
+     * Base64 of a small arbitrary payload; the bytes never reach a real provider in these tests.
+     *
+     * @return base64 image payload
+     */
+    private String image() {
+        return java.util.Base64.getEncoder().encodeToString(new byte[]{1, 2, 3, 4});
     }
 
     private KnowledgeBase knowledgeBase(boolean parentChild) {

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/system/ModelStatusServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/system/ModelStatusServiceTest.java
@@ -1,0 +1,84 @@
+package io.kbrag.app.system;
+
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.model.ModelStatus;
+import io.kbrag.domain.port.ChatProvider;
+import io.kbrag.domain.port.EmbeddingProvider;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
+import io.kbrag.domain.port.RerankProvider;
+import io.kbrag.domain.port.VisionProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the multimodal capability signal the console needs to grey out the page index switch: the
+ * status reports the multimodal provider independently of the other four, so a deployment that holds
+ * every other key but no multimodal one still sees exactly that one control disabled (M14 contract 6.2).
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class ModelStatusServiceTest {
+
+    private EmbeddingProvider embeddingProvider;
+    private RerankProvider rerankProvider;
+    private ChatProvider chatProvider;
+    private VisionProvider visionProvider;
+    private MultimodalEmbeddingProvider multimodalEmbeddingProvider;
+    private ModelStatusService service;
+
+    @BeforeEach
+    void setUp() {
+        embeddingProvider = mock(EmbeddingProvider.class);
+        rerankProvider = mock(RerankProvider.class);
+        chatProvider = mock(ChatProvider.class);
+        visionProvider = mock(VisionProvider.class);
+        multimodalEmbeddingProvider = mock(MultimodalEmbeddingProvider.class);
+        stubIdleProviders();
+        lenient().when(embeddingProvider.dimension()).thenReturn(0);
+        service = new ModelStatusService(embeddingProvider, rerankProvider, chatProvider,
+                visionProvider, multimodalEmbeddingProvider, new KbProperties());
+    }
+
+    @Test
+    void shouldReportTheMultimodalCapabilityAsUsableWhenTheProviderHoldsACredential() {
+        when(multimodalEmbeddingProvider.isConfigured()).thenReturn(true);
+        when(multimodalEmbeddingProvider.providerName()).thenReturn("dashscope");
+        when(multimodalEmbeddingProvider.model()).thenReturn("multimodal-embedding-v1");
+
+        ModelStatus status = service.current();
+
+        assertTrue(status.isMultimodalConfigured());
+        assertEquals("dashscope", status.getMultimodalProvider());
+        assertEquals("multimodal-embedding-v1", status.getMultimodalModel());
+    }
+
+    @Test
+    void shouldReportTheMultimodalCapabilityAsDisabledWhenTheProviderHasNoCredential() {
+        when(multimodalEmbeddingProvider.isConfigured()).thenReturn(false);
+        lenient().when(multimodalEmbeddingProvider.providerName()).thenReturn("none");
+        lenient().when(multimodalEmbeddingProvider.model()).thenReturn("none");
+
+        ModelStatus status = service.current();
+
+        // A missing multimodal key must disable only this switch, never the other four capabilities.
+        assertFalse(status.isMultimodalConfigured());
+    }
+
+    private void stubIdleProviders() {
+        lenient().when(embeddingProvider.providerName()).thenReturn("none");
+        lenient().when(embeddingProvider.model()).thenReturn("none");
+        lenient().when(rerankProvider.providerName()).thenReturn("none");
+        lenient().when(rerankProvider.model()).thenReturn("none");
+        lenient().when(chatProvider.providerName()).thenReturn("none");
+        lenient().when(chatProvider.model()).thenReturn("none");
+        lenient().when(visionProvider.providerName()).thenReturn("none");
+        lenient().when(visionProvider.model()).thenReturn("none");
+    }
+}

--- a/kb-rag-server/kb-common/src/main/java/io/kbrag/common/constant/KbConstants.java
+++ b/kb-rag-server/kb-common/src/main/java/io/kbrag/common/constant/KbConstants.java
@@ -73,6 +73,9 @@ public final class KbConstants {
     /** Business id prefix of a registered web source row. */
     public static final String WEB_SOURCE_ID_PREFIX = "ws";
 
+    /** Business id prefix of a registered external data source row. */
+    public static final String EXT_SOURCE_ID_PREFIX = "exts";
+
     /**
      * Fixed prefix of every open API key plaintext, requirement section 4.8 "kb-sk-{prefix}{random}".
      *

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
@@ -667,7 +667,7 @@ public class KbProperties {
 
         /** Accepted lower case extensions. */
         private List<String> allowedExtensions =
-                List.of("pdf", "docx", "txt", "md", "xlsx", "csv",
+                List.of("pdf", "docx", "txt", "md", "sql", "xlsx", "csv",
                         "png", "jpg", "jpeg", "webp", "bmp", "gif");
     }
 

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
@@ -48,6 +48,9 @@ public class KbProperties {
     /** Vision provider configuration, consumed by the image asset stage. */
     private Vision vision = new Vision();
 
+    /** Multimodal embedding provider configuration, the M14 contract section 6.1. */
+    private MultimodalEmbedding multimodalEmbedding = new MultimodalEmbedding();
+
     /** Image asset pipeline policy. */
     private Image image = new Image();
 
@@ -108,6 +111,9 @@ public class KbProperties {
     /** URL import policy: fetch limits and the scheduled sync pass, the M12 contract section 3.5. */
     private WebImport webImport = new WebImport();
 
+    /** External data source policy: scan limits and the scheduled sync pass, the M14 contract section 2.4. */
+    private ExtSource extSource = new ExtSource();
+
     /**
      * Content governance policy, the M11 contract section 2.3.
      */
@@ -157,6 +163,30 @@ public class KbProperties {
 
         /** Sources one scheduled pass re-fetches; fetching is slow outbound I/O, hence a count bound. */
         private int syncBatchSize = 50;
+    }
+
+    /**
+     * External data source policy, the M14 contract section 2.4.
+     */
+    @Getter
+    @Setter
+    @ToString
+    public static class ExtSource {
+
+        /** Cron expression of the nightly incremental sync pass. */
+        private String syncCron = "0 0 3 * * *";
+
+        /** {@code false} disables the scheduled pass; manual sync stays available. */
+        private boolean syncEnabled = true;
+
+        /** Sources one scheduled pass scans; a scan lists and fetches many objects, hence a small bound. */
+        private int syncBatchSize = 10;
+
+        /** Objects one scan considers per source; beyond it the pass records PARTIAL and truncates. */
+        private int maxObjectsPerSource = 500;
+
+        /** Connect and read budget of one connector call. */
+        private int fetchTimeoutMs = 30000;
     }
 
     /**
@@ -441,6 +471,47 @@ public class KbProperties {
     }
 
     /**
+     * Multimodal embedding provider configuration, the M14 contract section 6.1.
+     *
+     * <p>A blank API key switches the whole multimodal capability off: the index pipeline stops
+     * producing image vectors and retrieval stops running the third route. The key defaults to the
+     * same DashScope credential the rest of the model family shares, so a deployment that already set
+     * {@code DASHSCOPE_API_KEY} gets multimodal indexing the moment a knowledge base turns the switch
+     * on, with no second credential to provision.
+     */
+    @Getter
+    @Setter
+    @ToString(exclude = "apiKey")
+    public static class MultimodalEmbedding {
+
+        /** Provider implementation name. */
+        private String provider = "dashscope";
+
+        /** Model name. */
+        private String model = "multimodal-embedding-v1";
+
+        /** Vector dimension, frozen into the multimodal index at creation time. */
+        private int dimension = 1024;
+
+        /** Credential, blank switches the whole multimodal capability off. */
+        private String apiKey = "";
+
+        /**
+         * Full URL of the native multimodal embedding endpoint. DashScope exposes it outside the
+         * OpenAI compatible surface, so unlike text embedding this is a complete URL rather than a
+         * base URL, the same shape the rerank endpoint takes.
+         */
+        private String url =
+                "https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding";
+
+        /** Maximum items per provider request. */
+        private int batchSize = 8;
+
+        /** Request timeout in milliseconds. */
+        private int timeoutMs = 30000;
+    }
+
+    /**
      * Image asset pipeline policy.
      */
     @Getter
@@ -722,6 +793,12 @@ public class KbProperties {
 
         /** Rerank default when a rerank model is configured. */
         private boolean rerankEnabled = true;
+
+        /** Default rerank ordering mode, {@code semantic} or {@code hybrid}, the M14 contract section 5. */
+        private String rerankMode = "semantic";
+
+        /** Default semantic weight of the {@code hybrid} rerank mode, within {@code [0,1]}. */
+        private double rerankWSemantic = 0.7d;
 
         /**
          * Upper bound of knowledge bases one application version may link, requirement section 4.7.

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/constant/ChunkMetadataKeys.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/constant/ChunkMetadataKeys.java
@@ -1,5 +1,7 @@
 package io.kbrag.domain.constant;
 
+import java.util.Set;
+
 /**
  * Keys of {@code t_kb_chunk.metadata} that are mirrored into the engine side filterable fields.
  *
@@ -65,6 +67,28 @@ public final class ChunkMetadataKeys {
 
     /** Chunk keywords produced alongside the LLM semantic split, a JSON array of strings. */
     public static final String KEYWORDS = "keywords";
+
+    /**
+     * One based page number the M14 {@code page} splitting strategy stamps on every chunk, stored as a
+     * string so it rides the same engine projection and custom filter path the operator extracted keys
+     * use.
+     *
+     * <p>Deliberately kept out of {@link #RESERVED}: it is a per document value the operator did not
+     * declare a rule for, so it is mirrored under the {@code ext_} namespace like any other filterable
+     * metadata rather than getting an engine field of its own.
+     */
+    public static final String PAGE_NO = "page_no";
+
+    /**
+     * Every key the platform itself writes, the M14 contract section 3.1.
+     *
+     * <p>The configuration gate rejects a metadata rule that reuses one of these, and the engine
+     * projection treats every key outside this set as operator extracted: two purposes, one list, so
+     * a key added above without being registered here would be shipped to the engines under the
+     * {@code ext_} namespace instead of its own field.
+     */
+    public static final Set<String> RESERVED = Set.of(TAG_IDS, SESSION_ID, SENDER, MSG_TIME,
+            SESSION_NAME, WINDOW_SEQ, MSG_SPAN, IMAGE_URLS, TITLE, SUMMARY, KEYWORDS);
 
     private ChunkMetadataKeys() {
     }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/constant/IndexFields.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/constant/IndexFields.java
@@ -53,6 +53,15 @@ public final class IndexFields {
     /** Embedding vector. */
     public static final String VECTOR = "vector";
 
+    /**
+     * Namespace prefix of the operator extracted metadata fields, the M14 contract section 3.2.
+     *
+     * <p>The prefix exists only engine side: MySQL stores the raw rule key, and prefixing on the way
+     * into the engines is what keeps an operator chosen key from ever colliding with a column of the
+     * fixed mapping above.
+     */
+    public static final String EXT_PREFIX = "ext_";
+
     private IndexFields() {
     }
 }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/ExtSource.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/ExtSource.java
@@ -1,0 +1,85 @@
+package io.kbrag.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.kbrag.domain.enums.ExtSourceSyncStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+/**
+ * A registered external object store source, the M14 contract section 1: connection details of one
+ * S3/OSS compatible bucket, the sync switch and the outcome of the last sync pass.
+ *
+ * <p>The binding to the documents it produced is deliberately weak, the same shape as
+ * {@link WebSource}: removing the registration leaves the documents alone, and trashing a document
+ * leaves the registration alone - the two lifecycles meet only inside a sync pass.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Setter
+@ToString(callSuper = true, exclude = "secretKey")
+@TableName("t_kb_ext_source")
+public class ExtSource extends BaseEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Business identifier exposed through the API. */
+    @TableField("source_id")
+    private String sourceId;
+
+    /** Knowledge base the fetched objects land in. */
+    @TableField("kb_id")
+    private String kbId;
+
+    /** Connector type routing key, {@code s3} in this milestone. */
+    @TableField("source_type")
+    private String sourceType;
+
+    /** Operator facing display name, unique per knowledge base. */
+    @TableField("name")
+    private String name;
+
+    /** Service endpoint of the object store. */
+    @TableField("endpoint")
+    private String endpoint;
+
+    /** Optional region hint of the object store. */
+    @TableField("region")
+    private String region;
+
+    /** Bucket the scan lists. */
+    @TableField("bucket")
+    private String bucket;
+
+    /** Optional key prefix narrowing the scan. */
+    @TableField("prefix")
+    private String prefix;
+
+    /** Access key of the bucket credentials. */
+    @TableField("access_key")
+    private String accessKey;
+
+    /** Secret key of the bucket credentials; stored in clear, never returned by the read API. */
+    @TableField("secret_key")
+    private String secretKey;
+
+    /** {@code 1} includes the source in the scheduled sync pass. */
+    @TableField("sync_enabled")
+    private Integer syncEnabled;
+
+    /** When the last sync attempt ran, success or not. */
+    @TableField("last_sync_at")
+    private LocalDateTime lastSyncAt;
+
+    /** Outcome of the last sync pass. */
+    @TableField("last_sync_status")
+    private ExtSourceSyncStatus lastSyncStatus;
+
+    /** Why the last sync failed or was partial, {@code null} on success. */
+    @TableField("last_error")
+    private String lastError;
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/ExtSourceItem.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/ExtSourceItem.java
@@ -1,0 +1,59 @@
+package io.kbrag.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.kbrag.domain.enums.ExtSourceItemStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+/**
+ * One object of an external source and the outcome of its last sync, the M14 contract section 1.
+ *
+ * <p>A row is created the first time a listing surfaces the key and updated on every later visit,
+ * so the item table is the operator's per-object view of what a sync pass actually did.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Setter
+@ToString(callSuper = true)
+@TableName("t_kb_ext_source_item")
+public class ExtSourceItem extends BaseEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Owning external source business id. */
+    @TableField("source_id")
+    private String sourceId;
+
+    /** Object key inside the bucket. */
+    @TableField("object_key")
+    private String objectKey;
+
+    /** SHA-256 of the object key; the equality key a VARCHAR(1024) column cannot be. */
+    @TableField("object_key_hash")
+    private String objectKeyHash;
+
+    /** Etag of the last ingested object body, the unchanged check of an incremental sync. */
+    @TableField("etag")
+    private String etag;
+
+    /** Document the object feeds, {@code null} until the first successful ingest. */
+    @TableField("doc_id")
+    private String docId;
+
+    /** Outcome of the last sync visit of this object. */
+    @TableField("last_status")
+    private ExtSourceItemStatus lastStatus;
+
+    /** Why the last visit failed or was skipped, {@code null} on success. */
+    @TableField("last_error")
+    private String lastError;
+
+    /** When this object was last visited by a sync. */
+    @TableField("last_sync_at")
+    private LocalDateTime lastSyncAt;
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/DegradedReason.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/DegradedReason.java
@@ -69,7 +69,29 @@ public enum DegradedReason {
      * requested" case to distinguish: attaching an image <em>is</em> the request, so a caller that gets no
      * image semantics into its query always has to be told.
      */
-    IMAGE_UNDERSTANDING_UNAVAILABLE("image_understanding_unavailable");
+    IMAGE_UNDERSTANDING_UNAVAILABLE("image_understanding_unavailable"),
+
+    /**
+     * The knowledge base has the multimodal route switched on but the {@code fusion_mode} is
+     * {@code weighted}, so the route did not run, the M14 contract section 6.3.
+     *
+     * <p>Reciprocal rank fusion is the only mode that can merge a route lacking a comparable absolute
+     * score, exactly the reason the graph route is refused under weighted fusion. The multimodal
+     * vector route shares that constraint, so it is skipped rather than folded in on an incompatible
+     * scale, and the caller is told which route it lost.
+     */
+    MM_ROUTE_SKIPPED("mm_route_skipped"),
+
+    /**
+     * The knowledge base has the multimodal route switched on but embedding the query into the
+     * multimodal space failed or timed out, so the call ran on the remaining routes, the M14 contract
+     * section 6.3.
+     *
+     * <p>Reported for a configured but unreachable multimodal provider only. A knowledge base whose
+     * switch is off never asked for the route and carries no marker, the same silence the vector route
+     * keeps in zero key mode.
+     */
+    MM_ROUTE_UNAVAILABLE("mm_route_unavailable");
 
     private final String code;
 

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/ExtSourceItemStatus.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/ExtSourceItemStatus.java
@@ -1,0 +1,24 @@
+package io.kbrag.domain.enums;
+
+/**
+ * Per object outcome of one external source sync, the M14 contract section 2.2.
+ *
+ * <p>The four states mirror {@link WebSourceFetchStatus} on purpose: an object is a page with an
+ * etag instead of a body hash, and the operator reads both tables with the same eye.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum ExtSourceItemStatus {
+
+    /** The object was fetched and fed into the upload chain. */
+    SUCCESS,
+
+    /** The object's etag matches the previous ingest; nothing was written. */
+    UNCHANGED,
+
+    /** The ingest was not attempted or its result discarded, for a reason recorded in last_error. */
+    SKIPPED,
+
+    /** The fetch or the intake failed, for a reason recorded in last_error. */
+    FAILED
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/ExtSourceSyncStatus.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/ExtSourceSyncStatus.java
@@ -1,0 +1,22 @@
+package io.kbrag.domain.enums;
+
+/**
+ * Source level outcome of one external source sync pass, the M14 contract section 2.2.
+ *
+ * <p>PARTIAL exists because one pass touches many objects: some may ingest while others fail or
+ * the listing was truncated at the per-source cap, and the operator needs to know the pass both
+ * did work and left work behind - neither SUCCESS nor FAILED says that.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum ExtSourceSyncStatus {
+
+    /** Every listed object either ingested, was unchanged or was legitimately skipped. */
+    SUCCESS,
+
+    /** The pass ran but at least one object failed or the listing hit the per-source cap. */
+    PARTIAL,
+
+    /** A source level error stopped the pass before objects were visited, see last_error. */
+    FAILED
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/RerankMode.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/RerankMode.java
@@ -1,0 +1,58 @@
+package io.kbrag.domain.enums;
+
+/**
+ * Ordering mode of the rerank stage, the M14 contract section 5.
+ *
+ * <p>The two modes answer the same question with a different trust. {@link #SEMANTIC} orders by the
+ * cross encoder relevance alone, which is the score an absolute threshold can act on. {@link #HYBRID}
+ * mixes that relevance with the normalised BM25 score of the same candidate set so a strong keyword
+ * match is not buried by a semantically close but lexically distant passage - a linear blend that
+ * reproduces the model side hybrid rerank without depending on a model that offers it.
+ *
+ * <p>The mode only decides the <em>ordering</em>. The threshold keeps acting on the pure semantic
+ * score whatever the mode is, because the blended score is min-max normalised inside one candidate
+ * set and therefore not comparable across queries.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public enum RerankMode {
+
+    /** Cross encoder relevance orders the result, the default. */
+    SEMANTIC("semantic"),
+
+    /** Linear blend of the semantic relevance and the normalised BM25 score orders the result. */
+    HYBRID("hybrid");
+
+    private final String code;
+
+    RerankMode(String code) {
+        this.code = code;
+    }
+
+    /**
+     * Literal used in the API and in the configuration.
+     *
+     * @return API side value
+     */
+    public String code() {
+        return code;
+    }
+
+    /**
+     * Resolves a mode from its literal.
+     *
+     * @param value configuration or request value, case insensitive
+     * @return matching mode, {@link #SEMANTIC} when blank or unknown
+     */
+    public static RerankMode from(String value) {
+        if (value == null || value.isBlank()) {
+            return SEMANTIC;
+        }
+        for (RerankMode mode : values()) {
+            if (mode.code.equalsIgnoreCase(value.trim()) || mode.name().equalsIgnoreCase(value.trim())) {
+                return mode;
+            }
+        }
+        return SEMANTIC;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/RetrievalSource.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/enums/RetrievalSource.java
@@ -13,6 +13,9 @@ public enum RetrievalSource {
     /** BM25 full text route. */
     BM25,
 
+    /** Multimodal vector route, the M14 contract section 6.3. */
+    MM,
+
     /** Graph route, reserved for M7. */
     GRAPH;
 

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/ExtSourceItemMapper.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/ExtSourceItemMapper.java
@@ -1,0 +1,26 @@
+package io.kbrag.domain.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.kbrag.domain.entity.ExtSourceItem;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * Data access for t_kb_ext_source_item.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Mapper
+public interface ExtSourceItemMapper extends BaseMapper<ExtSourceItem> {
+
+    /**
+     * Physically removes every item row of one source.
+     *
+     * <p>Hard delete for the same reason as the source row: a soft-deleted item would hold
+     * {@code uk_source_object} hostage if the same source id were ever minted again, and item rows
+     * are pure sync bookkeeping with no lifecycle of their own to preserve.
+     */
+    @Delete("DELETE FROM t_kb_ext_source_item WHERE source_id = #{sourceId}")
+    int hardDeleteBySourceId(@Param("sourceId") String sourceId);
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/ExtSourceMapper.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/ExtSourceMapper.java
@@ -1,0 +1,27 @@
+package io.kbrag.domain.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.kbrag.domain.entity.ExtSource;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * Data access for t_kb_ext_source.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Mapper
+public interface ExtSourceMapper extends BaseMapper<ExtSource> {
+
+    /**
+     * Physically removes one source row.
+     *
+     * <p>The inherited delete would only flip the {@code deleted} flag, and a soft-deleted row
+     * still occupies {@code uk_kb_name} - re-registering the same name after a removal would then
+     * hit the unique key forever. Removal of a registration is contractually final (the documents
+     * stay, the binding does not), so a hard delete is the correct shape, not a workaround.
+     */
+    @Delete("DELETE FROM t_kb_ext_source WHERE id = #{id}")
+    int hardDeleteById(@Param("id") Long id);
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ChunkRecord.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ChunkRecord.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Engine side projection of a chunk.
@@ -51,6 +52,13 @@ public class ChunkRecord {
 
     /** Chat message timestamp in epoch milliseconds. */
     private final Long msgTime;
+
+    /**
+     * Operator extracted metadata already carrying the engine side {@code ext_} prefix, the M14
+     * contract section 3.2; values are strings or string lists, may be empty, never {@code null}
+     * semantics enforced by the writer.
+     */
+    private final Map<String, Object> extMetadata;
 
     /** Zero based order inside the document version. */
     private final Integer chunkSeq;

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ExtSourceConfig.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ExtSourceConfig.java
@@ -1,0 +1,31 @@
+package io.kbrag.domain.model;
+
+/**
+ * Connection details one connector call operates on, the M14 contract section 2.1.
+ *
+ * <p>A plain value instead of the {@code ExtSource} entity so a connector implementation never
+ * sees row identity, sync bookkeeping or the credential update rules - it receives exactly what a
+ * remote call needs and nothing it could accidentally persist.
+ *
+ * @param endpoint   service endpoint of the object store
+ * @param region     optional region hint, {@code null} when the store does not need one
+ * @param bucket     bucket to list and fetch from
+ * @param prefix     optional key prefix narrowing a listing, {@code null} for the whole bucket
+ * @param accessKey  access key of the credentials
+ * @param secretKey  secret key of the credentials
+ * @param maxObjects listing cap per scan; one object beyond it may be returned so the caller can
+ *                   tell a full listing from a truncated one
+ * @param timeoutMs  connect and read budget of one remote call
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ExtSourceConfig(
+        String endpoint,
+        String region,
+        String bucket,
+        String prefix,
+        String accessKey,
+        String secretKey,
+        int maxObjects,
+        int timeoutMs) {
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ImageInput.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ImageInput.java
@@ -1,0 +1,18 @@
+package io.kbrag.domain.model;
+
+/**
+ * One image handed to the multimodal embedding provider, the M14 contract section 6.1.
+ *
+ * <p>Carries the raw bytes rather than an object key so the provider layer stays free of any storage
+ * dependency: the caller reads the bytes from private storage and the provider only ever sees a byte
+ * array and its media type. That is what lets the same port serve a data URL inlining implementation
+ * and, should a vendor reject inlined bytes, a pre signed URL one, without either detail leaking into
+ * the index pipeline.
+ *
+ * @param content   raw image bytes, never empty
+ * @param mediaType MIME type of the bytes, {@code image/png} assumed by the provider when blank
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record ImageInput(byte[] content, String mediaType) {
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/KbIndexConfig.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/KbIndexConfig.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.List;
+
 /**
  * Typed view of the {@code t_kb_knowledge_base.index_config} JSON column.
  *
@@ -68,6 +70,50 @@ public class KbIndexConfig {
     private ChatAggregationParams chatAggregation = ChatAggregationParams.defaults();
 
     /**
+     * Operator declared metadata extraction rules, the M14 contract section 3.1, at most
+     * {@link MetadataRule#MAX_RULES}.
+     *
+     * <p>Inside the chunk fingerprint: the rules decide what metadata a build stamps on every chunk,
+     * so editing them has to mark the affected documents configuration stale exactly like changing
+     * the splitter would.
+     */
+    @JsonProperty("metadata_rules")
+    private List<MetadataRule> metadataRules;
+
+    /**
+     * Block delimiter of the M14 {@code separator} splitting strategy, {@code null} lets the strategy
+     * fall back to its own default; ignored by every other strategy.
+     */
+    @JsonProperty("split_separator")
+    private String splitSeparator;
+
+    /** Whether {@link #splitSeparator} is a regular expression, the M14 {@code separator} strategy. */
+    @JsonProperty("split_separator_is_regex")
+    private boolean splitSeparatorIsRegex;
+
+    /**
+     * Markdown heading depth of the M14 {@code heading} splitting strategy, {@code 0} lets the strategy
+     * fall back to its own default depth; ignored by every other strategy.
+     */
+    @JsonProperty("split_heading_level")
+    private int splitHeadingLevel;
+
+    /**
+     * Turns on the multimodal vector route for this knowledge base, the M14 contract section 6.2.
+     *
+     * <p>Off by default so shipping the feature changes nothing: a knowledge base that never set it
+     * keeps the exact chunk fingerprint it had before M14. When on and a multimodal provider is
+     * configured, the pipeline produces an extra vector for every image bearing chunk and retrieval
+     * gains a third recall route. When on but no provider is configured the switch is stored and the
+     * indexing is skipped, the same zero key tolerance the text vector route already has.
+     *
+     * <p>Inside the chunk fingerprint: flipping it changes what the pipeline produces, so it has to
+     * mark the affected documents configuration stale exactly like changing the splitter would.
+     */
+    @JsonProperty("multimodal_enabled")
+    private boolean multimodalEnabled;
+
+    /**
      * Suppresses a parent chunk entirely as soon as one of its children is disabled.
      *
      * <p>Off by default. The one phase semantics return the whole parent and merely report which of
@@ -112,6 +158,15 @@ public class KbIndexConfig {
     }
 
     /**
+     * Resolves the metadata extraction rules, never {@code null}.
+     *
+     * @return declared rules, empty when the column carried none
+     */
+    public List<MetadataRule> metadataRulesOrEmpty() {
+        return metadataRules == null ? List.of() : metadataRules;
+    }
+
+    /**
      * Resolves the parent child parameters, never {@code null}.
      *
      * @return parent child parameters, disabled when the column carried none
@@ -150,6 +205,7 @@ public class KbIndexConfig {
      * @return validated split parameters
      */
     public SplitParams splitParams(SplitParams.CacheContext cacheContext) {
-        return SplitParams.of(chunkMaxTokens, chunkOverlap, cacheContext);
+        return SplitParams.of(chunkMaxTokens, chunkOverlap, cacheContext, splitSeparator,
+                splitSeparatorIsRegex, splitHeadingLevel);
     }
 }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/KbRetrievalConfig.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/KbRetrievalConfig.java
@@ -52,6 +52,20 @@ public class KbRetrievalConfig {
     @JsonProperty("rerank_enabled")
     private Boolean rerankEnabled;
 
+    /**
+     * Rerank ordering mode, the M14 contract section 5. {@code null} falls through to the deployment
+     * default {@code semantic}, so a base configured before M14 keeps the pure semantic ordering.
+     */
+    @JsonProperty("rerank_mode")
+    private String rerankMode;
+
+    /**
+     * Semantic weight of the {@code hybrid} rerank mode, within {@code [0,1]}, the M14 contract section
+     * 5. The BM25 weight is its complement. {@code null} falls through to the deployment default.
+     */
+    @JsonProperty("rerank_w_semantic")
+    private Double rerankWSemantic;
+
     /** Query rewrite switch. */
     @JsonProperty("rewrite_enabled")
     private Boolean rewriteEnabled;

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/MetadataFilter.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/MetadataFilter.java
@@ -4,8 +4,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Optional narrowing predicate supplied by the caller.
@@ -38,6 +40,13 @@ public class MetadataFilter {
     private final Long msgTimeTo;
 
     /**
+     * Equality predicates on operator extracted metadata, the M14 contract section 3.3, keyed by the
+     * raw rule key and combined with AND semantics. A {@code keyword_match} key matches when the
+     * stored array contains the value.
+     */
+    private final Map<String, String> custom;
+
+    /**
      * Tells whether this filter carries at least one predicate.
      *
      * @return {@code true} when the filter narrows the candidate set
@@ -47,7 +56,8 @@ public class MetadataFilter {
                 && isBlank(sessionId)
                 && isBlank(sender)
                 && msgTimeFrom == null
-                && msgTimeTo == null;
+                && msgTimeTo == null
+                && MapUtils.isEmpty(custom);
     }
 
     private boolean isBlank(String value) {

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/MetadataRule.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/MetadataRule.java
@@ -1,0 +1,86 @@
+package io.kbrag.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * One operator declared metadata extraction rule of the {@code metadata_rules} block inside
+ * {@code t_kb_knowledge_base.index_config}, the M14 contract section 3.1.
+ *
+ * <p>Three rule types exist: {@code constant} stamps a fixed value on every chunk, {@code regex}
+ * captures a value out of the chunk text, {@code keyword_match} records which words of a vocabulary
+ * the chunk contains. The rule set feeds the chunk fingerprint, so editing it marks the affected
+ * documents configuration stale instead of silently leaving old and new metadata side by side.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MetadataRule {
+
+    /** Rule type: fixed value. */
+    public static final String TYPE_CONSTANT = "constant";
+
+    /** Rule type: first capture group of a pattern, or the whole match when there is no group. */
+    public static final String TYPE_REGEX = "regex";
+
+    /** Rule type: subset of a vocabulary found in the chunk text. */
+    public static final String TYPE_KEYWORD_MATCH = "keyword_match";
+
+    /** Shape every metadata key has to have, shared with the custom filter of the retrieval side. */
+    public static final Pattern KEY_PATTERN = Pattern.compile("^[a-z][a-z0-9_]{1,31}$");
+
+    /** Rules a knowledge base may declare at most. */
+    public static final int MAX_RULES = 10;
+
+    /** Longest accepted regular expression source. */
+    public static final int MAX_PATTERN_LENGTH = 64;
+
+    /** Largest accepted vocabulary. */
+    public static final int MAX_KEYWORDS = 50;
+
+    /** Longest accepted vocabulary word. */
+    public static final int MAX_KEYWORD_LENGTH = 32;
+
+    /** Longest stored extracted value; anything beyond is cut, never rejected. */
+    public static final int MAX_VALUE_LENGTH = 256;
+
+    /** Metadata key the extracted value is stored under. */
+    private String key;
+
+    /** Rule type, one of the three type literals. */
+    private String type;
+
+    /** Fixed value of a {@code constant} rule. */
+    private String value;
+
+    /** Pattern source of a {@code regex} rule. */
+    private String pattern;
+
+    /** Vocabulary of a {@code keyword_match} rule. */
+    private List<String> keywords;
+
+    /**
+     * Renders the rule into the canonical form the chunk fingerprint digests.
+     *
+     * @return stable text representation of every semantic carrying field
+     */
+    public String fingerprintSegment() {
+        return key + ":" + type + ":" + nullToEmpty(value) + ":" + nullToEmpty(pattern) + ":"
+                + (CollectionUtils.isEmpty(keywords) ? "" : String.join(",", keywords));
+    }
+
+    private String nullToEmpty(String text) {
+        return text == null ? "" : text;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ModelStatus.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/ModelStatus.java
@@ -59,4 +59,13 @@ public class ModelStatus {
 
     /** Vision model name, {@code none} when unconfigured. */
     private final String visionModel;
+
+    /** {@code false} disables the multimodal page index switch and greys it out (M14 contract 6.2). */
+    private final boolean multimodalConfigured;
+
+    /** Multimodal embedding provider name, {@code none} when unconfigured. */
+    private final String multimodalProvider;
+
+    /** Multimodal embedding model name, {@code none} when unconfigured. */
+    private final String multimodalModel;
 }

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/SplitParams.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/model/SplitParams.java
@@ -35,10 +35,30 @@ public final class SplitParams {
      */
     private final CacheContext cacheContext;
 
-    private SplitParams(int maxTokens, int overlapTokens, CacheContext cacheContext) {
+    /**
+     * Block delimiter of the M14 {@code separator} strategy, {@code null} for every other strategy; a
+     * {@code null} lets the separator splitter fall back to its own default rather than forcing every
+     * caller of the two argument factory to name one.
+     */
+    private final String separator;
+
+    /** Whether {@link #separator} is a regular expression, only read by the {@code separator} strategy. */
+    private final boolean separatorIsRegex;
+
+    /**
+     * Markdown heading depth of the M14 {@code heading} strategy, {@code 0} for every other strategy; a
+     * {@code 0} lets the heading splitter fall back to its own default depth.
+     */
+    private final int headingLevel;
+
+    private SplitParams(int maxTokens, int overlapTokens, CacheContext cacheContext,
+                        String separator, boolean separatorIsRegex, int headingLevel) {
         this.maxTokens = maxTokens;
         this.overlapTokens = overlapTokens;
         this.cacheContext = cacheContext;
+        this.separator = separator;
+        this.separatorIsRegex = separatorIsRegex;
+        this.headingLevel = headingLevel;
     }
 
     /**
@@ -64,13 +84,32 @@ public final class SplitParams {
      * @return validated parameters
      */
     public static SplitParams of(int maxTokens, int overlapTokens, CacheContext cacheContext) {
+        return of(maxTokens, overlapTokens, cacheContext, null, false, 0);
+    }
+
+    /**
+     * Builds the parameter set carrying the M14 {@code separator} and {@code heading} strategy inputs
+     * alongside the LLM cache coordinates.
+     *
+     * @param maxTokens        maximum estimated tokens per chunk, must be positive
+     * @param overlapTokens    overlap in estimated tokens, must be zero or positive and below
+     *                         {@code maxTokens}
+     * @param cacheContext     cache coordinates, {@code null} disables caching for this call
+     * @param separator        {@code separator} strategy delimiter, {@code null} keeps the strategy default
+     * @param separatorIsRegex whether {@code separator} is a regular expression
+     * @param headingLevel     {@code heading} strategy depth, {@code 0} keeps the strategy default
+     * @return validated parameters
+     */
+    public static SplitParams of(int maxTokens, int overlapTokens, CacheContext cacheContext,
+                                 String separator, boolean separatorIsRegex, int headingLevel) {
         if (maxTokens <= 0) {
             throw new IllegalArgumentException("maxTokens must be positive");
         }
         if (overlapTokens < 0 || overlapTokens >= maxTokens) {
             throw new IllegalArgumentException("overlapTokens must be within [0, maxTokens)");
         }
-        return new SplitParams(maxTokens, overlapTokens, cacheContext);
+        return new SplitParams(maxTokens, overlapTokens, cacheContext, separator, separatorIsRegex,
+                headingLevel);
     }
 
     /**
@@ -79,7 +118,7 @@ public final class SplitParams {
      * @return 600 token chunks with 100 token overlap
      */
     public static SplitParams defaults() {
-        return new SplitParams(DEFAULT_MAX_TOKENS, DEFAULT_OVERLAP_TOKENS, null);
+        return new SplitParams(DEFAULT_MAX_TOKENS, DEFAULT_OVERLAP_TOKENS, null, null, false, 0);
     }
 
     /**

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/ExternalConnector.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/ExternalConnector.java
@@ -1,0 +1,65 @@
+package io.kbrag.domain.port;
+
+import io.kbrag.domain.model.ExtSourceConfig;
+import io.kbrag.domain.model.HealthStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * SPI of one external data source type, the M14 contract section 2.1.
+ *
+ * <p>Implementations declare themselves as beans and are collected by the router keyed on
+ * {@link #type()}, the same plug-in shape as the text splitters: adding a Confluence or IM
+ * connector later means adding one bean, not touching the sync engine.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public interface ExternalConnector {
+
+    /**
+     * Routing key stored in {@code t_kb_ext_source.source_type}.
+     *
+     * @return connector type literal, lower case
+     */
+    String type();
+
+    /**
+     * Lists the objects a sync pass should consider.
+     *
+     * <p>May return up to one object beyond {@link ExtSourceConfig#maxObjects()} so the caller can
+     * distinguish a complete listing from a truncated one without a second remote call.
+     *
+     * @param config connection details
+     * @return listed objects, never {@code null}
+     */
+    List<RemoteObject> listObjects(ExtSourceConfig config);
+
+    /**
+     * Fetches one object body.
+     *
+     * @param config    connection details
+     * @param objectKey key of the object to fetch
+     * @return object bytes
+     */
+    byte[] fetchObject(ExtSourceConfig config, String objectKey);
+
+    /**
+     * Probes connectivity and credentials without touching any object.
+     *
+     * @param config connection details
+     * @return probe outcome, never throws
+     */
+    HealthStatus testConnection(ExtSourceConfig config);
+
+    /**
+     * One object surfaced by a listing.
+     *
+     * @param key          object key inside the bucket
+     * @param etag         change marker of the object body, {@code null} when the store has none
+     * @param size         object size in bytes
+     * @param lastModified last modification time, {@code null} when the store has none
+     */
+    record RemoteObject(String key, String etag, long size, LocalDateTime lastModified) {
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/MultimodalEmbeddingProvider.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/MultimodalEmbeddingProvider.java
@@ -1,0 +1,85 @@
+package io.kbrag.domain.port;
+
+import io.kbrag.common.exception.ProviderException;
+import io.kbrag.domain.model.HealthStatus;
+import io.kbrag.domain.model.ImageInput;
+
+import java.util.List;
+
+/**
+ * Outbound port of the multimodal embedding capability, the M14 contract section 6.1.
+ *
+ * <p>Text and images are embedded into one shared space, which is what lets a text query recall an
+ * image chunk and, in F6, an image query recall a text one. The dimension is frozen into the
+ * multimodal index at creation time exactly like the text embedding port, so a model whose dimension
+ * differs forces a rebuild instead of being adapted in place.
+ *
+ * <p>A blank credential yields the unconfigured implementation whose {@link #isConfigured()} returns
+ * {@code false}: the index pipeline then skips the multimodal vectors and retrieval skips the third
+ * route, which keeps the whole capability free of scattered null checks - a caller asks the flag once
+ * and either runs the route or does not.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public interface MultimodalEmbeddingProvider {
+
+    /**
+     * Provider implementation name recorded in the multimodal index registry.
+     *
+     * @return provider name, for example {@code dashscope} or {@code none}
+     */
+    String providerName();
+
+    /**
+     * Model identifier this instance was configured with.
+     *
+     * @return model name
+     */
+    String model();
+
+    /**
+     * Vector dimension produced by {@link #model()}.
+     *
+     * @return dimension, 0 when the provider is not configured
+     */
+    int dimension();
+
+    /**
+     * Tells whether the provider holds a usable credential.
+     *
+     * @return {@code true} when multimodal calls can be issued
+     */
+    boolean isConfigured();
+
+    /**
+     * Maximum number of items a single provider request accepts.
+     *
+     * @return batch size, callers must not exceed it
+     */
+    int maxBatchSize();
+
+    /**
+     * Embeds a batch of texts into the multimodal space, preserving the input order.
+     *
+     * @param texts input texts, size must not exceed {@link #maxBatchSize()}
+     * @return one vector per input text
+     * @throws ProviderException classified provider failure
+     */
+    List<float[]> embedTexts(List<String> texts);
+
+    /**
+     * Embeds a batch of images into the multimodal space, preserving the input order.
+     *
+     * @param images input images, size must not exceed {@link #maxBatchSize()}
+     * @return one vector per input image
+     * @throws ProviderException classified provider failure
+     */
+    List<float[]> embedImages(List<ImageInput> images);
+
+    /**
+     * Probes provider connectivity without consuming a meaningful quota.
+     *
+     * @return probe outcome
+     */
+    HealthStatus healthCheck();
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/BizIdGenerator.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/BizIdGenerator.java
@@ -199,6 +199,15 @@ public class BizIdGenerator {
         return generate(KbConstants.WEB_SOURCE_ID_PREFIX);
     }
 
+    /**
+     * Generates a registered external data source id.
+     *
+     * @return prefixed identifier
+     */
+    public String extSourceId() {
+        return generate(KbConstants.EXT_SOURCE_ID_PREFIX);
+    }
+
     private String generate(String prefix) {
         String random = UUID.randomUUID().toString().replace("-", "").substring(0, RANDOM_LENGTH);
         return prefix + KbConstants.ID_SEPARATOR + random;

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/ConnectorRouter.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/ConnectorRouter.java
@@ -1,0 +1,52 @@
+package io.kbrag.domain.service;
+
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.port.ExternalConnector;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Dispatches to the {@link ExternalConnector} bean a source's {@code source_type} names, the M14
+ * contract section 2.1.
+ *
+ * <p>Mirrors {@link SplitterRouter} in how implementations are collected from the container, but
+ * unlike the splitter router an unknown type is rejected instead of falling back: a connector that
+ * cannot be resolved has no "default behaviour" to fall back to - there is no bucket a wrong
+ * connector could safely scan on the operator's behalf.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class ConnectorRouter {
+
+    private final Map<String, ExternalConnector> connectors;
+
+    public ConnectorRouter(List<ExternalConnector> availableConnectors) {
+        this.connectors = new HashMap<>(availableConnectors.size());
+        for (ExternalConnector connector : availableConnectors) {
+            connectors.put(connector.type(), connector);
+        }
+    }
+
+    /**
+     * Resolves the connector of a source type.
+     *
+     * @param sourceType {@code t_kb_ext_source.source_type}, case insensitive
+     * @return matching connector, never {@code null}
+     * @throws BizException when no connector of this type is registered
+     */
+    public ExternalConnector resolve(String sourceType) {
+        if (sourceType == null || sourceType.isBlank()) {
+            throw BizException.invalidParam("数据源类型不能为空");
+        }
+        ExternalConnector connector = connectors.get(sourceType.toLowerCase(Locale.ROOT));
+        if (connector == null) {
+            throw BizException.invalidParam("不支持的数据源类型：" + sourceType);
+        }
+        return connector;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/FixedLengthTextSplitter.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/FixedLengthTextSplitter.java
@@ -60,6 +60,9 @@ public class FixedLengthTextSplitter implements TextSplitter {
     /** Upper bound of the characters {@link String#trim()} removes, mirrored so offsets match the text. */
     private static final char TRIM_BOUNDARY = ' ';
 
+    /** Newline that rejoins the blocks the M14 separator and heading strategies pack together. */
+    private static final String BLOCK_JOINER = "\n";
+
     private final TokenEstimator tokenEstimator;
 
     @Override
@@ -97,6 +100,64 @@ public class FixedLengthTextSplitter implements TextSplitter {
             }
         }
         return chunks;
+    }
+
+    /**
+     * Packs pre-segmented blocks into chunks, the packing half of the fixed length strategy the M14
+     * {@code separator} and {@code heading} strategies reuse rather than each owning an overflow path
+     * of its own, the contract section 4.
+     *
+     * <p>A block that fits is packed greedily with its neighbours up to the token budget; a block that
+     * alone exceeds the budget is re-split by the full fixed length algorithm so an over long paragraph
+     * or heading section still lands in chunks that respect {@code chunk_max_tokens} instead of being
+     * emitted whole. The packed chunks carry no source offsets: a strategy that packs blocks cannot be
+     * combined with parent child splitting, which is the only reader of an offset.
+     *
+     * @param blocks logical blocks in reading order, blank blocks ignored
+     * @param params split parameters
+     * @return ordered chunks
+     */
+    public List<SplitChunk> packBlocks(List<String> blocks, SplitParams params) {
+        List<SplitChunk> chunks = new ArrayList<>();
+        if (blocks == null || blocks.isEmpty()) {
+            return chunks;
+        }
+        List<String> buffer = new ArrayList<>();
+        int bufferTokens = 0;
+        int seq = 0;
+        for (String block : blocks) {
+            if (block == null || block.isBlank()) {
+                continue;
+            }
+            int blockTokens = tokenEstimator.estimate(block);
+            if (blockTokens > params.getMaxTokens()) {
+                if (!buffer.isEmpty()) {
+                    chunks.add(newBlockChunk(seq++, buffer));
+                    buffer = new ArrayList<>();
+                    bufferTokens = 0;
+                }
+                for (SplitChunk piece : split(block, params)) {
+                    chunks.add(new SplitChunk(seq++, piece.getContent(), piece.getTokenCount()));
+                }
+                continue;
+            }
+            if (!buffer.isEmpty() && bufferTokens + blockTokens > params.getMaxTokens()) {
+                chunks.add(newBlockChunk(seq++, buffer));
+                buffer = new ArrayList<>();
+                bufferTokens = 0;
+            }
+            buffer.add(block);
+            bufferTokens += blockTokens;
+        }
+        if (!buffer.isEmpty()) {
+            chunks.add(newBlockChunk(seq, buffer));
+        }
+        return chunks;
+    }
+
+    private SplitChunk newBlockChunk(int seq, List<String> blocks) {
+        String content = String.join(BLOCK_JOINER, blocks).trim();
+        return new SplitChunk(seq, content, tokenEstimator.estimate(content));
     }
 
     /**

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/HeadingTextSplitter.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/HeadingTextSplitter.java
@@ -1,0 +1,106 @@
+package io.kbrag.domain.service;
+
+import io.kbrag.domain.model.SplitChunk;
+import io.kbrag.domain.model.SplitParams;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Heading splitting strategy, the M14 contract section 4: opens a new block on every markdown heading
+ * up to a configured depth, the heading line staying with the content it introduces.
+ *
+ * <p>A document with no heading at the configured depth degrades to {@link FixedLengthTextSplitter}
+ * over the whole text: a strategy that produced one enormous chunk for a heading free document would
+ * be worse than the default, not a specialisation of it. Packing and the over long section fallback
+ * are delegated to {@link FixedLengthTextSplitter#packBlocks}.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HeadingTextSplitter implements TextSplitter {
+
+    /** Strategy code persisted in the split fingerprint. */
+    public static final String STRATEGY_CODE = "heading";
+
+    /** Shallowest heading depth an operator may configure. */
+    public static final int MIN_HEADING_LEVEL = 1;
+
+    /** Deepest heading depth an operator may configure, markdown stops at six. */
+    public static final int MAX_HEADING_LEVEL = 6;
+
+    /** Depth used when the configuration names none, the document sections rather than its subsections. */
+    public static final int DEFAULT_HEADING_LEVEL = 2;
+
+    private final FixedLengthTextSplitter fixedLengthTextSplitter;
+
+    @Override
+    public String strategy() {
+        return STRATEGY_CODE;
+    }
+
+    @Override
+    public List<SplitChunk> split(String text, SplitParams params) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        int level = resolveLevel(params.getHeadingLevel());
+        Pattern headingPattern = Pattern.compile("^#{1," + level + "}\\s");
+        List<String> blocks = toBlocks(text, headingPattern);
+        if (blocks.isEmpty()) {
+            return fixedLengthTextSplitter.split(text, params);
+        }
+        return fixedLengthTextSplitter.packBlocks(blocks, params);
+    }
+
+    private int resolveLevel(int configured) {
+        if (configured < MIN_HEADING_LEVEL || configured > MAX_HEADING_LEVEL) {
+            return DEFAULT_HEADING_LEVEL;
+        }
+        return configured;
+    }
+
+    /**
+     * Groups the lines into blocks, each starting at a heading line and running until the next one.
+     *
+     * <p>Text before the first heading is kept as its own leading block so an introduction is never
+     * dropped. An empty list means the document carried no heading at this depth, which is the caller's
+     * signal to fall back to the fixed length strategy.
+     *
+     * @param text           source text
+     * @param headingPattern compiled heading matcher
+     * @return blocks in reading order, empty when no heading was found
+     */
+    private List<String> toBlocks(String text, Pattern headingPattern) {
+        String[] lines = text.split("\n", -1);
+        List<String> blocks = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean headingSeen = false;
+        for (String line : lines) {
+            if (headingPattern.matcher(line).find()) {
+                if (current.length() > 0) {
+                    blocks.add(current.toString());
+                    current.setLength(0);
+                }
+                headingSeen = true;
+            }
+            if (current.length() > 0) {
+                current.append('\n');
+            }
+            current.append(line);
+        }
+        if (!headingSeen) {
+            return List.of();
+        }
+        if (current.length() > 0) {
+            blocks.add(current.toString());
+        }
+        return blocks;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/IndexNaming.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/IndexNaming.java
@@ -33,6 +33,9 @@ public class IndexNaming {
     /** Prefix of every physical index and alias. */
     private static final String NAME_PREFIX = "kb";
 
+    /** Engine independent marker of the multimodal index, the M14 contract section 6.2. */
+    private static final String MULTIMODAL_MARKER = "mm";
+
     /**
      * Builds the physical name of the vector index.
      *
@@ -134,6 +137,36 @@ public class IndexNaming {
      */
     public String alias(String kbId, VectorEngine engine) {
         return NAME_PREFIX + NAME_SEPARATOR + normalizeKbId(kbId) + NAME_SEPARATOR + engine.code();
+    }
+
+    /**
+     * Builds the alias of the multimodal index, the M14 contract section 6.2.
+     *
+     * <p>Engine independent on purpose: the multimodal vectors live in whichever engine the deployment
+     * uses for vectors - a Qdrant collection in full mode, an Elasticsearch dense_vector index in lite
+     * mode - but the retrieval side addresses them through one alias without caring which, exactly as
+     * it does for the text vector route.
+     *
+     * @param kbId knowledge base business id
+     * @return multimodal alias
+     */
+    public String multimodalAlias(String kbId) {
+        return NAME_PREFIX + NAME_SEPARATOR + normalizeKbId(kbId) + NAME_SEPARATOR + MULTIMODAL_MARKER;
+    }
+
+    /**
+     * Builds the physical name of the multimodal index, the M14 contract section 6.2.
+     *
+     * <p>Carries the multimodal marker in place of the snapshot segment so its name never collides with
+     * a text index of the same embedding segment, and keeps the embedding segment so a multimodal model
+     * switch produces a new physical name and forces a clean rebuild rather than mixing dimensions.
+     *
+     * @param kbId             knowledge base business id
+     * @param embeddingSegment abbreviated multimodal model segment
+     * @return physical multimodal index or collection name
+     */
+    public String multimodalPhysicalName(String kbId, String embeddingSegment) {
+        return physicalName(kbId, embeddingSegment, MULTIMODAL_MARKER);
     }
 
     /**

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/MetadataRuleExtractor.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/MetadataRuleExtractor.java
@@ -1,0 +1,151 @@
+package io.kbrag.domain.service;
+
+import io.kbrag.domain.model.MetadataRule;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Applies the metadata rules of a knowledge base to chunk text, the M14 contract section 3.2.
+ *
+ * <p>A pure function of rules and text: no repository, no engine, no clock. The pipeline prepares
+ * the rule set once per document so a pattern is compiled once instead of once per chunk, then runs
+ * the prepared set over every chunk it persists.
+ *
+ * <p>A rule that yields nothing writes no key at all - an absent key is how the engine side filter
+ * distinguishes "not extracted" from "extracted empty", so an empty placeholder would make every
+ * chunk match every equality filter on that key.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+public class MetadataRuleExtractor {
+
+    /**
+     * A rule with its pattern compiled, ready to run over any number of chunks.
+     *
+     * @param rule    declared rule
+     * @param pattern compiled pattern, {@code null} for every type but {@code regex}
+     */
+    public record PreparedRule(MetadataRule rule, Pattern pattern) {
+    }
+
+    /**
+     * Compiles the rule set once so the per chunk extraction never compiles anything.
+     *
+     * <p>A pattern that no longer compiles is skipped rather than failing the build: the configuration
+     * gate rejects it at write time, so hitting one here means the stored configuration predates a
+     * validation change, and losing one metadata key is the better outcome than losing the document.
+     *
+     * @param rules declared rules, may be empty
+     * @return prepared rules, empty when nothing is declared
+     */
+    public List<PreparedRule> prepare(List<MetadataRule> rules) {
+        if (CollectionUtils.isEmpty(rules)) {
+            return List.of();
+        }
+        List<PreparedRule> prepared = new ArrayList<>(rules.size());
+        for (MetadataRule rule : rules) {
+            if (rule == null || rule.getKey() == null || rule.getType() == null) {
+                continue;
+            }
+            if (MetadataRule.TYPE_REGEX.equals(rule.getType())) {
+                try {
+                    prepared.add(new PreparedRule(rule, Pattern.compile(rule.getPattern())));
+                } catch (Exception e) {
+                    log.info("skip metadata rule with uncompilable pattern, key={}", rule.getKey());
+                }
+                continue;
+            }
+            prepared.add(new PreparedRule(rule, null));
+        }
+        return prepared;
+    }
+
+    /**
+     * Runs the prepared rules over one chunk text.
+     *
+     * @param prepared prepared rules, may be empty
+     * @param content  chunk text
+     * @return extracted values by rule key, insertion ordered, empty when nothing matched
+     */
+    public Map<String, Object> extract(List<PreparedRule> prepared, String content) {
+        if (CollectionUtils.isEmpty(prepared) || content == null) {
+            return Map.of();
+        }
+        Map<String, Object> extracted = new LinkedHashMap<>();
+        for (PreparedRule entry : prepared) {
+            Object value = valueOf(entry, content);
+            if (value != null) {
+                extracted.put(entry.rule().getKey(), value);
+            }
+        }
+        return extracted;
+    }
+
+    private Object valueOf(PreparedRule entry, String content) {
+        MetadataRule rule = entry.rule();
+        if (MetadataRule.TYPE_CONSTANT.equals(rule.getType())) {
+            return truncate(rule.getValue());
+        }
+        if (MetadataRule.TYPE_REGEX.equals(rule.getType())) {
+            return regexValue(entry.pattern(), content);
+        }
+        if (MetadataRule.TYPE_KEYWORD_MATCH.equals(rule.getType())) {
+            return keywordValue(rule.getKeywords(), content);
+        }
+        return null;
+    }
+
+    /**
+     * First capture group of the first match, the whole match when the pattern declares no group.
+     *
+     * @param pattern compiled pattern
+     * @param content chunk text
+     * @return captured value, {@code null} when the pattern does not match
+     */
+    private String regexValue(Pattern pattern, String content) {
+        Matcher matcher = pattern.matcher(content);
+        if (!matcher.find()) {
+            return null;
+        }
+        String captured = matcher.groupCount() > 0 ? matcher.group(1) : matcher.group();
+        return truncate(captured);
+    }
+
+    /**
+     * Subset of the vocabulary the chunk contains, in vocabulary order.
+     *
+     * @param keywords vocabulary
+     * @param content  chunk text
+     * @return matched words, {@code null} when none matched
+     */
+    private List<String> keywordValue(List<String> keywords, String content) {
+        if (CollectionUtils.isEmpty(keywords)) {
+            return null;
+        }
+        List<String> matched = new ArrayList<>();
+        for (String keyword : keywords) {
+            if (keyword != null && !keyword.isBlank() && content.contains(keyword)) {
+                matched.add(keyword);
+            }
+        }
+        return matched.isEmpty() ? null : matched;
+    }
+
+    private String truncate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.length() > MetadataRule.MAX_VALUE_LENGTH
+                ? value.substring(0, MetadataRule.MAX_VALUE_LENGTH) : value;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/PageSplitter.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/PageSplitter.java
@@ -1,0 +1,98 @@
+package io.kbrag.domain.service;
+
+import io.kbrag.domain.constant.ChunkMetadataKeys;
+import io.kbrag.domain.model.ParsedDocument;
+import io.kbrag.domain.model.SplitChunk;
+import io.kbrag.domain.model.SplitParams;
+import io.kbrag.domain.port.TokenEstimator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Page splitting strategy, the M14 contract section 4: cuts the document on the page boundaries the
+ * parser reported rather than on anything found in the markdown.
+ *
+ * <p>Not a {@link TextSplitter} because it does not work off a flat string: page boundaries live in
+ * the parse artifact, so the pipeline hands this strategy the {@link ParsedDocument} directly. A
+ * format without a page concept - a plain text or an html file - yields a single page holding the
+ * whole document, so the strategy always produces at least the fixed length behaviour rather than
+ * nothing.
+ *
+ * <p>Every chunk carries its one based {@link ChunkMetadataKeys#PAGE_NO} so the retrieval side can
+ * filter by page. A page whose text alone exceeds the token budget is re-split by
+ * {@link FixedLengthTextSplitter}, and each resulting chunk keeps that page number: an over long page
+ * is still one page, just several chunks.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PageSplitter {
+
+    /** Strategy code persisted in the split fingerprint. */
+    public static final String STRATEGY_CODE = "page";
+
+    /** Page number of the synthetic single page a format without pages collapses to. */
+    private static final int SINGLE_PAGE_NO = 1;
+
+    private final FixedLengthTextSplitter fixedLengthTextSplitter;
+    private final TokenEstimator tokenEstimator;
+
+    /**
+     * Cuts the parsed document into one chunk per page, falling back to the whole markdown when the
+     * format carried no pages.
+     *
+     * @param parsed   parse artifact, may be {@code null} when none was readable
+     * @param markdown merged markdown, used as the single page of a format without pages
+     * @param params   split parameters
+     * @return ordered chunks, each tagged with its page number
+     */
+    public List<SplitChunk> split(ParsedDocument parsed, String markdown, SplitParams params) {
+        List<ParsedDocument.ParsedPage> pages = parsed == null ? List.of() : parsed.pagesOrEmpty();
+        List<SplitChunk> chunks = new ArrayList<>();
+        int seq = 0;
+        if (CollectionUtils.isEmpty(pages)) {
+            emitPage(SINGLE_PAGE_NO, markdown, params, chunks, seq);
+            return chunks;
+        }
+        for (ParsedDocument.ParsedPage page : pages) {
+            seq = emitPage(page.getPageNo(), page.getText(), params, chunks, seq);
+        }
+        return chunks;
+    }
+
+    /**
+     * Appends the chunks of one page, re-splitting the page when its text exceeds the token budget.
+     *
+     * @param pageNo one based page number
+     * @param text   page text
+     * @param params split parameters
+     * @param chunks accumulator the new chunks are appended to
+     * @param seq    next chunk sequence number
+     * @return sequence number after the appended chunks
+     */
+    private int emitPage(int pageNo, String text, SplitParams params, List<SplitChunk> chunks, int seq) {
+        if (text == null || text.isBlank()) {
+            return seq;
+        }
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ChunkMetadataKeys.PAGE_NO, String.valueOf(pageNo));
+        if (tokenEstimator.estimate(text) <= params.getMaxTokens()) {
+            chunks.add(new SplitChunk(seq++, text.trim(), tokenEstimator.estimate(text.trim()), metadata));
+            return seq;
+        }
+        for (SplitChunk piece : fixedLengthTextSplitter.split(text, params)) {
+            chunks.add(new SplitChunk(seq++, piece.getContent(), piece.getTokenCount(),
+                    new LinkedHashMap<>(metadata)));
+        }
+        return seq;
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/SeparatorTextSplitter.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/SeparatorTextSplitter.java
@@ -1,0 +1,90 @@
+package io.kbrag.domain.service;
+
+import io.kbrag.domain.model.SplitChunk;
+import io.kbrag.domain.model.SplitParams;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Separator splitting strategy, the M14 contract section 4: cuts the text on a literal or regular
+ * expression delimiter and packs the resulting blocks up to the token budget.
+ *
+ * <p>The delimiter itself is not kept - a paragraph break or a row marker carries no retrieval value
+ * once it has done its splitting job. Packing and the over long block fallback are delegated to
+ * {@link FixedLengthTextSplitter#packBlocks}, so this strategy owns only the segmentation and the
+ * fixed length one owns the token accounting exactly once.
+ *
+ * <p>The configuration gate compiles a regular expression delimiter at write time, so a pattern that
+ * reaches here can be trusted; a stored configuration that predates that gate and no longer compiles
+ * degrades to splitting the whole text as one block rather than failing the build, the same direction
+ * the metadata rule extractor takes.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeparatorTextSplitter implements TextSplitter {
+
+    /** Strategy code persisted in the split fingerprint. */
+    public static final String STRATEGY_CODE = "separator";
+
+    /** Delimiter used when the configuration names none, a blank line between paragraphs. */
+    public static final String DEFAULT_SEPARATOR = "\n\n";
+
+    private final FixedLengthTextSplitter fixedLengthTextSplitter;
+
+    @Override
+    public String strategy() {
+        return STRATEGY_CODE;
+    }
+
+    @Override
+    public List<SplitChunk> split(String text, SplitParams params) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        String separator = params.getSeparator() == null || params.getSeparator().isEmpty()
+                ? DEFAULT_SEPARATOR : params.getSeparator();
+        List<String> blocks = toBlocks(text, separator, params.isSeparatorIsRegex());
+        return fixedLengthTextSplitter.packBlocks(blocks, params);
+    }
+
+    /**
+     * Cuts the text on the delimiter, dropping empty blocks so a run of separators does not produce
+     * empty chunks.
+     *
+     * @param text      source text
+     * @param separator delimiter, literal or regular expression
+     * @param isRegex   whether {@code separator} is a regular expression
+     * @return blocks in reading order
+     */
+    private List<String> toBlocks(String text, String separator, boolean isRegex) {
+        Pattern pattern = compile(separator, isRegex);
+        List<String> blocks = new ArrayList<>();
+        for (String block : pattern.split(text, -1)) {
+            if (!block.isBlank()) {
+                blocks.add(block);
+            }
+        }
+        return blocks;
+    }
+
+    private Pattern compile(String separator, boolean isRegex) {
+        if (!isRegex) {
+            return Pattern.compile(Pattern.quote(separator));
+        }
+        try {
+            return Pattern.compile(separator);
+        } catch (Exception e) {
+            log.info("separator strategy pattern no longer compiles, splitting as one block, pattern={}",
+                    separator);
+            return Pattern.compile(Pattern.quote(separator));
+        }
+    }
+}

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/VersionFingerprintFactory.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/VersionFingerprintFactory.java
@@ -2,7 +2,12 @@ package io.kbrag.domain.service;
 
 import io.kbrag.common.util.HashUtil;
 import io.kbrag.domain.model.KbIndexConfig;
+import io.kbrag.domain.model.MetadataRule;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Produces the reuse fingerprints of a document version.
@@ -57,11 +62,40 @@ public class VersionFingerprintFactory {
      * @return hexadecimal digest
      */
     public String chunkFingerprint(KbIndexConfig config) {
-        return HashUtil.sha256Hex(String.join(SEPARATOR,
+        List<String> segments = new ArrayList<>(List.of(
                 "strategy=" + config.getSplitStrategy(),
                 "chunk_max_tokens=" + config.getChunkMaxTokens(),
                 "chunk_overlap=" + config.getChunkOverlap(),
                 config.parentChildOrDisabled().fingerprintSegment()));
+        // Appended only when rules exist: a knowledge base that never declared any keeps the exact
+        // fingerprint it had before M14, so shipping the feature marks nothing configuration stale.
+        if (CollectionUtils.isNotEmpty(config.metadataRulesOrEmpty())) {
+            segments.add("metadata_rules=" + config.metadataRulesOrEmpty().stream()
+                    .map(MetadataRule::fingerprintSegment)
+                    .reduce((left, right) -> left + ";" + right)
+                    .orElse(""));
+        }
+        // Only the strategy that reads a parameter folds it in, for the same reason: a fixed length or
+        // llm_semantic base never carried these keys, so adding them unconditionally would rebuild every
+        // pre-M14 knowledge base for a value it does not use.
+        if (SeparatorTextSplitter.STRATEGY_CODE.equals(config.getSplitStrategy())) {
+            String separator = config.getSplitSeparator() == null || config.getSplitSeparator().isEmpty()
+                    ? SeparatorTextSplitter.DEFAULT_SEPARATOR : config.getSplitSeparator();
+            segments.add("split_separator=" + separator + ";is_regex=" + config.isSplitSeparatorIsRegex());
+        } else if (HeadingTextSplitter.STRATEGY_CODE.equals(config.getSplitStrategy())) {
+            int level = config.getSplitHeadingLevel() < HeadingTextSplitter.MIN_HEADING_LEVEL
+                    || config.getSplitHeadingLevel() > HeadingTextSplitter.MAX_HEADING_LEVEL
+                    ? HeadingTextSplitter.DEFAULT_HEADING_LEVEL : config.getSplitHeadingLevel();
+            segments.add("split_heading_level=" + level);
+        }
+        // Appended only when on, for the same compatibility reason as the metadata rules: a knowledge
+        // base that never turned multimodal indexing on keeps the exact fingerprint it had before M14,
+        // so shipping the feature marks nothing configuration stale, while flipping the switch on marks
+        // every affected document stale so a rebuild backfills or clears the multimodal vectors.
+        if (config.isMultimodalEnabled()) {
+            segments.add("multimodal_enabled=true");
+        }
+        return HashUtil.sha256Hex(String.join(SEPARATOR, segments));
     }
 
     /**

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/config/ModelProviderConfig.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/config/ModelProviderConfig.java
@@ -4,6 +4,7 @@ import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.port.ChatProvider;
 import io.kbrag.domain.port.ChatProviderFactory;
 import io.kbrag.domain.port.EmbeddingProvider;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
 import io.kbrag.domain.port.RerankProvider;
 import io.kbrag.domain.port.VisionProvider;
 import io.kbrag.infrastructure.provider.UnconfiguredChatProvider;
@@ -12,6 +13,8 @@ import io.kbrag.infrastructure.provider.UnconfiguredVisionProvider;
 import io.kbrag.infrastructure.provider.chat.DashScopeChatProvider;
 import io.kbrag.infrastructure.provider.chat.ModelChatProviderFactory;
 import io.kbrag.infrastructure.provider.embedding.DashScopeEmbeddingProvider;
+import io.kbrag.infrastructure.provider.embedding.DashScopeMultimodalEmbeddingProvider;
+import io.kbrag.infrastructure.provider.embedding.NoopMultimodalEmbeddingProvider;
 import io.kbrag.infrastructure.provider.rerank.DashScopeRerankProvider;
 import io.kbrag.infrastructure.provider.embedding.UnconfiguredEmbeddingProvider;
 import io.kbrag.infrastructure.provider.vision.DashScopeVisionProvider;
@@ -50,6 +53,30 @@ public class ModelProviderConfig {
         log.info("embedding provider configured, provider={}, model={}, dimension={}",
                 config.getProvider(), config.getModel(), config.getDimension());
         return new DashScopeEmbeddingProvider(properties);
+    }
+
+    /**
+     * Selects the multimodal embedding provider implementation, the M14 contract section 6.1.
+     *
+     * <p>Configured independently from the text embedding credential: the multimodal capability drives
+     * a separate {@code _mm} index and a separate retrieval route, so a deployment can enable it on top
+     * of an existing text embedding without either one implying the other. A blank key yields the noop
+     * implementation, which makes the index pipeline skip the multimodal vectors and retrieval skip the
+     * third route.
+     *
+     * @param properties bound configuration
+     * @return configured provider, or the noop placeholder in zero key mode
+     */
+    @Bean
+    public MultimodalEmbeddingProvider multimodalEmbeddingProvider(KbProperties properties) {
+        KbProperties.MultimodalEmbedding config = properties.getMultimodalEmbedding();
+        if (config.getApiKey() == null || config.getApiKey().isBlank()) {
+            log.info("multimodal embedding provider not configured, multimodal route disabled");
+            return new NoopMultimodalEmbeddingProvider();
+        }
+        log.info("multimodal embedding provider configured, provider={}, model={}, dimension={}",
+                config.getProvider(), config.getModel(), config.getDimension());
+        return new DashScopeMultimodalEmbeddingProvider(properties);
     }
 
     /**

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/connector/S3CompatibleConnector.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/connector/S3CompatibleConnector.java
@@ -1,0 +1,151 @@
+package io.kbrag.infrastructure.connector;
+
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.model.ExtSourceConfig;
+import io.kbrag.domain.model.HealthStatus;
+import io.kbrag.domain.port.ExternalConnector;
+import io.minio.BucketExistsArgs;
+import io.minio.GetObjectArgs;
+import io.minio.ListObjectsArgs;
+import io.minio.MinioClient;
+import io.minio.Result;
+import io.minio.messages.Item;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * S3/OSS compatible connector, the M14 contract section 2.1, first implementation of the SPI.
+ *
+ * <p>Reuses the MinIO SDK the object storage adapter already depends on: the S3 wire protocol is
+ * what MinIO, OSS and every compatible store speak, so one client covers them all. Unlike
+ * {@code MinioObjectStorage} the client here is built per call from the source's own credentials -
+ * every registered source points at a different store, so there is no bean to share.
+ *
+ * <p>The endpoint is deliberately not passed through the SSRF guard: it is an administrator
+ * configuration value, not end user input, and its legitimate values are exactly the intranet
+ * addresses the guard exists to block.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+public class S3CompatibleConnector implements ExternalConnector {
+
+    /** Routing key stored in {@code t_kb_ext_source.source_type}. */
+    static final String TYPE = "s3";
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+
+    @Override
+    public List<RemoteObject> listObjects(ExtSourceConfig config) {
+        MinioClient client = buildClient(config);
+        List<RemoteObject> objects = new ArrayList<>();
+        // One beyond the cap on purpose: the caller tells a truncated listing from a complete one
+        // by the extra element, without a second remote round trip.
+        int limit = config.maxObjects() + 1;
+        try {
+            Iterable<Result<Item>> results = client.listObjects(ListObjectsArgs.builder()
+                    .bucket(config.bucket())
+                    .prefix(config.prefix() == null ? "" : config.prefix())
+                    .recursive(true)
+                    .build());
+            for (Result<Item> result : results) {
+                Item item = result.get();
+                if (item.isDir()) {
+                    continue;
+                }
+                objects.add(new RemoteObject(
+                        item.objectName(),
+                        stripQuotes(item.etag()),
+                        item.size(),
+                        lastModifiedOf(item)));
+                if (objects.size() >= limit) {
+                    break;
+                }
+            }
+            return objects;
+        } catch (Exception e) {
+            log.error("list objects failed, errorCode={}, bucket={}", ErrorCode.INTERNAL_ERROR, config.bucket(), e);
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "list objects failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public byte[] fetchObject(ExtSourceConfig config, String objectKey) {
+        MinioClient client = buildClient(config);
+        try (InputStream stream = client.getObject(GetObjectArgs.builder()
+                .bucket(config.bucket())
+                .object(objectKey)
+                .build())) {
+            return stream.readAllBytes();
+        } catch (Exception e) {
+            log.error("fetch object failed, errorCode={}, bucket={}, object={}",
+                    ErrorCode.INTERNAL_ERROR, config.bucket(), objectKey, e);
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "fetch object failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public HealthStatus testConnection(ExtSourceConfig config) {
+        try {
+            boolean exists = buildClient(config).bucketExists(BucketExistsArgs.builder()
+                    .bucket(config.bucket())
+                    .build());
+            return exists
+                    ? HealthStatus.up("bucket reachable")
+                    : HealthStatus.down("bucket not found: " + config.bucket());
+        } catch (Exception e) {
+            log.info("ext source connection test failed, bucket={}, reason={}", config.bucket(), e.getMessage());
+            return HealthStatus.down("connection failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Builds a client bound to one source's endpoint and credentials, with the configured budget
+     * applied to connect, read and write alike - the SDK default of five minutes would let one
+     * dead store stall a whole scheduled pass.
+     */
+    private MinioClient buildClient(ExtSourceConfig config) {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .connectTimeout(config.timeoutMs(), TimeUnit.MILLISECONDS)
+                .readTimeout(config.timeoutMs(), TimeUnit.MILLISECONDS)
+                .writeTimeout(config.timeoutMs(), TimeUnit.MILLISECONDS)
+                .build();
+        MinioClient.Builder builder = MinioClient.builder()
+                .endpoint(config.endpoint())
+                .credentials(config.accessKey(), config.secretKey())
+                .httpClient(httpClient);
+        if (config.region() != null && !config.region().isBlank()) {
+            builder.region(config.region());
+        }
+        return builder.build();
+    }
+
+    /** S3 etags arrive wrapped in double quotes; the stored comparison value must not keep them. */
+    private String stripQuotes(String etag) {
+        if (etag == null) {
+            return null;
+        }
+        return etag.replace("\"", "");
+    }
+
+    /** Some stores omit the timestamp in listings; absence must not fail the whole scan. */
+    private LocalDateTime lastModifiedOf(Item item) {
+        try {
+            return item.lastModified() == null ? null : item.lastModified().toLocalDateTime();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/provider/embedding/DashScopeMultimodalEmbeddingProvider.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/provider/embedding/DashScopeMultimodalEmbeddingProvider.java
@@ -1,0 +1,213 @@
+package io.kbrag.infrastructure.provider.embedding;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.ProviderErrorType;
+import io.kbrag.common.exception.ProviderException;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.model.HealthStatus;
+import io.kbrag.domain.model.ImageInput;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
+import io.kbrag.infrastructure.provider.DashScopeHttp;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DashScope multimodal embedding provider driven by plain HTTP, the M14 contract section 6.1.
+ *
+ * <p>Transport choice. Like rerank and unlike text embedding, the multimodal endpoint has no OpenAI
+ * compatible equivalent, so the native path
+ * {@code /api/v1/services/embeddings/multimodal-embedding/multimodal-embedding} is used with its own
+ * envelope: the payload nests a {@code contents} array under {@code input}, each element being either
+ * a {@code text} or an {@code image}, and the answer arrives under {@code output.embeddings} with an
+ * index per element. No vendor SDK is involved.
+ *
+ * <p><b>Why a data URL and not a pre signed link.</b> The same reasoning as the vision provider: the
+ * bucket is private and the model provider sits outside the deployment, so inlining the bytes keeps
+ * the storage private and removes any dependency on the provider reaching this network. Should the
+ * endpoint reject inlined bytes, the fallback documented in the contract is a pre signed URL, which
+ * this class would switch to without touching its port.
+ *
+ * <p>Result alignment. The endpoint answers with an index per embedding and may reorder entries, so
+ * vectors are scattered back into the submitted order and the dimension of each is verified against
+ * the configured one, which turns a silent model mismatch into an actionable failure instead of a
+ * corrupt index.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class DashScopeMultimodalEmbeddingProvider implements MultimodalEmbeddingProvider {
+
+    /** Provider name recorded in the multimodal index registry. */
+    public static final String PROVIDER_NAME = "dashscope";
+
+    private static final String STAGE = "multimodal-embedding";
+    private static final String FIELD_MODEL = "model";
+    private static final String FIELD_INPUT = "input";
+    private static final String FIELD_CONTENTS = "contents";
+    private static final String FIELD_TEXT = "text";
+    private static final String FIELD_IMAGE = "image";
+    private static final String FIELD_OUTPUT = "output";
+    private static final String FIELD_EMBEDDINGS = "embeddings";
+    private static final String FIELD_INDEX = "index";
+    private static final String FIELD_EMBEDDING = "embedding";
+    private static final String DATA_URL_PREFIX = "data:";
+    private static final String DATA_URL_BASE64 = ";base64,";
+    private static final String DEFAULT_MEDIA_TYPE = "image/png";
+    private static final String HEALTH_PROBE_TEXT = "ping";
+
+    private final KbProperties.MultimodalEmbedding config;
+    private final RestClient restClient;
+
+    public DashScopeMultimodalEmbeddingProvider(KbProperties properties) {
+        this.config = properties.getMultimodalEmbedding();
+        this.restClient = DashScopeHttp.client(null, config.getApiKey(), config.getTimeoutMs());
+    }
+
+    @Override
+    public String providerName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public String model() {
+        return config.getModel();
+    }
+
+    @Override
+    public int dimension() {
+        return config.getDimension();
+    }
+
+    @Override
+    public boolean isConfigured() {
+        return true;
+    }
+
+    @Override
+    public int maxBatchSize() {
+        return config.getBatchSize();
+    }
+
+    @Override
+    public List<float[]> embedTexts(List<String> texts) {
+        if (CollectionUtils.isEmpty(texts)) {
+            return List.of();
+        }
+        List<Map<String, Object>> contents = new ArrayList<>(texts.size());
+        for (String text : texts) {
+            contents.add(Map.of(FIELD_TEXT, text));
+        }
+        return embed(contents);
+    }
+
+    @Override
+    public List<float[]> embedImages(List<ImageInput> images) {
+        if (CollectionUtils.isEmpty(images)) {
+            return List.of();
+        }
+        List<Map<String, Object>> contents = new ArrayList<>(images.size());
+        for (ImageInput image : images) {
+            contents.add(Map.of(FIELD_IMAGE, dataUrl(image.content(), image.mediaType())));
+        }
+        return embed(contents);
+    }
+
+    @Override
+    public HealthStatus healthCheck() {
+        try {
+            List<float[]> vectors = embedTexts(List.of(HEALTH_PROBE_TEXT));
+            return HealthStatus.up(config.getModel() + " dim=" + vectors.get(0).length);
+        } catch (ProviderException e) {
+            log.error("multimodal embedding health check failed, errorCode={}, type={}",
+                    e.getErrorCode(), e.getErrorType(), e);
+            return HealthStatus.down(e.getErrorType().name());
+        }
+    }
+
+    /**
+     * Issues one request for a batch of contents and returns the aligned vectors.
+     *
+     * @param contents request items, texts or images, size already bounded by the caller
+     * @return one vector per content in submitted order
+     */
+    private List<float[]> embed(List<Map<String, Object>> contents) {
+        if (contents.size() > maxBatchSize()) {
+            throw new ProviderException(PROVIDER_NAME, ProviderErrorType.UNKNOWN,
+                    "batch size exceeds the provider limit of " + maxBatchSize());
+        }
+        Map<String, Object> input = new LinkedHashMap<>();
+        input.put(FIELD_CONTENTS, contents);
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put(FIELD_MODEL, config.getModel());
+        payload.put(FIELD_INPUT, input);
+
+        String body = DashScopeHttp.post(restClient, config.getUrl(), payload, PROVIDER_NAME, STAGE);
+        return parseVectors(body, contents.size());
+    }
+
+    /**
+     * Scatters the returned embeddings back into the submitted order and verifies each dimension.
+     *
+     * @param body         raw response body
+     * @param expectedSize number of submitted contents
+     * @return one vector per submitted content
+     */
+    private List<float[]> parseVectors(String body, int expectedSize) {
+        JsonNode root = JsonUtil.parse(body, JsonNode.class);
+        JsonNode embeddings = root == null ? null : root.path(FIELD_OUTPUT).path(FIELD_EMBEDDINGS);
+        if (embeddings == null || !embeddings.isArray() || embeddings.size() != expectedSize) {
+            log.error("multimodal embedding response size mismatch, errorCode={}, expected={}",
+                    ErrorCode.UPSTREAM_MODEL_ERROR, expectedSize);
+            throw new ProviderException(PROVIDER_NAME, ProviderErrorType.UNKNOWN,
+                    "multimodal embedding response does not match the request size");
+        }
+        float[][] ordered = new float[expectedSize][];
+        for (JsonNode item : embeddings) {
+            int index = item.path(FIELD_INDEX).asInt(-1);
+            if (index < 0 || index >= expectedSize) {
+                continue;
+            }
+            ordered[index] = vectorOf(item.path(FIELD_EMBEDDING));
+        }
+        List<float[]> vectors = new ArrayList<>(expectedSize);
+        for (float[] vector : ordered) {
+            if (vector == null) {
+                log.error("multimodal embedding response missing an entry, errorCode={}, expected={}",
+                        ErrorCode.UPSTREAM_MODEL_ERROR, expectedSize);
+                throw new ProviderException(PROVIDER_NAME, ProviderErrorType.UNKNOWN,
+                        "multimodal embedding response is missing an entry");
+            }
+            vectors.add(vector);
+        }
+        return vectors;
+    }
+
+    private float[] vectorOf(JsonNode embedding) {
+        float[] vector = new float[embedding.size()];
+        for (int i = 0; i < embedding.size(); i++) {
+            vector[i] = (float) embedding.get(i).asDouble();
+        }
+        if (vector.length != config.getDimension()) {
+            log.error("multimodal embedding dimension mismatch, errorCode={}, expected={}, actual={}",
+                    ErrorCode.UPSTREAM_MODEL_ERROR, config.getDimension(), vector.length);
+            throw new ProviderException(PROVIDER_NAME, ProviderErrorType.DIMENSION_MISMATCH,
+                    "model returned dimension " + vector.length
+                            + " while the index expects " + config.getDimension());
+        }
+        return vector;
+    }
+
+    private String dataUrl(byte[] content, String mediaType) {
+        String type = mediaType == null || mediaType.isBlank() ? DEFAULT_MEDIA_TYPE : mediaType;
+        return DATA_URL_PREFIX + type + DATA_URL_BASE64 + Base64.getEncoder().encodeToString(content);
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/provider/embedding/NoopMultimodalEmbeddingProvider.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/provider/embedding/NoopMultimodalEmbeddingProvider.java
@@ -1,0 +1,70 @@
+package io.kbrag.infrastructure.provider.embedding;
+
+import io.kbrag.common.exception.ProviderErrorType;
+import io.kbrag.common.exception.ProviderException;
+import io.kbrag.domain.model.HealthStatus;
+import io.kbrag.domain.model.ImageInput;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
+
+import java.util.List;
+
+/**
+ * Multimodal embedding provider used when no credential is configured, the M14 contract section 6.1.
+ *
+ * <p>Reporting the missing configuration through the same port instead of leaving the bean absent
+ * keeps every collaborator free of null checks: the index pipeline asks {@link #isConfigured()} once
+ * and skips the multimodal vectors, and retrieval skips the third route. Calling {@link #embedTexts}
+ * or {@link #embedImages} is a programming error and fails fast.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public class NoopMultimodalEmbeddingProvider implements MultimodalEmbeddingProvider {
+
+    /** Provider name recorded in the multimodal index registry and physical index name. */
+    public static final String PROVIDER_NAME = "none";
+
+    /** Model placeholder reported by the model status endpoint. */
+    public static final String MODEL_NAME = "none";
+
+    @Override
+    public String providerName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public String model() {
+        return MODEL_NAME;
+    }
+
+    @Override
+    public int dimension() {
+        return 0;
+    }
+
+    @Override
+    public boolean isConfigured() {
+        return false;
+    }
+
+    @Override
+    public int maxBatchSize() {
+        return 0;
+    }
+
+    @Override
+    public List<float[]> embedTexts(List<String> texts) {
+        throw new ProviderException(PROVIDER_NAME, ProviderErrorType.AUTH_FAILED,
+                "no multimodal embedding provider configured");
+    }
+
+    @Override
+    public List<float[]> embedImages(List<ImageInput> images) {
+        throw new ProviderException(PROVIDER_NAME, ProviderErrorType.AUTH_FAILED,
+                "no multimodal embedding provider configured");
+    }
+
+    @Override
+    public HealthStatus healthCheck() {
+        return HealthStatus.down("multimodal embedding provider not configured");
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/search/es/EsIndexAdmin.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/search/es/EsIndexAdmin.java
@@ -3,6 +3,7 @@ package io.kbrag.infrastructure.search.es;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.mapping.DynamicTemplate;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
@@ -24,6 +25,7 @@ import io.kbrag.domain.model.RetrievalFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -51,6 +53,9 @@ public class EsIndexAdmin {
     private static final String SIMILARITY_COSINE = "cosine";
     private static final String ERROR_ALREADY_EXISTS = "resource_already_exists_exception";
 
+    /** Name of the dynamic template that maps every {@code ext_*} field to a keyword. */
+    private static final String EXT_TEMPLATE_NAME = "ext_metadata";
+
     /** Bulk item status of a partial update whose document does not exist. */
     private static final int STATUS_NOT_FOUND = 404;
 
@@ -67,6 +72,13 @@ public class EsIndexAdmin {
             boolean exists = client.indices().exists(b -> b.index(spec.getPhysicalIndexName())).value();
             if (!exists) {
                 createIndex(spec);
+            } else {
+                // Idempotent template refresh for indexes created before M14: without it a rebuild that
+                // starts writing ext_ fields into an old physical index would let the default dynamic
+                // mapping type them as text, and every equality filter on them would silently miss.
+                client.indices().putMapping(request -> request
+                        .index(spec.getPhysicalIndexName())
+                        .dynamicTemplates(extDynamicTemplates()));
             }
             pointAliasAtSingleIndex(spec);
             log.info("es index ready, index={}, alias={}, vectorField={}",
@@ -371,6 +383,13 @@ public class EsIndexAdmin {
                 return r;
             })));
         }
+        if (MapUtils.isNotEmpty(metadata.getCustom())) {
+            // Equality per entry, AND across entries; a keyword_match key holds an array and a term
+            // query on a keyword array matches when any element equals, which is exactly the
+            // "array contains" semantics the M14 contract section 3.3 asks for.
+            metadata.getCustom().forEach((key, value) -> filters.add(
+                    Query.of(q -> q.term(t -> t.field(IndexFields.EXT_PREFIX + key).value(value)))));
+        }
     }
 
     private Query termsQuery(String field, List<String> values) {
@@ -424,8 +443,23 @@ public class EsIndexAdmin {
                         .numberOfReplicas(replicas))
                 .mappings(mappings -> mappings
                         .properties(mappingProperties)
+                        .dynamicTemplates(extDynamicTemplates())
                         .meta(META_SCHEMA_VERSION, JsonData.of(spec.getSchemaVersion()))));
         log.info("es index created, index={}, analyzer={}", spec.getPhysicalIndexName(), analyzer);
+    }
+
+    /**
+     * Declares the {@code ext_*} namespace of the operator extracted metadata, the M14 contract
+     * section 3.2: the keys are chosen per knowledge base at configuration time, so they cannot be
+     * part of the fixed field list and a dynamic template types them instead.
+     *
+     * @return single entry template list in the shape the mapping API expects
+     */
+    private List<Map<String, DynamicTemplate>> extDynamicTemplates() {
+        DynamicTemplate template = DynamicTemplate.of(t -> t
+                .match(IndexFields.EXT_PREFIX + "*")
+                .mapping(keyword()));
+        return List.of(Map.of(EXT_TEMPLATE_NAME, template));
     }
 
     /**
@@ -481,6 +515,9 @@ public class EsIndexAdmin {
         document.put(IndexFields.MSG_TIME, record.getMsgTime());
         document.put(IndexFields.CHUNK_SEQ, record.getChunkSeq());
         document.put(IndexFields.CONTENT, record.getContent());
+        if (MapUtils.isNotEmpty(record.getExtMetadata())) {
+            document.putAll(record.getExtMetadata());
+        }
         if (record.getVector() != null) {
             document.put(IndexFields.VECTOR, toFloatList(record.getVector()));
         }

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/search/qdrant/QdrantVectorStore.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/search/qdrant/QdrantVectorStore.java
@@ -17,6 +17,7 @@ import io.kbrag.domain.port.VectorStore;
 import io.kbrag.domain.service.VectorScoreNormalizer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -425,6 +426,12 @@ public class QdrantVectorStore implements VectorStore {
             }
             conditions.add(Map.of("key", IndexFields.MSG_TIME, "range", range));
         }
+        if (MapUtils.isNotEmpty(metadata.getCustom())) {
+            // Equality per entry, AND across entries; a match on an array payload matches when any
+            // element equals, which is the "array contains" semantics of a keyword_match key.
+            metadata.getCustom().forEach((key, value) ->
+                    conditions.add(matchValue(IndexFields.EXT_PREFIX + key, value)));
+        }
     }
 
     private Map<String, Object> matchValue(String field, Object value) {
@@ -472,6 +479,11 @@ public class QdrantVectorStore implements VectorStore {
         payload.put(IndexFields.MSG_TIME, record.getMsgTime() == null ? 0L : record.getMsgTime());
         payload.put(IndexFields.CHUNK_SEQ, record.getChunkSeq() == null ? 0 : record.getChunkSeq());
         payload.put(IndexFields.CONTENT, truncate(record.getContent()));
+        if (MapUtils.isNotEmpty(record.getExtMetadata())) {
+            // Unindexed payload entries: Qdrant filters them by scanning, and the operator chosen key
+            // set is unknown at collection provisioning time, so no per key index is created.
+            payload.putAll(record.getExtMetadata());
+        }
         return payload;
     }
 

--- a/kb-rag-web/src/api/document.ts
+++ b/kb-rag-web/src/api/document.ts
@@ -12,6 +12,8 @@ import type {
 export interface ListDocumentsParams {
   process_status?: ProcessStatus;
   page?: number;
+  /** 页大小，缺省由服务端取 DEFAULT_PAGE_SIZE（20）。 */
+  size?: number;
 }
 
 export function listDocuments(kbId: string, params?: ListDocumentsParams): Promise<PageResult<KbDocument>> {

--- a/kb-rag-web/src/api/extSource.ts
+++ b/kb-rag-web/src/api/extSource.ts
@@ -1,0 +1,65 @@
+// Author: owlzhangfq@gmail.com
+import { apiDelete, apiGet, apiPost, apiPut } from './request';
+import type {
+  ExtSource,
+  ExtSourceItem,
+  ExtSourceSyncAccepted,
+  ExtSourceTestResult,
+  PageResult,
+  RegisterExtSourceRequest,
+  UpdateExtSourceRequest,
+} from './types';
+
+/**
+ * POST /api/v1/kb/{kbId}/ext-sources (M14 contract section 2.3): registers one object-store source
+ * and hands its first scan to the executor. Unlike the single-page web import, a bucket holds an
+ * unbounded number of objects, so the request returns the registration row at once -- the first
+ * scan's outcome appears on the row (and its item rows) once the scan finishes, watched by re-listing.
+ */
+export function registerExtSource(kbId: string, payload: RegisterExtSourceRequest): Promise<ExtSource> {
+  return apiPost<ExtSource>(`/kb/${kbId}/ext-sources`, payload);
+}
+
+/** GET /api/v1/kb/{kbId}/ext-sources (M14 contract section 2.3), most recently registered first. */
+export function listExtSources(kbId: string, page = 1, size = 20): Promise<PageResult<ExtSource>> {
+  return apiGet<PageResult<ExtSource>>(`/kb/${kbId}/ext-sources`, { page, size });
+}
+
+/**
+ * POST /api/v1/ext-sources/{sourceId}/sync (M14 contract section 2.3): accepts one on-demand scan.
+ * The scan runs off the request thread, so this only acknowledges acceptance -- the outcome lands
+ * on the source and item rows.
+ */
+export function syncExtSource(sourceId: string): Promise<ExtSourceSyncAccepted> {
+  return apiPost<ExtSourceSyncAccepted>(`/ext-sources/${sourceId}/sync`);
+}
+
+/** GET /api/v1/ext-sources/{sourceId}/items (M14 contract section 2.3): per-object sync outcomes. */
+export function listExtSourceItems(sourceId: string, page = 1, size = 20): Promise<PageResult<ExtSourceItem>> {
+  return apiGet<PageResult<ExtSourceItem>>(`/ext-sources/${sourceId}/items`, { page, size });
+}
+
+/**
+ * PUT /api/v1/ext-sources/{sourceId} (M14 contract section 2.3): edits connection details. A blank
+ * or omitted secret_key keeps the stored credential (the read API always masks it).
+ */
+export function updateExtSource(sourceId: string, payload: UpdateExtSourceRequest): Promise<ExtSource> {
+  return apiPut<ExtSource>(`/ext-sources/${sourceId}`, payload);
+}
+
+/**
+ * POST /api/v1/ext-sources/{sourceId}/test (M14 contract section 2.3): probes connectivity and
+ * credentials without touching any object. `up` is false with a detail string when the store did
+ * not answer or the bucket does not exist.
+ */
+export function testExtSource(sourceId: string): Promise<ExtSourceTestResult> {
+  return apiPost<ExtSourceTestResult>(`/ext-sources/${sourceId}/test`);
+}
+
+/**
+ * DELETE /api/v1/ext-sources/{sourceId} (M14 contract section 2.3): removes the source and its item
+ * rows only -- the documents they fed stay in the knowledge base (weak binding).
+ */
+export function removeExtSource(sourceId: string): Promise<void> {
+  return apiDelete<void>(`/ext-sources/${sourceId}`);
+}

--- a/kb-rag-web/src/api/types.ts
+++ b/kb-rag-web/src/api/types.ts
@@ -50,15 +50,16 @@ export interface CurrentUser {
 // ---------------------------------------------------------------------------
 
 /**
- * index_config.split_strategy: the splitter the indexing pipeline routes to. Mirrors the server's
- * SplitStrategy enum, which currently has exactly these TWO members -- the requirements doc
- * describes six splitting strategies, but only fixed-length and LLM-semantic are implemented
- * (parent/child is orthogonal: it is its own switch, applied on top of whichever strategy runs).
+ * index_config.split_strategy: the splitter the indexing pipeline routes to (M14 contract
+ * section 4). Five strategies exist server-side, one per TextSplitter STRATEGY_CODE:
+ * `separator` cuts on a literal or regex block delimiter, `heading` cuts on a Markdown heading
+ * depth, `page` keeps one chunk per source page. Parent/child is orthogonal: it is its own
+ * switch, applied on top of whichever strategy runs.
  *
  * `llm_semantic` requires a configured chat model; saving it without one is rejected server-side
  * with INVALID_PARAM ("the LLM semantic split strategy requires a configured chat model").
  */
-export type SplitStrategy = 'fixed_length' | 'llm_semantic';
+export type SplitStrategy = 'fixed_length' | 'llm_semantic' | 'separator' | 'heading' | 'page';
 
 /** M2-CONTRACTS.md section 1.4: parent/child two-level chunking switch and lengths. */
 export interface ParentChildConfig {
@@ -123,6 +124,27 @@ export interface ChatAggregationConfig {
 }
 
 /**
+ * M14 contract section 3.1: one metadata_rules entry (server MetadataRule). `constant` stamps a
+ * fixed value on every chunk, `regex` captures the first group of a pattern out of the chunk text,
+ * `keyword_match` records which words of a vocabulary the chunk contains. key must match
+ * ^[a-z][a-z0-9_]{1,31}$; value belongs to `constant`, pattern to `regex`, keywords to
+ * `keyword_match` -- the other two stay absent per type.
+ */
+export type MetadataRuleType = 'constant' | 'regex' | 'keyword_match';
+
+/** One operator declared metadata extraction rule of index_config.metadata_rules. */
+export interface MetadataRule {
+  key: string;
+  type: MetadataRuleType;
+  /** `constant` only: the fixed value stamped on every chunk. */
+  value?: string;
+  /** `regex` only: pattern source, at most 64 chars server-side. */
+  pattern?: string;
+  /** `keyword_match` only: vocabulary, at most 50 words of at most 32 chars each. */
+  keywords?: string[];
+}
+
+/**
  * t_kb_knowledge_base.index_config JSON (M1-CONTRACTS.md section 2). Field names verified against
  * the server's KbIndexConfig (2026-07-27).
  */
@@ -133,6 +155,30 @@ export interface IndexConfig {
    * rejected with INVALID_PARAM rather than silently ignored.
    */
   split_strategy?: SplitStrategy;
+  /**
+   * M14 contract section 4: block delimiter of the `separator` strategy. null/absent lets the
+   * strategy fall back to its own default; ignored by every other strategy.
+   */
+  split_separator?: string;
+  /** M14 contract section 4: whether split_separator is a regular expression (`separator` strategy). */
+  split_separator_is_regex?: boolean;
+  /**
+   * M14 contract section 4: Markdown heading depth of the `heading` strategy. 0/absent lets the
+   * strategy fall back to its own default depth; ignored by every other strategy.
+   */
+  split_heading_level?: number;
+  /**
+   * M14 contract section 3.1: operator declared metadata extraction rules, at most 10. Empty/absent
+   * = current behaviour (no operator metadata stamped). Participates in the chunk fingerprint, so
+   * editing marks the affected documents config_stale.
+   */
+  metadata_rules?: MetadataRule[];
+  /**
+   * M14 contract section 6.2: turns on the multimodal vector route for this KB. Default false so
+   * shipping the feature changes nothing. Participates in the chunk fingerprint, so flipping marks
+   * the affected documents config_stale.
+   */
+  multimodal_enabled?: boolean;
   /** Embedding model the current index was built with; server-assigned, never sent back on a PUT. */
   embedding_model?: string;
   chunk_max_tokens: number;
@@ -335,6 +381,11 @@ export interface MetadataFilter {
   msg_time_from?: number;
   /** epoch millis, inclusive upper bound. */
   msg_time_to?: number;
+  /**
+   * M14 contract section 3.3: equality predicates on operator extracted metadata, keyed by the raw
+   * rule key (each key must match ^[a-z][a-z0-9_]{1,31}$, else the search is rejected INVALID_PARAM).
+   */
+  custom?: Record<string, string>;
 }
 
 /**
@@ -461,8 +512,21 @@ export interface RetrievalNode {
   preview_url: string | null;
 }
 
+/**
+ * M14 contract section 5: rerank ordering mode. `semantic` is the pre-M14 behaviour (order by the
+ * rerank model score alone); `hybrid` blends the rerank score with the fusion score by
+ * rerank_w_semantic. Default `semantic` when absent.
+ */
+export type RerankMode = 'semantic' | 'hybrid';
+
 export interface SearchRequest {
   query: string;
+  /**
+   * M14 contract section 7: base64 encoded images attached to the query for image-to-image /
+   * multimodal recall. Absent/empty = text-only search (pre-M14 behaviour). Bounded and validated
+   * server-side by the image gate; images that cannot be embedded are dropped with a degraded marker.
+   */
+  images?: string[];
   recall_top_k: number;
   top_n: number;
   /** 0.01-1.0, omit/null = no filtering (M2-CONTRACTS.md section 1.3). */
@@ -470,6 +534,13 @@ export interface SearchRequest {
   fusion?: FusionConfig;
   /** Default true when a rerank model is configured (M2-CONTRACTS.md section 1.5). */
   rerank_enabled?: boolean;
+  /** M14 contract section 5: rerank ordering mode, default `semantic`. */
+  rerank_mode?: RerankMode;
+  /**
+   * M14 contract section 5: semantic weight of the `hybrid` rerank mode, within [0,1] (the fusion
+   * weight is its complement). Only meaningful when rerank_mode = 'hybrid'.
+   */
+  rerank_w_semantic?: number;
   /** Default false (M2-CONTRACTS.md section 1.5). */
   rewrite_enabled?: boolean;
   messages?: ChatMessage[];
@@ -536,6 +607,15 @@ export interface ModelStatus {
   vision_configured: boolean;
   vision_provider: string | null;
   vision_model: string | null;
+  /**
+   * M14 contract section 6.2: whether a multimodal embedding provider is configured. When false the
+   * console greys out the KB-level "多模态整页索引" switch (the switch still stores, but indexing is
+   * skipped, the same zero-key tolerance the text vector route has). Optional so pre-M14 fixtures
+   * still type-check; the server always emits it.
+   */
+  multimodal_configured?: boolean;
+  multimodal_provider?: string | null;
+  multimodal_model?: string | null;
 }
 
 /** View model assembled from the flat ModelStatus fields, one per model capability. */
@@ -1901,4 +1981,110 @@ export interface RegisterWebSourceRequest {
   /** Defaults to true server-side when omitted. */
   sync_enabled?: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// External data source connector (M14 contract section 2.3): S3/OSS compatible
+// object store, scanned into the knowledge base as documents.
+// ---------------------------------------------------------------------------
+
+/**
+ * ExtSourceResponse.last_sync_status (M14 contract section 2.3): outcome of the last whole-source
+ * sync pass. PARTIAL means the scan ran but at least one object failed/was skipped; the per-object
+ * detail lives on the item rows. null before the first sync.
+ */
+export type ExtSourceSyncStatus = 'SUCCESS' | 'PARTIAL' | 'FAILED';
+
+/**
+ * ExtSourceItemResponse.last_status (M14 contract section 2.3): per-object outcome of the last
+ * sync visit. UNCHANGED (etag identical) and SKIPPED (bound document in the recycle bin) are
+ * deliberate non-writes, not failures. null before the first visit.
+ */
+export type ExtSourceItemStatus = 'SUCCESS' | 'UNCHANGED' | 'SKIPPED' | 'FAILED';
+
+/**
+ * t_kb_ext_source row (M14 contract section 2.3): one registered object-store source and the
+ * outcome of its last sync pass. secret_key is always the fixed mask on the way out; the update
+ * endpoint treats a blank secret as "keep the stored one" so this view round-trips through an edit
+ * form without destroying the credential. Binding is weak -- removing the source never touches the
+ * documents it fed.
+ */
+export interface ExtSource {
+  source_id: string;
+  kb_id: string;
+  /** Connector type routing key, `s3` in this milestone. */
+  source_type: string;
+  name: string;
+  endpoint: string;
+  region: string | null;
+  bucket: string;
+  prefix: string | null;
+  access_key: string;
+  /** Fixed mask ("******"), never the stored value. */
+  secret_key: string;
+  sync_enabled: boolean;
+  last_sync_status: ExtSourceSyncStatus | null;
+  last_sync_at: string | null;
+  last_error: string | null;
+  created_at: string;
+}
+
+/** t_kb_ext_source_item row (M14 contract section 2.3): per-object sync outcome of one source. */
+export interface ExtSourceItem {
+  object_key: string;
+  /** Change marker of the last ingested body; null before the first ingest. */
+  etag: string | null;
+  /** Document the object feeds; null until the first successful ingest. */
+  doc_id: string | null;
+  last_status: ExtSourceItemStatus | null;
+  last_error: string | null;
+  last_sync_at: string | null;
+  created_at: string;
+}
+
+/** POST /api/v1/kb/{kbId}/ext-sources request body (M14 contract section 2.3). */
+export interface RegisterExtSourceRequest {
+  /** Connector type routing key, `s3` in this milestone. */
+  source_type: string;
+  name: string;
+  endpoint: string;
+  region?: string;
+  bucket: string;
+  prefix?: string;
+  access_key: string;
+  secret_key: string;
+  /** Defaults to true server-side when omitted. */
+  sync_enabled?: boolean;
+}
+
+/**
+ * PUT /api/v1/ext-sources/{sourceId} request body (M14 contract section 2.3): edits connection
+ * details. No source_type -- the connector type is fixed at registration. A blank/absent secret_key
+ * keeps the stored one; sync_enabled absent keeps current.
+ */
+export interface UpdateExtSourceRequest {
+  name: string;
+  endpoint: string;
+  region?: string;
+  bucket: string;
+  prefix?: string;
+  access_key: string;
+  secret_key?: string;
+  sync_enabled?: boolean;
+}
+
+/**
+ * POST /api/v1/ext-sources/{sourceId}/sync response (M14 contract section 2.3): the scan runs off
+ * the request thread, so this only acknowledges acceptance -- the outcome lands on the source and
+ * item rows, watched by re-listing.
+ */
+export interface ExtSourceSyncAccepted {
+  accepted: boolean;
+}
+
+/** POST /api/v1/ext-sources/{sourceId}/test response (M14 contract section 2.3): connection probe. */
+export interface ExtSourceTestResult {
+  up: boolean;
+  detail: string;
+}
+
 

--- a/kb-rag-web/src/pages/kb/KbDetailPage.tsx
+++ b/kb-rag-web/src/pages/kb/KbDetailPage.tsx
@@ -58,11 +58,19 @@ import WebSourcesTab from './components/WebSourcesTab';
 // each targeted document's config_stale flag flip back to false.
 const POLL_INTERVAL_MS = 3000;
 
+// 与 DocumentController 的 DEFAULT_PAGE_SIZE 对齐：首屏不传 size 时服务端就按 20 返回，
+// 前端跟着写 20 才不会出现"表格标了每页 10 条、实际拿回 20 条"的错位。
+const DEFAULT_DOC_PAGE_SIZE = 20;
+const DOC_PAGE_SIZE_OPTIONS = ['20', '50', '100'];
+
 export default function KbDetailPage() {
   const { kbId } = useParams<{ kbId: string }>();
   const navigate = useNavigate();
   const [kb, setKb] = useState<KnowledgeBase | null>(null);
   const [documents, setDocuments] = useState<KbDocument[]>([]);
+  const [docPage, setDocPage] = useState(1);
+  const [docPageSize, setDocPageSize] = useState(DEFAULT_DOC_PAGE_SIZE);
+  const [docTotal, setDocTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [chunkDoc, setChunkDoc] = useState<KbDocument | null>(null);
   const [previewDoc, setPreviewDoc] = useState<KbDocument | null>(null);
@@ -87,10 +95,32 @@ export default function KbDetailPage() {
     setKb(detail);
   }, [kbId]);
 
-  const loadDocuments = useCallback(async () => {
+  /**
+   * 翻页状态放在 ref 里而不是进 useCallback 依赖：这个函数有二十余处无参调用（上传、删除、
+   * 重建、各 Tab 的回调），若依赖 page 就会在每次翻页时重建，连带把挂载时那个 useEffect
+   * 再跑一遍。无参调用的语义因此是"刷新当前页"，翻页则显式传页码。
+   */
+  const docPageRef = useRef(1);
+  const docPageSizeRef = useRef(DEFAULT_DOC_PAGE_SIZE);
+
+  const loadDocuments = useCallback(async (page?: number, size?: number) => {
     if (!kbId) return;
-    const result = await listDocuments(kbId);
+    const targetPage = page ?? docPageRef.current;
+    const targetSize = size ?? docPageSizeRef.current;
+    const result = await listDocuments(kbId, { page: targetPage, size: targetSize });
+    // 删掉末页最后一条后该页会空掉，此时按 total 直接跳到真正的末页——逐页回退在页码
+    // 远超范围时会递归几十次，而服务端对越界页码只是返回空列表、并不纠正 page
+    const lastPage = Math.max(1, Math.ceil(result.total / targetSize));
+    if (result.items.length === 0 && targetPage > lastPage) {
+      await loadDocuments(lastPage, targetSize);
+      return;
+    }
     setDocuments(result.items);
+    setDocTotal(result.total);
+    docPageRef.current = result.page;
+    docPageSizeRef.current = result.size;
+    setDocPage(result.page);
+    setDocPageSize(result.size);
   }, [kbId]);
 
   useEffect(() => {
@@ -354,7 +384,7 @@ export default function KbDetailPage() {
                   </p>
                   <p className="ant-upload-text">点击或拖拽文件到此处上传</p>
                   <p className="ant-upload-hint">
-                    支持 pdf / docx / txt / md / xlsx / csv / html，单文件不超过 100MB，可批量上传
+                    支持 pdf / docx / txt / md / sql / xlsx / csv / html，单文件不超过 100MB，可批量上传
                   </p>
                 </Upload.Dragger>
 
@@ -362,7 +392,15 @@ export default function KbDetailPage() {
                   rowKey="doc_id"
                   loading={loading}
                   dataSource={documents}
-                  pagination={false}
+                  pagination={{
+                    current: docPage,
+                    pageSize: docPageSize,
+                    total: docTotal,
+                    showSizeChanger: true,
+                    pageSizeOptions: DOC_PAGE_SIZE_OPTIONS,
+                    showTotal: (total, range) => `第 ${range[0]}-${range[1]} 条，共 ${total} 个文档`,
+                    onChange: (page, size) => loadDocuments(page, size),
+                  }}
                   rowSelection={{
                     selectedRowKeys: selectedPendingIds,
                     onChange: (keys) => setSelectedPendingIds(keys as string[]),

--- a/kb-rag-web/src/pages/kb/KbDetailPage.tsx
+++ b/kb-rag-web/src/pages/kb/KbDetailPage.tsx
@@ -41,6 +41,7 @@ import { formatFileSize } from '../../utils/format';
 import { PROCESS_STATUS_META, metaOf } from '../../utils/statusMeta';
 import ChatImportWizard from './components/ChatImportWizard';
 import ChunkDrawer from './components/ChunkDrawer';
+import ExternalSourceTab from './components/ExternalSourceTab';
 import FeedbackTab from './components/FeedbackTab';
 import { RejectModal, ValidityModal } from './components/GovernanceModals';
 import GraphTab from './components/GraphTab';
@@ -536,6 +537,12 @@ export default function KbDetailPage() {
             key: 'webSources',
             label: '网页导入',
             children: kbId ? <WebSourcesTab kbId={kbId} onSynced={loadDocuments} /> : null,
+          },
+          // M14 contract section 2.3: S3/OSS compatible object store connector + per-object sync.
+          {
+            key: 'extSources',
+            label: '外部数据源',
+            children: kbId ? <ExternalSourceTab kbId={kbId} onSynced={loadDocuments} /> : null,
           },
         ]}
       />

--- a/kb-rag-web/src/pages/kb/components/ExternalSourceTab.tsx
+++ b/kb-rag-web/src/pages/kb/components/ExternalSourceTab.tsx
@@ -1,0 +1,494 @@
+// Author: owlzhangfq@gmail.com
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Button,
+  Drawer,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from 'antd';
+import {
+  listExtSourceItems,
+  listExtSources,
+  registerExtSource,
+  removeExtSource,
+  syncExtSource,
+  testExtSource,
+  updateExtSource,
+} from '../../../api/extSource';
+import type {
+  ExtSource,
+  ExtSourceItem,
+  ExtSourceItemStatus,
+  ExtSourceSyncStatus,
+  RegisterExtSourceRequest,
+} from '../../../api/types';
+import {
+  EXT_SOURCE_ITEM_STATUS_META,
+  EXT_SOURCE_SYNC_STATUS_META,
+  metaOf,
+} from '../../../utils/statusMeta';
+
+interface ExternalSourceTabProps {
+  kbId: string;
+  /** Fired after a sync that may have created/updated documents, so the parent refreshes the list. */
+  onSynced: () => void;
+}
+
+const PAGE_SIZE = 20;
+
+/** The only connector type this milestone ships; the picker stays single-option and disabled. */
+const SOURCE_TYPE_S3 = 's3';
+
+/** Shape the register/edit form binds to; secret_key is optional on edit (blank keeps the stored one). */
+interface SourceFormValues {
+  name: string;
+  endpoint: string;
+  region?: string;
+  bucket: string;
+  prefix?: string;
+  access_key: string;
+  secret_key?: string;
+  sync_enabled: boolean;
+}
+
+/**
+ * 外部数据源 tab of the KB detail page (M14 contract section 2.3): register an S3/OSS compatible
+ * object store, watch its sync outcome down to the object, trigger a scan, test the connection,
+ * edit, remove. Unlike the single-page web import, a scan runs off the request thread over an
+ * unbounded bucket, so sync only acknowledges acceptance -- the outcome lands on the rows later and
+ * the list is re-read (or refreshed by hand) to see it. Removing a source keeps the documents it fed.
+ */
+export default function ExternalSourceTab({ kbId, onSynced }: ExternalSourceTabProps) {
+  const [items, setItems] = useState<ExtSource[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // source_id of the row whose sync/test/toggle/remove request is in flight, to scope the spinners.
+  const [actingId, setActingId] = useState<string | null>(null);
+  // null while the modal is closed; the row being edited, or a sentinel for a fresh registration.
+  const [editing, setEditing] = useState<ExtSource | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  // The source whose per-object item rows the drawer is showing, null while it is closed.
+  const [itemsSource, setItemsSource] = useState<ExtSource | null>(null);
+  const [form] = Form.useForm<SourceFormValues>();
+
+  const load = useCallback(async (targetPage: number) => {
+    setLoading(true);
+    try {
+      const result = await listExtSources(kbId, targetPage);
+      setItems(result.items);
+      setTotal(result.total);
+      setPage(targetPage);
+    } finally {
+      setLoading(false);
+    }
+  }, [kbId]);
+
+  useEffect(() => {
+    load(1);
+  }, [load]);
+
+  const openCreate = () => {
+    setEditing(null);
+    form.resetFields();
+    form.setFieldsValue({ sync_enabled: true });
+    setModalOpen(true);
+  };
+
+  const openEdit = (row: ExtSource) => {
+    setEditing(row);
+    form.setFieldsValue({
+      name: row.name,
+      endpoint: row.endpoint,
+      region: row.region ?? undefined,
+      bucket: row.bucket,
+      prefix: row.prefix ?? undefined,
+      access_key: row.access_key,
+      // The read API always masks the secret, so an edit form has nothing real to echo back.
+      secret_key: undefined,
+      sync_enabled: row.sync_enabled,
+    });
+    setModalOpen(true);
+  };
+
+  const handleSubmit = async (values: SourceFormValues) => {
+    setSaving(true);
+    try {
+      if (editing) {
+        await updateExtSource(editing.source_id, {
+          name: values.name.trim(),
+          endpoint: values.endpoint.trim(),
+          region: values.region?.trim() || undefined,
+          bucket: values.bucket.trim(),
+          prefix: values.prefix?.trim() || undefined,
+          access_key: values.access_key.trim(),
+          // Blank keeps the stored secret; only send a new one when the operator typed it.
+          secret_key: values.secret_key?.trim() || undefined,
+          sync_enabled: values.sync_enabled,
+        });
+        message.success('已更新数据源');
+      } else {
+        const payload: RegisterExtSourceRequest = {
+          source_type: SOURCE_TYPE_S3,
+          name: values.name.trim(),
+          endpoint: values.endpoint.trim(),
+          region: values.region?.trim() || undefined,
+          bucket: values.bucket.trim(),
+          prefix: values.prefix?.trim() || undefined,
+          access_key: values.access_key.trim(),
+          secret_key: values.secret_key!.trim(),
+          sync_enabled: values.sync_enabled,
+        };
+        await registerExtSource(kbId, payload);
+        message.success('已登记数据源，首次扫描已在后台开始');
+      }
+      setModalOpen(false);
+      load(editing ? page : 1);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSync = async (row: ExtSource) => {
+    setActingId(row.source_id);
+    try {
+      await syncExtSource(row.source_id);
+      message.info('已提交同步，扫描在后台进行，稍后刷新查看结果');
+      // The outcome lands on the rows later; nudge the parent so newly ingested docs surface too.
+      onSynced();
+      load(page);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleTest = async (row: ExtSource) => {
+    setActingId(row.source_id);
+    try {
+      const result = await testExtSource(row.source_id);
+      if (result.up) {
+        message.success(`连接正常：${result.detail}`);
+      } else {
+        message.error(`连接失败：${result.detail}`);
+      }
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleToggle = async (row: ExtSource, enabled: boolean) => {
+    setActingId(row.source_id);
+    try {
+      // The update endpoint keeps the stored secret on a blank one, so a bare toggle is safe.
+      await updateExtSource(row.source_id, {
+        name: row.name,
+        endpoint: row.endpoint,
+        region: row.region ?? undefined,
+        bucket: row.bucket,
+        prefix: row.prefix ?? undefined,
+        access_key: row.access_key,
+        sync_enabled: enabled,
+      });
+      message.success(enabled ? '已开启定时同步' : '已关闭定时同步');
+      load(page);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleRemove = async (row: ExtSource) => {
+    setActingId(row.source_id);
+    try {
+      await removeExtSource(row.source_id);
+      message.success('已移除数据源，已入库的文档保持不变');
+      load(page);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  return (
+    <>
+      <Typography.Paragraph type="secondary">
+        登记 S3/OSS 兼容对象存储后，系统按前缀扫描桶内对象并入库为文档；开启定时同步的数据源会在每日定时任务中重新扫描，
+        对象内容变化时生成新版本。移除数据源不会删除已入库的文档。
+      </Typography.Paragraph>
+
+      <Space style={{ marginBottom: 16 }}>
+        <Button type="primary" onClick={openCreate}>
+          登记数据源
+        </Button>
+        <Button onClick={() => load(page)}>刷新</Button>
+      </Space>
+
+      <Table<ExtSource>
+        rowKey="source_id"
+        loading={loading}
+        dataSource={items}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (nextPage) => load(nextPage),
+        }}
+        columns={[
+          {
+            title: '名称',
+            dataIndex: 'name',
+            width: 160,
+            ellipsis: { showTitle: false },
+            render: (name: string) => (
+              <Tooltip title={name} placement="topLeft">
+                {name}
+              </Tooltip>
+            ),
+          },
+          {
+            title: '桶 / 前缀',
+            width: 220,
+            ellipsis: { showTitle: false },
+            render: (_, record) => {
+              const label = record.prefix ? `${record.bucket}/${record.prefix}` : record.bucket;
+              return (
+                <Tooltip title={`${record.endpoint} · ${label}`} placement="topLeft">
+                  {label}
+                </Tooltip>
+              );
+            },
+          },
+          {
+            title: '定时同步',
+            dataIndex: 'sync_enabled',
+            width: 100,
+            render: (_, record) => (
+              <Switch
+                size="small"
+                checked={record.sync_enabled}
+                loading={actingId === record.source_id}
+                onChange={(checked) => handleToggle(record, checked)}
+              />
+            ),
+          },
+          {
+            title: '最近同步',
+            dataIndex: 'last_sync_status',
+            width: 110,
+            render: (status: ExtSourceSyncStatus | null, record) => {
+              if (!status) {
+                return <Tag>未同步</Tag>;
+              }
+              const meta = metaOf(EXT_SOURCE_SYNC_STATUS_META, status);
+              const tag = <Tag color={meta.color}>{meta.label}</Tag>;
+              // PARTIAL/FAILED keep the reason on the row; surface it without widening the table.
+              return record.last_error ? <Tooltip title={record.last_error}>{tag}</Tooltip> : tag;
+            },
+          },
+          { title: '最近同步时间', dataIndex: 'last_sync_at', width: 180 },
+          {
+            title: '操作',
+            width: 300,
+            render: (_, record) => (
+              <Space size={0} wrap>
+                <Button
+                  size="small"
+                  type="link"
+                  loading={actingId === record.source_id}
+                  onClick={() => handleSync(record)}
+                >
+                  立即同步
+                </Button>
+                <Button
+                  size="small"
+                  type="link"
+                  loading={actingId === record.source_id}
+                  onClick={() => handleTest(record)}
+                >
+                  测试连接
+                </Button>
+                <Button size="small" type="link" onClick={() => setItemsSource(record)}>
+                  查看对象
+                </Button>
+                <Button size="small" type="link" onClick={() => openEdit(record)}>
+                  编辑
+                </Button>
+                <Popconfirm
+                  title="移除该数据源？"
+                  description="仅移除数据源登记，已扫描入库的文档会保留在知识库中。"
+                  okText="移除"
+                  okButtonProps={{ danger: true }}
+                  cancelText="取消"
+                  onConfirm={() => handleRemove(record)}
+                >
+                  <Button size="small" type="link" danger loading={actingId === record.source_id}>
+                    移除
+                  </Button>
+                </Popconfirm>
+              </Space>
+            ),
+          },
+        ]}
+      />
+
+      <Modal
+        title={editing ? '编辑数据源' : '登记数据源'}
+        open={modalOpen}
+        confirmLoading={saving}
+        onOk={() => form.submit()}
+        onCancel={() => setModalOpen(false)}
+        okText={editing ? '保存' : '登记'}
+        cancelText="取消"
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" onFinish={handleSubmit} preserve={false}>
+          <Form.Item label="连接器类型">
+            <Input value="S3 / OSS 兼容对象存储" disabled />
+          </Form.Item>
+          <Form.Item
+            name="name"
+            label="名称"
+            rules={[{ required: true, message: '请输入名称' }, { max: 128, message: '最多 128 个字符' }]}
+          >
+            <Input placeholder="例如：产品手册归档桶" allowClear />
+          </Form.Item>
+          <Form.Item
+            name="endpoint"
+            label="Endpoint"
+            rules={[{ required: true, message: '请输入 Endpoint' }, { max: 512, message: '最多 512 个字符' }]}
+          >
+            <Input placeholder="https://oss-cn-hangzhou.aliyuncs.com" allowClear />
+          </Form.Item>
+          <Form.Item name="region" label="Region（可选）" rules={[{ max: 64, message: '最多 64 个字符' }]}>
+            <Input placeholder="cn-hangzhou" allowClear />
+          </Form.Item>
+          <Form.Item
+            name="bucket"
+            label="Bucket"
+            rules={[{ required: true, message: '请输入 Bucket' }, { max: 128, message: '最多 128 个字符' }]}
+          >
+            <Input placeholder="my-docs-bucket" allowClear />
+          </Form.Item>
+          <Form.Item name="prefix" label="前缀（可选）" rules={[{ max: 512, message: '最多 512 个字符' }]}>
+            <Input placeholder="docs/manuals/" allowClear />
+          </Form.Item>
+          <Form.Item
+            name="access_key"
+            label="Access Key"
+            rules={[{ required: true, message: '请输入 Access Key' }, { max: 256, message: '最多 256 个字符' }]}
+          >
+            <Input placeholder="Access Key ID" allowClear />
+          </Form.Item>
+          <Form.Item
+            name="secret_key"
+            label={editing ? 'Secret Key（留空保留原密钥）' : 'Secret Key'}
+            rules={
+              editing
+                ? [{ max: 512, message: '最多 512 个字符' }]
+                : [{ required: true, message: '请输入 Secret Key' }, { max: 512, message: '最多 512 个字符' }]
+            }
+          >
+            <Input.Password placeholder={editing ? '不修改请留空' : 'Secret Access Key'} allowClear />
+          </Form.Item>
+          <Form.Item name="sync_enabled" label="定时同步" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <ExtSourceItemsDrawer source={itemsSource} onClose={() => setItemsSource(null)} />
+    </>
+  );
+}
+
+interface ExtSourceItemsDrawerProps {
+  /** The source whose object rows to show; null keeps the drawer closed. */
+  source: ExtSource | null;
+  onClose: () => void;
+}
+
+/** Per-object sync outcome drawer of one external source (M14 contract section 2.3). */
+function ExtSourceItemsDrawer({ source, onClose }: ExtSourceItemsDrawerProps) {
+  const [items, setItems] = useState<ExtSourceItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async (sourceId: string, targetPage: number) => {
+    setLoading(true);
+    try {
+      const result = await listExtSourceItems(sourceId, targetPage);
+      setItems(result.items);
+      setTotal(result.total);
+      setPage(targetPage);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (source) {
+      load(source.source_id, 1);
+    }
+  }, [source, load]);
+
+  return (
+    <Drawer
+      title={source ? `对象同步明细 · ${source.name}` : '对象同步明细'}
+      width={720}
+      open={Boolean(source)}
+      onClose={onClose}
+      destroyOnClose
+    >
+      <Table<ExtSourceItem>
+        rowKey="object_key"
+        loading={loading}
+        dataSource={items}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (nextPage) => source && load(source.source_id, nextPage),
+        }}
+        columns={[
+          {
+            title: '对象 Key',
+            dataIndex: 'object_key',
+            ellipsis: { showTitle: false },
+            render: (key: string) => (
+              <Tooltip title={key} placement="topLeft">
+                {key}
+              </Tooltip>
+            ),
+          },
+          {
+            title: '状态',
+            dataIndex: 'last_status',
+            width: 100,
+            render: (status: ExtSourceItemStatus | null, record) => {
+              if (!status) {
+                return <Tag>未同步</Tag>;
+              }
+              const meta = metaOf(EXT_SOURCE_ITEM_STATUS_META, status);
+              const tag = <Tag color={meta.color}>{meta.label}</Tag>;
+              return record.last_error ? <Tooltip title={record.last_error}>{tag}</Tooltip> : tag;
+            },
+          },
+          { title: '最近同步时间', dataIndex: 'last_sync_at', width: 180 },
+        ]}
+      />
+    </Drawer>
+  );
+}

--- a/kb-rag-web/src/pages/kb/components/IndexConfigDrawer.tsx
+++ b/kb-rag-web/src/pages/kb/components/IndexConfigDrawer.tsx
@@ -1,8 +1,8 @@
 // Author: owlzhangfq@gmail.com
 import { useEffect, useState } from 'react';
-import { Alert, Button, Drawer, Form, InputNumber, Select, Space, Switch, Typography, message } from 'antd';
+import { Alert, Button, Card, Drawer, Form, Input, InputNumber, Select, Space, Switch, Typography, message } from 'antd';
 import { updateIndexConfig } from '../../../api/kb';
-import type { ChatAggregationConfig, CleanRules, IndexConfig, SplitStrategy } from '../../../api/types';
+import type { ChatAggregationConfig, CleanRules, IndexConfig, MetadataRule, SplitStrategy } from '../../../api/types';
 import { useModelStatus } from '../../../context/ModelStatusContext';
 import { LLM_SPLIT_REQUIRES_CHAT_MODEL, SPLIT_STRATEGY_META } from '../../../utils/statusMeta';
 import CleanRulesFields from './CleanRulesFields';
@@ -35,15 +35,42 @@ const DEFAULT_HIDE_PARENT_WITH_DISABLED_CHILD = false;
 const DEFAULT_INHERIT_DISABLE_ANNOTATION = true;
 // Server default when a knowledge base has never had a strategy written (KnowledgeBaseService).
 const DEFAULT_SPLIT_STRATEGY: SplitStrategy = 'fixed_length';
+// M14 contract section 4 splitter fallbacks: 0 lets each strategy pick its own default.
+const DEFAULT_SPLIT_HEADING_LEVEL = 0;
+// M14 contract section 3.1: the console mirrors the server MetadataRule.KEY_PATTERN so an illegal
+// key is caught before the PUT rather than coming back as INVALID_PARAM.
+const METADATA_KEY_PATTERN = /^[a-z][a-z0-9_]{1,31}$/;
+const MAX_METADATA_RULES = 10;
+
+/** Copy shown under the split-strategy picker, one line per strategy (M14 contract section 4). */
+function splitStrategyHint(strategy: SplitStrategy): string {
+  switch (strategy) {
+    case 'llm_semantic':
+      return '由对话模型只输出切割点（不复述正文），结果落库缓存；适合无结构长文，成本高于定长切分';
+    case 'separator':
+      return '按分隔符切块，适合有固定分隔标记的文档；可选按正则解析分隔符';
+    case 'heading':
+      return '按 Markdown 标题层级切块，适合层级清晰的结构化文档';
+    case 'page':
+      return '每个源文档页面独立成片，适合页面边界即语义边界的文档';
+    default:
+      return '按 token 长度顺序切分，配合下方重叠长度使用';
+  }
+}
 
 interface IndexConfigFormValues {
   split_strategy: SplitStrategy;
+  split_separator?: string;
+  split_separator_is_regex: boolean;
+  split_heading_level: number;
   chunk_max_tokens: number;
   chunk_overlap: number;
   parent_child_enabled: boolean;
   parent_max_tokens: number;
   child_max_tokens: number;
   child_overlap: number;
+  metadata_rules: MetadataRule[];
+  multimodal_enabled: boolean;
   clean_rules: CleanRules;
   parse_preview_required: boolean;
   chat_aggregation: ChatAggregationConfig;
@@ -63,12 +90,17 @@ interface IndexConfigDrawerProps {
 function toFormValues(config: IndexConfig | null): IndexConfigFormValues {
   return {
     split_strategy: config?.split_strategy ?? DEFAULT_SPLIT_STRATEGY,
+    split_separator: config?.split_separator ?? undefined,
+    split_separator_is_regex: config?.split_separator_is_regex ?? false,
+    split_heading_level: config?.split_heading_level ?? DEFAULT_SPLIT_HEADING_LEVEL,
     chunk_max_tokens: config?.chunk_max_tokens ?? DEFAULT_CHUNK_MAX_TOKENS,
     chunk_overlap: config?.chunk_overlap ?? DEFAULT_CHUNK_OVERLAP,
     parent_child_enabled: config?.parent_child.enabled ?? false,
     parent_max_tokens: config?.parent_child.parent_max_tokens ?? DEFAULT_PARENT_MAX_TOKENS,
     child_max_tokens: config?.parent_child.child_max_tokens ?? DEFAULT_CHILD_MAX_TOKENS,
     child_overlap: config?.parent_child.child_overlap ?? DEFAULT_CHILD_OVERLAP,
+    metadata_rules: config?.metadata_rules ?? [],
+    multimodal_enabled: config?.multimodal_enabled ?? false,
     clean_rules: config?.clean_rules ?? DEFAULT_CLEAN_RULES,
     parse_preview_required: config?.parse_preview_required ?? false,
     // Rebuilt field by field rather than passed through: a pre-M8 stored config has no
@@ -99,6 +131,9 @@ export default function IndexConfigDrawer({ kbId, open, indexConfig, onClose, on
   // letting the save round-trip into an INVALID_PARAM.
   const { modelStatus } = useModelStatus();
   const chatConfigured = modelStatus?.chat_configured ?? false;
+  // F5 (M14 contract section 6.2): the multimodal switch stores regardless, but without a provider
+  // indexing is skipped, so the console greys it out and says why rather than silently no-op.
+  const multimodalConfigured = modelStatus?.multimodal_configured ?? false;
 
   useEffect(() => {
     if (open) {
@@ -114,6 +149,11 @@ export default function IndexConfigDrawer({ kbId, open, indexConfig, onClose, on
         // The server replaces the whole index_config object from this body, so every key the kb
         // already has must be present here -- including the ones this drawer has no control for.
         split_strategy: values.split_strategy,
+        // M14 section 4: only meaningful to the matching strategy, ignored by the others, but sent
+        // every time so the server keeps a coherent record instead of a half-updated object.
+        split_separator: values.split_separator?.trim() || undefined,
+        split_separator_is_regex: values.split_separator_is_regex,
+        split_heading_level: values.split_heading_level,
         chunk_max_tokens: values.chunk_max_tokens,
         chunk_overlap: values.chunk_overlap,
         parent_child: {
@@ -122,6 +162,9 @@ export default function IndexConfigDrawer({ kbId, open, indexConfig, onClose, on
           child_max_tokens: values.child_max_tokens,
           child_overlap: values.child_overlap,
         },
+        // M14 section 3.1: an empty list clears every operator rule; sent whole so removals stick.
+        metadata_rules: values.metadata_rules ?? [],
+        multimodal_enabled: values.multimodal_enabled,
         clean_rules: values.clean_rules,
         parse_preview_required: values.parse_preview_required,
         chat_aggregation: values.chat_aggregation,
@@ -170,11 +213,7 @@ export default function IndexConfigDrawer({ kbId, open, indexConfig, onClose, on
           name="split_strategy"
           label="切分方式"
           rules={[{ required: true, message: '请选择切分策略' }]}
-          extra={
-            splitStrategy === 'llm_semantic'
-              ? '由对话模型只输出切割点（不复述正文），结果落库缓存；适合无结构长文，成本高于定长切分'
-              : '按 token 长度顺序切分，配合下方重叠长度使用'
-          }
+          extra={splitStrategyHint(splitStrategy)}
         >
           <Select
             options={(Object.keys(SPLIT_STRATEGY_META) as SplitStrategy[]).map((code) => ({
@@ -186,6 +225,39 @@ export default function IndexConfigDrawer({ kbId, open, indexConfig, onClose, on
         </Form.Item>
         {!chatConfigured && (
           <Alert type="warning" showIcon message={LLM_SPLIT_REQUIRES_CHAT_MODEL} style={{ marginBottom: 16 }} />
+        )}
+        {splitStrategy === 'separator' && (
+          <>
+            <Form.Item name="split_separator" label="分隔符" extra="留空使用默认分隔符（连续空行）">
+              <Input placeholder="例如：---、## 或自定义分隔符" allowClear />
+            </Form.Item>
+            <Form.Item
+              name="split_separator_is_regex"
+              label="分隔符按正则解析"
+              valuePropName="checked"
+              tooltip="开启后分隔符作为正则表达式匹配；关闭时按字面量匹配"
+            >
+              <Switch />
+            </Form.Item>
+          </>
+        )}
+        {splitStrategy === 'heading' && (
+          <Form.Item
+            name="split_heading_level"
+            label="标题层级"
+            extra="0 使用默认层级；按 Markdown # 号深度切分（1-6）"
+            rules={[{ required: true, message: '请输入标题层级' }]}
+          >
+            <InputNumber min={0} max={6} style={{ width: '100%' }} />
+          </Form.Item>
+        )}
+        {splitStrategy === 'page' && (
+          <Alert
+            type="info"
+            showIcon
+            message="按页切分：每个源文档页面独立成片，下方分段长度/重叠仅在单页过长时作为兑底上限"
+            style={{ marginBottom: 16 }}
+          />
         )}
 
         <Typography.Title level={5}>分段参数</Typography.Title>
@@ -234,6 +306,123 @@ export default function IndexConfigDrawer({ kbId, open, indexConfig, onClose, on
             </Form.Item>
           </>
         )}
+
+        <Typography.Title level={5}>元数据抽取</Typography.Title>
+        <Typography.Paragraph type="secondary">
+          在切片上戴固定值、正则捕获值或命中的关键词；抽取的元数据可用于检索时的结构过滤。
+          最多 {MAX_METADATA_RULES} 条；修改后已索引文档需重建才生效。
+        </Typography.Paragraph>
+        <Form.List name="metadata_rules">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name, ...restField }) => (
+                <Card
+                  key={key}
+                  size="small"
+                  style={{ marginBottom: 12 }}
+                  extra={
+                    <Button type="link" danger size="small" onClick={() => remove(name)}>
+                      删除
+                    </Button>
+                  }
+                >
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'key']}
+                    label="元数据键"
+                    rules={[
+                      { required: true, message: '请输入元数据键' },
+                      { pattern: METADATA_KEY_PATTERN, message: '小写字母开头，仅小写字母/数字/下划线，2-32 位' },
+                    ]}
+                  >
+                    <Input placeholder="例如：doc_type" allowClear />
+                  </Form.Item>
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'type']}
+                    label="规则类型"
+                    rules={[{ required: true, message: '请选择规则类型' }]}
+                  >
+                    <Select
+                      options={[
+                        { value: 'constant', label: '固定值' },
+                        { value: 'regex', label: '正则捕获' },
+                        { value: 'keyword_match', label: '关键词命中' },
+                      ]}
+                    />
+                  </Form.Item>
+                  <Form.Item noStyle shouldUpdate>
+                    {() => {
+                      const type = form.getFieldValue(['metadata_rules', name, 'type']) as string | undefined;
+                      if (type === 'constant') {
+                        return (
+                          <Form.Item
+                            {...restField}
+                            name={[name, 'value']}
+                            label="固定值"
+                            rules={[{ required: true, message: '请输入固定值' }]}
+                          >
+                            <Input placeholder="戴在每个切片上的固定值" allowClear />
+                          </Form.Item>
+                        );
+                      }
+                      if (type === 'regex') {
+                        return (
+                          <Form.Item
+                            {...restField}
+                            name={[name, 'pattern']}
+                            label="正则表达式"
+                            extra="捕获第一个分组；无分组时取整个匹配，最长 64 字符"
+                            rules={[{ required: true, message: '请输入正则表达式' }, { max: 64, message: '最多 64 个字符' }]}
+                          >
+                            <Input placeholder="例如：合同编号[：:]\s*(\w+)" allowClear />
+                          </Form.Item>
+                        );
+                      }
+                      if (type === 'keyword_match') {
+                        return (
+                          <Form.Item
+                            {...restField}
+                            name={[name, 'keywords']}
+                            label="关键词词表"
+                            extra="记录切片命中的词；回车分隔，最多 50 个，单词最长 32 字符"
+                            rules={[{ required: true, message: '请输入至少一个关键词' }]}
+                          >
+                            <Select mode="tags" tokenSeparators={[',', '\n']} placeholder="输入后回车添加" />
+                          </Form.Item>
+                        );
+                      }
+                      return null;
+                    }}
+                  </Form.Item>
+                </Card>
+              ))}
+              {fields.length < MAX_METADATA_RULES && (
+                <Button type="dashed" block onClick={() => add({ type: 'constant' })} style={{ marginBottom: 16 }}>
+                  添加元数据规则
+                </Button>
+              )}
+            </>
+          )}
+        </Form.List>
+
+        <Typography.Title level={5}>多模态整页索引</Typography.Title>
+        {!multimodalConfigured && (
+          <Alert
+            type="warning"
+            showIcon
+            message="多模态整页索引需已配置多模态向量模型，请先在系统设置中配置"
+            style={{ marginBottom: 16 }}
+          />
+        )}
+        <Form.Item
+          name="multimodal_enabled"
+          label="启用多模态整页索引"
+          valuePropName="checked"
+          tooltip="开启后为含图切片额外生成多模态向量，检索新增一路以图搜图召回；未配置多模态模型时开关仍会保存，但索引跳过"
+        >
+          <Switch disabled={!multimodalConfigured} />
+        </Form.Item>
 
         <Typography.Title level={5}>清洗规则</Typography.Title>
         <CleanRulesFields form={form} namePath={['clean_rules']} />

--- a/kb-rag-web/src/pages/search/SearchPage.tsx
+++ b/kb-rag-web/src/pages/search/SearchPage.tsx
@@ -24,9 +24,10 @@ import type { Dayjs } from 'dayjs';
 import { search } from '../../api/search';
 import { listKnowledgeBases } from '../../api/kb';
 import { submitRetrievalFeedback, type RetrievalVerdict } from '../../api/retrievalFeedback';
-import type { FusionMode, KnowledgeBase, MetadataFilter, SearchRequest, SearchResponse } from '../../api/types';
+import type { FusionMode, KnowledgeBase, MetadataFilter, RerankMode, SearchRequest, SearchResponse } from '../../api/types';
 import { useModelStatus } from '../../context/ModelStatusContext';
 import { GRAPH_FUSION_MUTEX_HINT, describeDegradedReason, describeThresholdApplied } from '../../utils/statusMeta';
+import ImagePicker, { toImagesPayload, type PickedImage } from '../../components/ImagePicker';
 import AppliedInfoBar from './components/AppliedInfoBar';
 import CollectToEvalModal from './components/CollectToEvalModal';
 import RetrievalNodeCard from './components/RetrievalNodeCard';
@@ -36,6 +37,8 @@ const DEFAULT_TOP_N = 5;
 const DEFAULT_RRF_K = 60;
 const DEFAULT_W_VEC = 0.5;
 const DEFAULT_SCORE_THRESHOLD = 0.5;
+// M14 contract section 5: rerank_w_semantic defaults to 0.7 (semantic-leaning) when hybrid is picked.
+const DEFAULT_RERANK_W_SEMANTIC = 0.7;
 
 interface SearchFormValues {
   kb_id: string;
@@ -50,6 +53,8 @@ interface SearchFormValues {
   rrf_k: number;
   // 重排
   rerank_enabled: boolean;
+  rerank_mode: RerankMode;
+  rerank_w_semantic: number;
   // 过滤
   threshold_enabled: boolean;
   score_threshold: number;
@@ -92,10 +97,14 @@ export default function SearchPage() {
   /** 好/坏 verdict per chunk_id for the current result set; cleared on every new search. */
   const [feedbackByChunkId, setFeedbackByChunkId] = useState<Record<string, RetrievalVerdict>>({});
   const [collectModalOpen, setCollectModalOpen] = useState(false);
+  // F6 image-query picks kept as data URLs for preview; stripped to bare base64 at submit time.
+  const [queryImages, setQueryImages] = useState<PickedImage[]>([]);
   const { modelStatus } = useModelStatus();
   const [form] = Form.useForm<SearchFormValues>();
   const fusionMode = Form.useWatch('fusion_mode', form) ?? 'rrf';
   const thresholdEnabled = Form.useWatch('threshold_enabled', form) ?? false;
+  const rerankEnabled = Form.useWatch('rerank_enabled', form) ?? false;
+  const rerankMode = Form.useWatch('rerank_mode', form) ?? 'semantic';
   const selectedKbId = Form.useWatch('kb_id', form);
 
   const rewriteAvailable = modelStatus?.chat_configured ?? false;
@@ -133,6 +142,13 @@ export default function SearchPage() {
         top_n: values.top_n,
         rewrite_enabled: rewriteAvailable ? values.rewrite_enabled : false,
         rerank_enabled: rerankAvailable ? values.rerank_enabled : false,
+        // F4 (M14 contract section 5): rerank_mode/w_semantic only bite when rerank actually runs, so
+        // they are omitted otherwise -- the request keeps its pre-M14 shape and defaults to semantic.
+        rerank_mode: rerankAvailable && values.rerank_enabled ? values.rerank_mode : undefined,
+        rerank_w_semantic:
+          rerankAvailable && values.rerank_enabled && values.rerank_mode === 'hybrid'
+            ? values.rerank_w_semantic
+            : undefined,
         score_threshold: values.threshold_enabled ? values.score_threshold : null,
         fusion: {
           mode: values.fusion_mode,
@@ -140,6 +156,8 @@ export default function SearchPage() {
           rrf_k: values.fusion_mode === 'rrf' ? values.rrf_k : undefined,
         },
         metadata_filter: buildMetadataFilter(values),
+        // F6 (M14 contract section 7): bare base64, no data: prefix; server is the size/count authority.
+        images: toImagesPayload(queryImages),
       };
       const res = await search(values.kb_id, payload);
       setResult(res);
@@ -195,6 +213,8 @@ export default function SearchPage() {
             w_vec: DEFAULT_W_VEC,
             rrf_k: DEFAULT_RRF_K,
             rerank_enabled: true,
+            rerank_mode: 'semantic',
+            rerank_w_semantic: DEFAULT_RERANK_W_SEMANTIC,
             threshold_enabled: false,
             score_threshold: DEFAULT_SCORE_THRESHOLD,
           }}
@@ -207,6 +227,12 @@ export default function SearchPage() {
           </Form.Item>
           <Form.Item name="query" label="检索内容" rules={[{ required: true, message: '请输入检索内容' }]}>
             <Input.TextArea placeholder="输入需要检索的问题或关键词" rows={3} />
+          </Form.Item>
+          <Form.Item
+            label="以图搜图（可选）"
+            tooltip="附带图片查询：知识库开启多模态时图片直接进入多模态空间检索，否则回落 VLM 转写为文本后检索；检索内容仍必填"
+          >
+            <ImagePicker value={queryImages} onChange={setQueryImages} />
           </Form.Item>
 
           <Collapse
@@ -280,7 +306,7 @@ export default function SearchPage() {
                 key: 'rerank',
                 label: '重排',
                 children: (
-                  <Space direction="vertical">
+                  <Space direction="vertical" style={{ width: '100%' }}>
                     <Form.Item
                       name="rerank_enabled"
                       label="启用重排序"
@@ -292,6 +318,37 @@ export default function SearchPage() {
                     </Form.Item>
                     {!rerankAvailable && (
                       <Typography.Text type="secondary">未配置重排模型（rerank），重排序不可用</Typography.Text>
+                    )}
+                    {rerankAvailable && rerankEnabled && (
+                      <>
+                        <Form.Item
+                          name="rerank_mode"
+                          label="重排模式"
+                          tooltip="hybrid 将语义重排分与归一化 BM25 分线性加权，仅影响排序；semantic 为纯语义重排"
+                        >
+                          <Radio.Group
+                            optionType="button"
+                            options={[
+                              { label: '语义（semantic）', value: 'semantic' },
+                              { label: '混合（hybrid）', value: 'hybrid' },
+                            ]}
+                          />
+                        </Form.Item>
+                        {rerankMode === 'hybrid' && (
+                          <>
+                            <Form.Item
+                              name="rerank_w_semantic"
+                              label="语义分权重 w_semantic（BM25 权重 = 1 - w_semantic）"
+                              tooltip="排序分 = w × 语义重排分 + (1 - w) × 归一化 BM25 分，min-max 在本次候选集内归一化"
+                            >
+                              <Slider min={0} max={1} step={0.01} marks={{ 0: '0', 0.7: '0.7', 1: '1' }} />
+                            </Form.Item>
+                            <Typography.Text type="secondary">
+                              阈值过滤仍作用于纯语义重排分，hybrid 只改变排序，不影响 score_threshold 的绝对语义
+                            </Typography.Text>
+                          </>
+                        )}
+                      </>
                     )}
                   </Space>
                 ),

--- a/kb-rag-web/src/utils/statusMeta.ts
+++ b/kb-rag-web/src/utils/statusMeta.ts
@@ -11,6 +11,8 @@ import type {
   DocumentVersionStatus,
   EmbeddingStatus,
   EvalMode,
+  ExtSourceItemStatus,
+  ExtSourceSyncStatus,
   FeedbackStatus,
   FeedbackVerdict,
   FusionMode,
@@ -99,13 +101,16 @@ export const FUSION_MODE_META: Record<FusionMode, { color: string; label: string
 export const GRAPH_FUSION_MUTEX_HINT = '开启图路的知识库库内融合强制为 RRF';
 
 /**
- * index_config.split_strategy picker meta. Only these two strategies exist server-side
- * (SplitStrategy enum); parent/child chunking is not one of them -- it is an orthogonal switch
- * layered on top of whichever strategy runs.
+ * index_config.split_strategy picker meta (M14 contract section 4). Five strategies exist
+ * server-side; parent/child chunking is NOT one of them -- it is an orthogonal switch layered on
+ * top of whichever strategy runs.
  */
 export const SPLIT_STRATEGY_META: Record<SplitStrategy, TagMeta> = {
   fixed_length: { color: 'default', label: '定长切分' },
   llm_semantic: { color: 'purple', label: 'LLM 语义切分' },
+  separator: { color: 'blue', label: '分隔符切分' },
+  heading: { color: 'geekblue', label: '标题层级切分' },
+  page: { color: 'cyan', label: '按页切分' },
 };
 
 /** Shown wherever 「LLM 语义切分」 has to be greyed out for want of a chat model. */
@@ -206,6 +211,27 @@ export const SEARCH_INSIGHT_SOURCE_META: Record<SearchInsightSource, TagMeta> = 
  * are deliberate non-writes, not failures, hence the neutral colors.
  */
 export const WEB_SOURCE_STATUS_META: Record<WebSourceFetchStatus, TagMeta> = {
+  SUCCESS: { color: 'success', label: '已入库' },
+  UNCHANGED: { color: 'default', label: '内容未变' },
+  SKIPPED: { color: 'warning', label: '已跳过' },
+  FAILED: { color: 'error', label: '失败' },
+};
+
+/**
+ * ExtSource.last_sync_status Tag meta (M14 contract section 2.3): outcome of the last whole-source
+ * sync pass. PARTIAL means the scan ran but some objects failed/were skipped (see the item rows).
+ */
+export const EXT_SOURCE_SYNC_STATUS_META: Record<ExtSourceSyncStatus, TagMeta> = {
+  SUCCESS: { color: 'success', label: '同步成功' },
+  PARTIAL: { color: 'warning', label: '部分成功' },
+  FAILED: { color: 'error', label: '同步失败' },
+};
+
+/**
+ * ExtSourceItem.last_status Tag meta (M14 contract section 2.3): per-object outcome. UNCHANGED
+ * (etag identical) and SKIPPED (bound document in the recycle bin) are deliberate non-writes.
+ */
+export const EXT_SOURCE_ITEM_STATUS_META: Record<ExtSourceItemStatus, TagMeta> = {
   SUCCESS: { color: 'success', label: '已入库' },
   UNCHANGED: { color: 'default', label: '内容未变' },
   SKIPPED: { color: 'warning', label: '已跳过' },
@@ -334,6 +360,17 @@ export const DEGRADED_REASON_LABELS: Record<string, string> = {
    * for every image -- all images are dropped and retrieval falls back to text-only on `query`.
    */
   image_understanding_unavailable: '图片理解不可用，已忽略图片仅文本检索',
+  /**
+   * M14 contract section 6.3: the kb has multimodal_enabled=true but fusion_mode is `weighted`;
+   * RRF is the only mode that can merge a route without a comparable absolute score, so the
+   * multimodal route is skipped rather than folded in on an incompatible scale.
+   */
+  mm_route_skipped: '多模态路检索在加权融合下不生效，已跳过该路',
+  /**
+   * M14 contract section 6.3: the kb has multimodal_enabled=true but embedding the query into the
+   * multimodal space failed/timed out -- that route is skipped, the other routes proceed.
+   */
+  mm_route_unavailable: '多模态检索不可用，已降级为其余路检索',
 };
 
 export function describeDegradedReason(reason: string): string {


### PR DESCRIPTION
三期第一批六项功能，契约见 [`docs/M14-CONTRACTS.md`](kb-rag-deploy/docs/M14-CONTRACTS.md)。

**全部为纯新增**：新表、新端点、新配置键，存量行为零变化。新的 JSON 配置字段缺省即现状 —— `metadata_rules` 空、`split_strategy` 沿用旧值、`rerank_mode=semantic`、`multimodal_enabled=false`。

## ① 外部数据源连接器

连接器 SPI（`ExternalConnector` / `ConnectorRouter`，为后续 Confluence、飞书预留）与首个实现 S3/OSS 兼容对象存储。

按 prefix 扫描桶内对象，走既有上传管线入库并派生稳定文件名。增量语义靠 ETag：未变即 `UNCHANGED` 不重传，变了建新版本。**源与文档弱绑定** —— 移除登记或对象消失都不删文档（`SKIPPED`），避免上游一次误删连带清空知识库。

新增 `t_kb_ext_source` / `t_kb_ext_source_item`（Flyway `V15__ext_source.sql`）。

端点：`POST|GET /kb/{kbId}/ext-sources`、`POST /ext-sources/{id}/sync`、`GET /ext-sources/{id}/items`、`PUT|DELETE /ext-sources/{id}`、`POST /ext-sources/{id}/test`（连通性测试）。

## ② 配置化元数据抽取

知识库级 `metadata_rules`，三类规则（`constant` / `regex` / `keyword_match`），上限 10 条。切分后逐 chunk 抽取写入 metadata，并以 `ext_` 前缀镜像到引擎，检索侧经 `metadata_filter.custom` 做等值过滤。

规则计入 chunk 指纹 —— 改规则会正确触发重建，不会出现"改了配置但索引还是旧的"。

## ③ 切分策略扩展

新增三个 `TextSplitter`：`separator`（分隔符或正则）、`heading`（markdown 标题层级）、`page`（解析页边界）。超长段统一回落 `fixed_length`。

与父子分片**互斥**，组合提交报 `INVALID_PARAM` 而不是静默选一个。

## ④ Rerank 混合模式

`rerank_mode=hybrid` 把语义重排分与归一化 BM25 分线性加权（`rerank_w_semantic` 默认 0.7）决定排序。

**只影响排序，不改变 `score_threshold` 的绝对阈值语义**，rerank 的降级链路照旧 —— 这点值得 review 时确认，阈值语义是跨版本的兼容承诺。

## ⑤ 视觉理解整页索引

知识库级 `multimodal_enabled` 开关。开启且多模态 provider 已配置时，对 IMAGE 类 chunk（内嵌图、独立上传图、扫描页整页渲染）额外产多模态向量（`multimodal-embedding-v1`，1024 维，物理索引 `{kbId}_mm`）。

检索新增**第三条召回路**进 RRF 融合 —— 图文同空间，纯文本 query 也能命中图片。VLM 文本代理链路保持不变，两者互补而非替代。

`degraded` 枚举相应新增 `mm_route_unavailable`（多模态检索不可用）与 `mm_route_skipped`（加权融合下多模态路跳过）。

## ⑥ 以图搜图

检索调试页支持 `SearchRequest.images`（裸 base64，≤3 张、单张 5MB、总量 10MB）。multimodal 开启时图片直接嵌入多模态空间检索，否则回落 VLM 转写。

## 前端

知识库详情新增「外部数据源」Tab；索引配置抽屉增加切分条件字段、元数据抽取分组、多模态开关；检索调试页增加重排模式选择与图片上传。

## Reviewer 需要注意的两点

**外部对象存储凭据的存储方式。** `secret_key` 存在 `t_kb_ext_source`，API 出参固定掩码、永不回传，更新端点把空值视为「保持原存储值」以支持前端 round trip —— 这几点都处理到位了。但**库内是明文列**，安全性依赖数据库自身的访问控制。对自托管部署这是常见取舍（`.env` 里的 MinIO / DashScope 凭据同样是明文），但既然这是项目第一次持久化外部凭据，值得确认这个取舍是有意为之。

**新增环境变量共 12 个**，全部有默认值、不配也能跑：

```
EXT_SOURCE_SYNC_CRON / _SYNC_ENABLED / _SYNC_BATCH_SIZE
EXT_SOURCE_MAX_OBJECTS_PER_SOURCE / _FETCH_TIMEOUT_MS
MULTIMODAL_EMBEDDING_MODEL / _API_KEY / _DIM / _URL / _TIMEOUT_MS
RETRIEVAL_RERANK_MODE / RETRIEVAL_RERANK_W_SEMANTIC
```

`MULTIMODAL_EMBEDDING_API_KEY` 留空即继承 `DASHSCOPE_API_KEY`，两者皆空等于多模态能力整体关闭 —— 与项目里「留空即降级、不阻断启动」的一贯做法一致。

## 规模

48 个文件改动 + 36 个新增，约 2650 行新增。OpenAPI 升至 `0.14.0-m14`。

## 安全扫描

提交前已扫：无真实密钥、无私钥、无硬编码凭据（含 36 个未跟踪的新文件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
