### PR TITLE
docs(schema): 建表语句注释全面中文化并补齐缺失注释

### DIFF
--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V10__chunk_parent_offset.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V10__chunk_parent_offset.sql
@@ -1,15 +1,15 @@
--- Milestone M9 schema increment: where a child chunk sits inside its parent, requirement section 4.5.
+-- 里程碑 M9 的结构增量：子分片在父分片中的位置，对应需求文档 4.5 节。
 --
--- Why a column and not a derivation. The retrieval side cuts the passage of a disabled child out of the
--- parent text before returning it, and recovering the position by searching the child text inside the
--- parent at query time would be both slower and ambiguous - overlapping children repeat text by design,
--- so a search could land on the wrong occurrence. The splitter already knows the position, because a
--- child is literally cut out of the parent, so it is written down once and read back cheaply.
+-- 为什么要建列而不是运行时推导。检索侧在返回父分片正文之前，会把已停用子分片对应的那一段抠掉；
+-- 如果查询时再去父分片里搜索子分片文本来还原位置，既更慢又有歧义——重叠切分本来就会让相邻子分片
+-- 重复同一段文本，搜索可能落到错误的那一次出现上。切分器本身是知道这个位置的（子分片就是从父分片
+-- 里切出来的），所以写一次、以后廉价读回即可。
 --
--- Nullable on purpose, and null is the safe value. Every existing row gets NULL, which the retrieval side
--- reads as "this parent cannot be redacted precisely" and answers by returning the whole parent, exactly
--- as it did before this milestone. The annotation write paths clear the pair whenever the text moves.
+-- 刻意设计成可空，并且 null 就是安全值。存量数据一律为 NULL，检索侧把它读作「这个父分片无法精确
+-- 抠除」，于是原样返回整个父分片，行为和本里程碑之前完全一致。标注的写入链路只要文本位置发生移动，
+-- 就会把这一对偏移清空。
+SET NAMES utf8mb4;
 
 ALTER TABLE t_kb_chunk
-    ADD COLUMN parent_start_offset INT DEFAULT NULL COMMENT 'start offset of this child inside its parent content, null when unknown' AFTER parent_id,
-    ADD COLUMN parent_end_offset   INT DEFAULT NULL COMMENT 'exclusive end offset of this child inside its parent content, null when unknown' AFTER parent_start_offset;
+    ADD COLUMN parent_start_offset INT DEFAULT NULL COMMENT '本子分片在父分片正文中的起始偏移，未知时为 null' AFTER parent_id,
+    ADD COLUMN parent_end_offset   INT DEFAULT NULL COMMENT '本子分片在父分片正文中的结束偏移（不含），未知时为 null' AFTER parent_start_offset;

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V11__auth_token.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V11__auth_token.sql
@@ -1,25 +1,26 @@
--- Console session tokens move from process memory into the database, so a restart of the
--- single instance no longer ends every session. The 24 hour TTL semantics stay unchanged.
+-- 控制台会话令牌从进程内存迁到数据库，这样单实例重启不再让所有会话失效。
+-- 24 小时 TTL 的语义保持不变。
 --
--- Only the SHA-256 digest of the token is stored, mirroring t_kb_api_key: a database dump can
--- not be replayed against the console because the plaintext only ever lives in the browser.
+-- 与 t_kb_api_key 一致，只存令牌的 SHA-256 摘要：明文只存在于浏览器里，
+-- 因此即使数据库被拖库，也无法拿去重放控制台。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_auth_token
 (
-    id           BIGINT       NOT NULL AUTO_INCREMENT,
-    token_hash   VARCHAR(64)  NOT NULL COMMENT 'SHA-256 digest of the opaque bearer token, the only stored form',
-    username     VARCHAR(64)  NOT NULL COMMENT 'console account the session belongs to',
-    expires_at   DATETIME     NOT NULL COMMENT 'absolute expiry, issued time plus the configured TTL',
-    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT          NOT NULL DEFAULT 0,
-    deleted      TINYINT      NOT NULL DEFAULT 0,
+    id           BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    token_hash   VARCHAR(64)  NOT NULL COMMENT '不透明 bearer 令牌的 SHA-256 摘要，也是唯一的存储形式',
+    username     VARCHAR(64)  NOT NULL COMMENT '会话所属的控制台账号',
+    expires_at   DATETIME     NOT NULL COMMENT '绝对过期时刻，等于签发时间加上配置的 TTL',
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_token_hash (token_hash),
-    -- revokeAll walks the sessions of one account after a password change,
-    -- the expiry purge on login walks the expired rows.
+    -- 改密之后 revokeAll 会扫描单个账号的全部会话，
+    -- 登录时的过期清理会扫描已过期的行。
     KEY idx_username (username),
     KEY idx_expires_at (expires_at)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='console session tokens, survives a process restart';
+  COLLATE = utf8mb4_general_ci COMMENT ='控制台会话令牌，可跨进程重启存活';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V12__retrieval_feedback_and_search_insight.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V12__retrieval_feedback_and_search_insight.sql
@@ -1,62 +1,62 @@
--- M10: the retrieval quality loop. Feedback stops being a log line and becomes a managed row that
--- can be converted into an evaluation case, and every online retrieval leaves an insight row so the
--- console can answer "what are people searching for that the corpus cannot serve".
+-- M10：检索质量闭环。反馈不再只是一行日志，而是可被管理、并能转化成评测用例的记录；
+-- 同时每一次线上检索都会留下一行洞察数据，好让控制台回答「大家在搜什么、而语料答不上来」。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_retrieval_feedback
 (
-    id                BIGINT       NOT NULL AUTO_INCREMENT,
-    feedback_id       VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the console',
-    kb_id             VARCHAR(64)  NOT NULL COMMENT 'knowledge base the query ran against',
-    -- Stored raw on purpose, unlike the insight digest: converting a feedback into an evaluation
-    -- case replays the exact query, and a masked copy would create a case that never ran.
-    query             TEXT         NOT NULL COMMENT 'query the debug page ran, raw, replayed on conversion',
-    chunk_id          VARCHAR(64)  NOT NULL COMMENT 'chunk the verdict concerns',
-    doc_id            VARCHAR(64)           DEFAULT NULL COMMENT 'owning document, resolved server side, null when the chunk was already deleted',
-    verdict           VARCHAR(16)  NOT NULL COMMENT 'GOOD/BAD',
-    status            VARCHAR(16)  NOT NULL DEFAULT 'NEW' COMMENT 'NEW/CONVERTED/DISMISSED',
-    converted_case_id VARCHAR(64)           DEFAULT NULL COMMENT 'evaluation case created from this row, null until converted',
-    note              VARCHAR(512)          DEFAULT NULL COMMENT 'free form operator note',
-    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version      INT          NOT NULL DEFAULT 0,
-    deleted           TINYINT      NOT NULL DEFAULT 0,
+    id                BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    feedback_id       VARCHAR(64)  NOT NULL COMMENT '控制台对外暴露的业务标识',
+    kb_id             VARCHAR(64)  NOT NULL COMMENT '本次查询所命中的知识库',
+    -- 与洞察表的脱敏摘要不同，这里刻意存原文：把一条反馈转成评测用例时要重放一模一样的查询，
+    -- 存脱敏副本会造出一个从未真正跑过的用例。
+    query             TEXT         NOT NULL COMMENT '调试页执行的查询原文，转化用例时按原文重放',
+    chunk_id          VARCHAR(64)  NOT NULL COMMENT '本次评价所针对的分片',
+    doc_id            VARCHAR(64)           DEFAULT NULL COMMENT '所属文档，由服务端解析；分片已被删除时为 null',
+    verdict           VARCHAR(16)  NOT NULL COMMENT '评价结论：GOOD 好评 / BAD 差评',
+    status            VARCHAR(16)  NOT NULL DEFAULT 'NEW' COMMENT '处理状态：NEW 待处理 / CONVERTED 已转用例 / DISMISSED 已忽略',
+    converted_case_id VARCHAR(64)           DEFAULT NULL COMMENT '由本行转化而来的评测用例 id，未转化时为 null',
+    note              VARCHAR(512)          DEFAULT NULL COMMENT '运营人员的自由文本备注',
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version      INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted           TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_feedback_id (feedback_id),
     KEY idx_kb_id (kb_id),
     KEY idx_status (status),
-    -- The console lists the open feedback of one knowledge base, which is exactly this pair.
+    -- 控制台列出单个知识库的待处理反馈，条件正好就是这两个字段。
     KEY idx_kb_status (kb_id, status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='good/bad verdicts on debug results, convertible into evaluation cases';
+  COLLATE = utf8mb4_general_ci COMMENT ='对调试结果的好评/差评，可转化为评测用例';
 
 CREATE TABLE t_kb_search_insight
 (
-    id           BIGINT      NOT NULL AUTO_INCREMENT,
-    insight_id   VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the console',
-    kb_id        VARCHAR(64) NOT NULL COMMENT 'knowledge base the retrieval ran against',
-    source       VARCHAR(16) NOT NULL COMMENT 'CONSOLE/OPEN_API, the boundary the call entered through',
-    -- Masked by the section 4.2 rules and then truncated, the exact t_kb_api_audit_log discipline:
-    -- an analytics table kept for 90 days must not become an unmasked copy of what users typed.
-    query_digest VARCHAR(200)         DEFAULT NULL COMMENT 'masked and truncated query, never the raw text',
-    query_hash   CHAR(64)    NOT NULL COMMENT 'SHA-256 of the normalized query, the grouping key of the miss report',
-    result_count INT         NOT NULL DEFAULT 0 COMMENT 'nodes the call returned',
-    top_score    DOUBLE               DEFAULT NULL COMMENT 'score of the first node, null on zero hits',
-    zero_hit     TINYINT     NOT NULL DEFAULT 0 COMMENT 'derived from result_count = 0, the column the report scans',
-    degraded     JSON                 DEFAULT NULL COMMENT 'degradation markers of this call',
-    request_id   VARCHAR(64)          DEFAULT NULL COMMENT 'correlation id, links the row to logs and audit',
-    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT         NOT NULL DEFAULT 0,
-    deleted      TINYINT     NOT NULL DEFAULT 0,
+    id           BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    insight_id   VARCHAR(64) NOT NULL COMMENT '控制台对外暴露的业务标识',
+    kb_id        VARCHAR(64) NOT NULL COMMENT '本次检索所命中的知识库',
+    source       VARCHAR(16) NOT NULL COMMENT '调用入口：CONSOLE 控制台 / OPEN_API 开放接口',
+    -- 与 t_kb_api_audit_log 完全一致的纪律：先按 4.2 节规则脱敏再截断。
+    -- 一张要保留 90 天的分析表，绝不能变成用户输入内容的未脱敏副本。
+    query_digest VARCHAR(200)         DEFAULT NULL COMMENT '脱敏并截断后的查询文本，绝不存原文',
+    query_hash   CHAR(64)    NOT NULL COMMENT '归一化查询的 SHA-256，未命中报表的分组键',
+    result_count INT         NOT NULL DEFAULT 0 COMMENT '本次调用返回的结果条数',
+    top_score    DOUBLE               DEFAULT NULL COMMENT '首条结果的得分，零命中时为 null',
+    zero_hit     TINYINT     NOT NULL DEFAULT 0 COMMENT '由 result_count = 0 派生，报表实际扫描的就是这一列',
+    degraded     JSON                 DEFAULT NULL COMMENT '本次调用的降级标记',
+    request_id   VARCHAR(64)          DEFAULT NULL COMMENT '链路追踪 id，把本行与日志、审计关联起来',
+    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_insight_id (insight_id),
     KEY idx_kb_id (kb_id),
     KEY idx_query_hash (query_hash),
-    -- The zero hit report of one knowledge base over a time window, which is exactly this triple.
+    -- 单个知识库在某个时间窗内的零命中报表，条件正好就是这三个字段。
     KEY idx_kb_zero_created (kb_id, zero_hit, created_at),
-    -- The retention pass walks the expired rows.
+    -- 保留期清理任务扫描已过期的行。
     KEY idx_created_at (created_at)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='one row per online retrieval, deleted after the retention window';
+  COLLATE = utf8mb4_general_ci COMMENT ='线上检索逐次留痕，超过保留期后删除';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V13__document_governance.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V13__document_governance.sql
@@ -1,17 +1,17 @@
--- M11: content governance. A document stops being retrievable the moment it is uploaded and
--- becomes retrievable when governance says so: published, inside its validity window and not in
--- the trash. Every existing row defaults to the permissive state, so upgrading changes nothing.
+-- M11：内容治理。文档上传的那一刻起就不可检索，只有治理侧点头之后才变得可检索：
+-- 已发布、处于有效期内、且不在回收站里。存量数据一律取宽松的默认值，因此升级不改变任何行为。
+SET NAMES utf8mb4;
 
 ALTER TABLE t_kb_document
-    ADD COLUMN publish_status VARCHAR(16) NOT NULL DEFAULT 'PUBLISHED' COMMENT 'DRAFT/PENDING_REVIEW/PUBLISHED/REJECTED' AFTER process_status,
-    ADD COLUMN review_note    VARCHAR(512)         DEFAULT NULL COMMENT 'latest rejection reason, cleared on approval' AFTER publish_status,
-    ADD COLUMN effective_at   DATETIME             DEFAULT NULL COMMENT 'retrievable from this instant, null means no lower bound' AFTER review_note,
-    ADD COLUMN expires_at     DATETIME             DEFAULT NULL COMMENT 'retrievable before this instant, null means no upper bound' AFTER effective_at,
-    ADD COLUMN trashed        TINYINT      NOT NULL DEFAULT 0 COMMENT '1 while the document sits in the recycle bin' AFTER expires_at,
-    ADD COLUMN trashed_at     DATETIME             DEFAULT NULL COMMENT 'when the document entered the recycle bin, drives the purge pass' AFTER trashed,
+    ADD COLUMN publish_status VARCHAR(16) NOT NULL DEFAULT 'PUBLISHED' COMMENT '发布状态：DRAFT 草稿 / PENDING_REVIEW 待审核 / PUBLISHED 已发布 / REJECTED 已驳回' AFTER process_status,
+    ADD COLUMN review_note    VARCHAR(512)         DEFAULT NULL COMMENT '最近一次的驳回理由，审核通过时清空' AFTER publish_status,
+    ADD COLUMN effective_at   DATETIME             DEFAULT NULL COMMENT '生效时间，从该时刻起可检索；为 null 表示不设下界' AFTER review_note,
+    ADD COLUMN expires_at     DATETIME             DEFAULT NULL COMMENT '失效时间，在该时刻之前可检索；为 null 表示不设上界' AFTER effective_at,
+    ADD COLUMN trashed        TINYINT      NOT NULL DEFAULT 0 COMMENT '文档在回收站中时置 1' AFTER expires_at,
+    ADD COLUMN trashed_at     DATETIME             DEFAULT NULL COMMENT '进入回收站的时间，驱动彻底清除任务' AFTER trashed,
     ADD KEY idx_kb_publish (kb_id, publish_status),
     ADD KEY idx_kb_trashed (kb_id, trashed),
     ADD KEY idx_trashed_at (trashed_at);
 
 ALTER TABLE t_kb_knowledge_base
-    ADD COLUMN review_required TINYINT NOT NULL DEFAULT 0 COMMENT '1 makes a new document start as DRAFT instead of PUBLISHED' AFTER retrieval_config;
+    ADD COLUMN review_required TINYINT NOT NULL DEFAULT 0 COMMENT '置 1 时新文档的初始状态为 DRAFT 而不是 PUBLISHED' AFTER retrieval_config;

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V14__web_source.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V14__web_source.sql
@@ -1,31 +1,31 @@
--- M12: URL import and incremental sync. A registered web source is the bridge between a URL and
--- the document its fetches produce: the fetch itself funnels into the ordinary upload chain, so
--- this table only records the binding, the sync switch and the outcome of the last fetch.
+-- M12：URL 导入与增量同步。一个已注册的网页源，是 URL 与其抓取所产出文档之间的桥梁：
+-- 抓取本身汇入普通的上传链路，因此这张表只记录绑定关系、同步开关和最近一次抓取的结果。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_web_source
 (
-    id                BIGINT        NOT NULL AUTO_INCREMENT,
-    source_id         VARCHAR(64)   NOT NULL COMMENT 'business identifier exposed by the console',
-    kb_id             VARCHAR(64)   NOT NULL COMMENT 'knowledge base the fetched pages land in',
-    url               VARCHAR(2048) NOT NULL COMMENT 'registered page address, http or https',
-    -- The equality key: a VARCHAR(2048) cannot carry a unique index, the digest of it can.
-    url_hash          CHAR(64)      NOT NULL COMMENT 'SHA-256 of the url, the dedup and lookup key',
-    doc_id            VARCHAR(64)            DEFAULT NULL COMMENT 'document the fetches feed, null until the first success',
-    file_name         VARCHAR(255)           DEFAULT NULL COMMENT 'derived stable file name the upload chain sees',
-    sync_enabled      TINYINT       NOT NULL DEFAULT 1 COMMENT '1 includes the source in the scheduled sync pass',
-    last_content_hash CHAR(64)               DEFAULT NULL COMMENT 'SHA-256 of the last fetched body, the unchanged check',
-    last_fetch_at     DATETIME               DEFAULT NULL COMMENT 'when the last sync attempt ran',
-    last_fetch_status VARCHAR(16)            DEFAULT NULL COMMENT 'SUCCESS/UNCHANGED/SKIPPED/FAILED',
-    last_error        VARCHAR(512)           DEFAULT NULL COMMENT 'why the last sync failed or was skipped, null on success',
-    created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version      INT           NOT NULL DEFAULT 0,
-    deleted           TINYINT       NOT NULL DEFAULT 0,
+    id                BIGINT        NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    source_id         VARCHAR(64)   NOT NULL COMMENT '控制台对外暴露的业务标识',
+    kb_id             VARCHAR(64)   NOT NULL COMMENT '抓取到的页面所落入的知识库',
+    url               VARCHAR(2048) NOT NULL COMMENT '已注册的页面地址，http 或 https',
+    -- 等值比较用的键：VARCHAR(2048) 撑不起唯一索引，它的摘要可以。
+    url_hash          CHAR(64)      NOT NULL COMMENT 'url 的 SHA-256，去重与查找键',
+    doc_id            VARCHAR(64)            DEFAULT NULL COMMENT '抓取内容所喂养的文档，首次成功前为 null',
+    file_name         VARCHAR(255)           DEFAULT NULL COMMENT '派生出的稳定文件名，上传链路看到的就是它',
+    sync_enabled      TINYINT       NOT NULL DEFAULT 1 COMMENT '置 1 时该源纳入定时同步任务',
+    last_content_hash CHAR(64)               DEFAULT NULL COMMENT '最近一次抓取正文的 SHA-256，用于判断内容是否未变',
+    last_fetch_at     DATETIME               DEFAULT NULL COMMENT '最近一次同步尝试的执行时间',
+    last_fetch_status VARCHAR(16)            DEFAULT NULL COMMENT '最近一次同步结果：SUCCESS/UNCHANGED/SKIPPED/FAILED',
+    last_error        VARCHAR(512)           DEFAULT NULL COMMENT '最近一次同步失败或被跳过的原因，成功时为 null',
+    created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version      INT           NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted           TINYINT       NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_source_id (source_id),
-    -- One registration per URL per knowledge base; other knowledge bases may register the same URL.
+    -- 同一个知识库下一个 URL 只能注册一次；其他知识库可以注册同一个 URL。
     UNIQUE KEY uk_kb_url (kb_id, url_hash),
     KEY idx_kb_id (kb_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='registered web page sources feeding documents via URL import';
+  COLLATE = utf8mb4_general_ci COMMENT ='已注册的网页源，经 URL 导入喂养文档';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V15__ext_source.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V15__ext_source.sql
@@ -1,60 +1,60 @@
--- M14: external data source connectors. A registered source describes one S3/OSS compatible
--- bucket whose objects are scanned and funnelled into the ordinary upload chain; the item table
--- records the per-object binding and the outcome of its last sync, mirroring the weak binding of
--- the web source table - removing a registration never touches the documents it produced.
+-- M14：外部数据源连接器。一条已注册的数据源描述一个兼容 S3/OSS 的桶，其中的对象会被扫描出来
+-- 并汇入普通的上传链路；条目表记录逐对象的绑定关系及其最近一次同步结果。它沿用网页源表那种弱绑定：
+-- 删除一条注册，绝不牵动它曾经产出的文档。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_ext_source
 (
-    id               BIGINT       NOT NULL AUTO_INCREMENT,
-    source_id        VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the console',
-    kb_id            VARCHAR(64)  NOT NULL COMMENT 'knowledge base the fetched objects land in',
-    source_type      VARCHAR(16)  NOT NULL COMMENT 'connector type routing key, s3 in this milestone',
-    name             VARCHAR(128) NOT NULL COMMENT 'operator facing display name, unique per knowledge base',
-    endpoint         VARCHAR(512) NOT NULL COMMENT 'service endpoint of the object store',
-    region           VARCHAR(64)           DEFAULT NULL COMMENT 'optional region hint of the object store',
-    bucket           VARCHAR(128) NOT NULL COMMENT 'bucket the scan lists',
-    prefix           VARCHAR(512)          DEFAULT NULL COMMENT 'optional key prefix narrowing the scan',
-    access_key       VARCHAR(256) NOT NULL COMMENT 'access key of the bucket credentials',
-    -- Stored in clear on purpose: single admin console behind network isolation, the D17 premise.
-    -- The read API never returns this column; envelope encryption belongs to the RBAC milestone.
-    secret_key       VARCHAR(512) NOT NULL COMMENT 'secret key of the bucket credentials, never returned by the API',
-    sync_enabled     TINYINT      NOT NULL DEFAULT 1 COMMENT '1 includes the source in the scheduled sync pass',
-    last_sync_at     DATETIME              DEFAULT NULL COMMENT 'when the last sync attempt ran',
-    last_sync_status VARCHAR(16)           DEFAULT NULL COMMENT 'SUCCESS/PARTIAL/FAILED',
-    last_error       VARCHAR(512)          DEFAULT NULL COMMENT 'why the last sync failed or was partial, null on success',
-    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version     INT          NOT NULL DEFAULT 0,
-    deleted          TINYINT      NOT NULL DEFAULT 0,
+    id               BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    source_id        VARCHAR(64)  NOT NULL COMMENT '控制台对外暴露的业务标识',
+    kb_id            VARCHAR(64)  NOT NULL COMMENT '拉取到的对象所落入的知识库',
+    source_type      VARCHAR(16)  NOT NULL COMMENT '连接器类型路由键，本里程碑固定为 s3',
+    name             VARCHAR(128) NOT NULL COMMENT '面向运营人员的展示名称，知识库内唯一',
+    endpoint         VARCHAR(512) NOT NULL COMMENT '对象存储的服务端点',
+    region           VARCHAR(64)           DEFAULT NULL COMMENT '对象存储的可选 region 提示',
+    bucket           VARCHAR(128) NOT NULL COMMENT '扫描所列举的桶名',
+    prefix           VARCHAR(512)          DEFAULT NULL COMMENT '可选的 key 前缀，用于收窄扫描范围',
+    access_key       VARCHAR(256) NOT NULL COMMENT '桶凭据的 access key',
+    -- 刻意明文存储：单管理员控制台、部署在网络隔离环境内，这是 D17 的前提。
+    -- 读接口永不回传这一列；信封加密属于 RBAC 里程碑的范围。
+    secret_key       VARCHAR(512) NOT NULL COMMENT '桶凭据的 secret key，接口永不回传',
+    sync_enabled     TINYINT      NOT NULL DEFAULT 1 COMMENT '置 1 时该数据源纳入定时同步任务',
+    last_sync_at     DATETIME              DEFAULT NULL COMMENT '最近一次同步尝试的执行时间',
+    last_sync_status VARCHAR(16)           DEFAULT NULL COMMENT '最近一次同步结果：SUCCESS 全部成功 / PARTIAL 部分成功 / FAILED 失败',
+    last_error       VARCHAR(512)          DEFAULT NULL COMMENT '最近一次同步失败或仅部分成功的原因，全部成功时为 null',
+    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version     INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted          TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_source_id (source_id),
-    -- One name per knowledge base; the name is what the operator recognises a source by.
+    -- 同一个知识库下名称唯一；运营人员正是靠这个名称来辨认一条数据源的。
     UNIQUE KEY uk_kb_name (kb_id, name),
     KEY idx_kb (kb_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='registered external object store sources feeding documents';
+  COLLATE = utf8mb4_general_ci COMMENT ='已注册的外部对象存储数据源，用于喂养文档';
 
 CREATE TABLE t_kb_ext_source_item
 (
-    id              BIGINT        NOT NULL AUTO_INCREMENT,
-    source_id       VARCHAR(64)   NOT NULL COMMENT 'owning external source business id',
-    object_key      VARCHAR(1024) NOT NULL COMMENT 'object key inside the bucket',
-    -- The equality key: a VARCHAR(1024) cannot carry a unique index, the digest of it can.
-    object_key_hash CHAR(64)      NOT NULL COMMENT 'SHA-256 of the object key, the dedup and lookup key',
-    etag            VARCHAR(128)           DEFAULT NULL COMMENT 'etag of the last ingested object body, the unchanged check',
-    doc_id          VARCHAR(64)            DEFAULT NULL COMMENT 'document the object feeds, null until the first success',
-    last_status     VARCHAR(16)            DEFAULT NULL COMMENT 'SUCCESS/UNCHANGED/SKIPPED/FAILED',
-    last_error      VARCHAR(512)           DEFAULT NULL COMMENT 'why the last sync failed or was skipped, null on success',
-    last_sync_at    DATETIME               DEFAULT NULL COMMENT 'when this object was last visited by a sync',
-    created_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version    INT           NOT NULL DEFAULT 0,
-    deleted         TINYINT       NOT NULL DEFAULT 0,
+    id              BIGINT        NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    source_id       VARCHAR(64)   NOT NULL COMMENT '所属外部数据源的业务标识',
+    object_key      VARCHAR(1024) NOT NULL COMMENT '桶内的对象 key',
+    -- 等值比较用的键：VARCHAR(1024) 撑不起唯一索引，它的摘要可以。
+    object_key_hash CHAR(64)      NOT NULL COMMENT '对象 key 的 SHA-256，去重与查找键',
+    etag            VARCHAR(128)           DEFAULT NULL COMMENT '最近一次入库的对象正文 etag，用于判断内容是否未变',
+    doc_id          VARCHAR(64)            DEFAULT NULL COMMENT '该对象所喂养的文档，首次成功前为 null',
+    last_status     VARCHAR(16)            DEFAULT NULL COMMENT '最近一次同步结果：SUCCESS/UNCHANGED/SKIPPED/FAILED',
+    last_error      VARCHAR(512)           DEFAULT NULL COMMENT '最近一次同步失败或被跳过的原因，成功时为 null',
+    last_sync_at    DATETIME               DEFAULT NULL COMMENT '该对象最近一次被同步任务访问的时间',
+    created_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version    INT           NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted         TINYINT       NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
-    -- One row per object per source; re-listing the same key updates the row instead of adding one.
+    -- 一个数据源下每个对象一行；再次列举到同一个 key 时更新原行，而不是新增一行。
     UNIQUE KEY uk_source_object (source_id, object_key_hash),
     KEY idx_source (source_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='per object sync outcome of an external source';
+  COLLATE = utf8mb4_general_ci COMMENT ='外部数据源逐对象的同步结果';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V1__baseline.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V1__baseline.sql
@@ -1,44 +1,44 @@
--- Baseline schema of the knowledge base service (milestone M1).
--- Conventions applied to every business table: surrogate auto increment primary key, business key
--- as a prefixed varchar, created_at / updated_at, lock_version for optimistic locking, deleted for
--- soft deletion, utf8mb4, and an index on every status column that a compensation scan walks.
--- Later milestones add their tables through V2 and above; this file is never edited after release.
+-- 知识库服务的基线表结构（里程碑 M1）。
+-- 所有业务表统一遵守的约定：自增代理主键、带前缀的 varchar 业务主键、created_at / updated_at、
+-- lock_version 乐观锁、deleted 逻辑删除、utf8mb4 字符集，以及补偿扫描会走的每个状态列都建索引。
+-- 后续里程碑通过 V2 及以上的迁移脚本追加自己的表；本文件发布后不再修改。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_knowledge_base
 (
-    id                         BIGINT       NOT NULL AUTO_INCREMENT,
-    kb_id                      VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the API',
-    name                       VARCHAR(128) NOT NULL COMMENT 'display name',
-    description                VARCHAR(1024)         DEFAULT NULL COMMENT 'free text description',
-    index_config               JSON                  DEFAULT NULL COMMENT 'split and embed parameters',
-    current_config_fingerprint VARCHAR(64)           DEFAULT NULL COMMENT 'drives the document config_stale flag',
-    created_at                 DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at                 DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version               INT          NOT NULL DEFAULT 0,
-    deleted                    TINYINT      NOT NULL DEFAULT 0,
+    id                         BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    kb_id                      VARCHAR(64)  NOT NULL COMMENT '对外暴露的业务标识',
+    name                       VARCHAR(128) NOT NULL COMMENT '展示名称',
+    description                VARCHAR(1024)         DEFAULT NULL COMMENT '自由文本描述',
+    index_config               JSON                  DEFAULT NULL COMMENT '切分与向量化参数',
+    current_config_fingerprint VARCHAR(64)           DEFAULT NULL COMMENT '配置指纹，驱动文档的 config_stale 标记',
+    created_at                 DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at                 DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version               INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted                    TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_kb_id (kb_id),
     KEY idx_name (name)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='knowledge base';
+  COLLATE = utf8mb4_general_ci COMMENT ='知识库';
 
 CREATE TABLE t_kb_document
 (
-    id                 BIGINT       NOT NULL AUTO_INCREMENT,
-    doc_id             VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the API',
-    kb_id              VARCHAR(64)  NOT NULL COMMENT 'owning knowledge base',
-    file_name          VARCHAR(512) NOT NULL COMMENT 'original upload file name',
-    file_ext           VARCHAR(16)  NOT NULL COMMENT 'lower case extension without the dot',
-    file_size          BIGINT       NOT NULL DEFAULT 0 COMMENT 'original size in bytes',
-    current_version_id VARCHAR(64)           DEFAULT NULL COMMENT 'active version pointer',
-    process_status     VARCHAR(32)  NOT NULL COMMENT 'UPLOADED/PARSING/PARSE_FAILED/PARSED/INDEXING/INDEXED/INDEX_FAILED',
-    config_stale       TINYINT      NOT NULL DEFAULT 0 COMMENT 'set when the active version used an older configuration',
-    fail_reason        VARCHAR(1024)         DEFAULT NULL COMMENT 'classified failure cause',
-    created_at         DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at         DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version       INT          NOT NULL DEFAULT 0,
-    deleted            TINYINT      NOT NULL DEFAULT 0,
+    id                 BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    doc_id             VARCHAR(64)  NOT NULL COMMENT '对外暴露的业务标识',
+    kb_id              VARCHAR(64)  NOT NULL COMMENT '所属知识库',
+    file_name          VARCHAR(512) NOT NULL COMMENT '上传时的原始文件名',
+    file_ext           VARCHAR(16)  NOT NULL COMMENT '小写扩展名，不含点号',
+    file_size          BIGINT       NOT NULL DEFAULT 0 COMMENT '原始文件字节数',
+    current_version_id VARCHAR(64)           DEFAULT NULL COMMENT '生效版本指针',
+    process_status     VARCHAR(32)  NOT NULL COMMENT '处理状态：UPLOADED/PARSING/PARSE_FAILED/PARSED/INDEXING/INDEXED/INDEX_FAILED',
+    config_stale       TINYINT      NOT NULL DEFAULT 0 COMMENT '生效版本使用了旧配置时置 1',
+    fail_reason        VARCHAR(1024)         DEFAULT NULL COMMENT '归类后的失败原因',
+    created_at         DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at         DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version       INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted            TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_doc_id (doc_id),
     KEY idx_kb_id (kb_id),
@@ -47,59 +47,59 @@ CREATE TABLE t_kb_document
     KEY idx_config_stale (kb_id, config_stale)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='document master record';
+  COLLATE = utf8mb4_general_ci COMMENT ='文档主记录';
 
 CREATE TABLE t_kb_document_version
 (
-    id                BIGINT      NOT NULL AUTO_INCREMENT,
-    version_id        VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the API',
-    doc_id            VARCHAR(64) NOT NULL COMMENT 'owning document',
-    version           VARCHAR(16) NOT NULL COMMENT 'major.minor, starts at 1.0',
-    minio_object      VARCHAR(512)         DEFAULT NULL COMMENT 'object key of the original file',
-    parsed_object     VARCHAR(512)         DEFAULT NULL COMMENT 'object key of the parsed markdown',
-    content_hash      VARCHAR(64)          DEFAULT NULL COMMENT 'SHA-256 of the original byte stream',
-    parse_fingerprint VARCHAR(64)          DEFAULT NULL COMMENT 'fingerprint of the parse stage inputs',
-    chunk_fingerprint VARCHAR(64)          DEFAULT NULL COMMENT 'fingerprint of the split stage inputs',
-    embedding_version VARCHAR(64)          DEFAULT NULL COMMENT 'embedding model this build used',
-    status            VARCHAR(32) NOT NULL COMMENT 'BUILDING/BUILD_FAILED/READY/ACTIVE/ARCHIVED',
-    active_flag       TINYINT              DEFAULT NULL COMMENT '1 for the single active version, NULL otherwise',
-    changelog         VARCHAR(1024)        DEFAULT NULL COMMENT 'change note shown in the version list',
-    created_at        DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version      INT         NOT NULL DEFAULT 0,
-    deleted           TINYINT     NOT NULL DEFAULT 0,
+    id                BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    version_id        VARCHAR(64) NOT NULL COMMENT '对外暴露的业务标识',
+    doc_id            VARCHAR(64) NOT NULL COMMENT '所属文档',
+    version           VARCHAR(16) NOT NULL COMMENT '版本号 major.minor，从 1.0 开始',
+    minio_object      VARCHAR(512)         DEFAULT NULL COMMENT '原始文件的对象存储 key',
+    parsed_object     VARCHAR(512)         DEFAULT NULL COMMENT '解析产物 markdown 的对象存储 key',
+    content_hash      VARCHAR(64)          DEFAULT NULL COMMENT '原始字节流的 SHA-256',
+    parse_fingerprint VARCHAR(64)          DEFAULT NULL COMMENT '解析阶段入参的指纹',
+    chunk_fingerprint VARCHAR(64)          DEFAULT NULL COMMENT '切分阶段入参的指纹',
+    embedding_version VARCHAR(64)          DEFAULT NULL COMMENT '本次构建使用的向量模型',
+    status            VARCHAR(32) NOT NULL COMMENT '版本状态：BUILDING/BUILD_FAILED/READY/ACTIVE/ARCHIVED',
+    active_flag       TINYINT              DEFAULT NULL COMMENT '唯一生效版本置 1，其余为 NULL',
+    changelog         VARCHAR(1024)        DEFAULT NULL COMMENT '版本列表展示的变更说明',
+    created_at        DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at        DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version      INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted           TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_version_id (version_id),
     UNIQUE KEY uk_doc_version (doc_id, version),
-    -- MySQL treats NULL values as distinct in a unique index, so this enforces at most one active
-    -- version per document while leaving every other row unconstrained.
+    -- MySQL 的唯一索引把多个 NULL 视为互不相同，因此这个索引既能保证「一个文档最多一个生效版本」，
+    -- 又不会约束到其余任何行。
     UNIQUE KEY uk_doc_active (doc_id, active_flag),
     KEY idx_doc_id (doc_id),
     KEY idx_status (status),
     KEY idx_content_hash (content_hash)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='document version';
+  COLLATE = utf8mb4_general_ci COMMENT ='文档版本';
 
 CREATE TABLE t_kb_chunk
 (
-    id                  BIGINT      NOT NULL AUTO_INCREMENT,
-    chunk_id            VARCHAR(64) NOT NULL COMMENT 'business identifier, also the engine primary key',
-    kb_id               VARCHAR(64) NOT NULL COMMENT 'owning knowledge base',
-    doc_id              VARCHAR(64) NOT NULL COMMENT 'owning document',
-    document_version_id VARCHAR(64) NOT NULL COMMENT 'owning version, mandatory for retrieval isolation',
-    content             MEDIUMTEXT COMMENT 'chunk text, MySQL is the fact source',
-    chunk_text_hash     VARCHAR(64)          DEFAULT NULL COMMENT 'SHA-256 of the normalised text',
-    parent_id           VARCHAR(64)          DEFAULT NULL COMMENT 'parent chunk for parent child splitting',
-    seq                 INT         NOT NULL DEFAULT 0 COMMENT 'order inside the version',
-    chunk_type          VARCHAR(32) NOT NULL DEFAULT 'TEXT' COMMENT 'TEXT/IMAGE/CHAT_LOG',
-    enabled             TINYINT     NOT NULL DEFAULT 1 COMMENT '0 excludes the chunk from retrieval',
-    embedding_status    VARCHAR(32) NOT NULL COMMENT 'PENDING/DONE/FAILED/SKIPPED',
-    metadata            JSON                 DEFAULT NULL COMMENT 'non filterable metadata, MySQL only',
-    created_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version        INT         NOT NULL DEFAULT 0,
-    deleted             TINYINT     NOT NULL DEFAULT 0,
+    id                  BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    chunk_id            VARCHAR(64) NOT NULL COMMENT '业务标识，同时也是检索引擎侧的主键',
+    kb_id               VARCHAR(64) NOT NULL COMMENT '所属知识库',
+    doc_id              VARCHAR(64) NOT NULL COMMENT '所属文档',
+    document_version_id VARCHAR(64) NOT NULL COMMENT '所属文档版本，检索隔离必填',
+    content             MEDIUMTEXT COMMENT '分片正文，MySQL 是事实源',
+    chunk_text_hash     VARCHAR(64)          DEFAULT NULL COMMENT '归一化文本的 SHA-256',
+    parent_id           VARCHAR(64)          DEFAULT NULL COMMENT '父子切分时的父分片 id',
+    seq                 INT         NOT NULL DEFAULT 0 COMMENT '在本版本内的排序序号',
+    chunk_type          VARCHAR(32) NOT NULL DEFAULT 'TEXT' COMMENT '分片类型：TEXT/IMAGE/CHAT_LOG',
+    enabled             TINYINT     NOT NULL DEFAULT 1 COMMENT '置 0 时该分片不参与检索',
+    embedding_status    VARCHAR(32) NOT NULL COMMENT '向量化状态：PENDING/DONE/FAILED/SKIPPED',
+    metadata            JSON                 DEFAULT NULL COMMENT '不可过滤的元数据，仅存 MySQL',
+    created_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version        INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted             TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_chunk_id (chunk_id),
     KEY idx_kb_id (kb_id),
@@ -110,47 +110,47 @@ CREATE TABLE t_kb_chunk
     KEY idx_embedding_status (embedding_status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='chunk fact source';
+  COLLATE = utf8mb4_general_ci COMMENT ='分片事实源';
 
 CREATE TABLE t_kb_chunk_index_sync
 (
-    id                  BIGINT       NOT NULL AUTO_INCREMENT,
-    chunk_id            VARCHAR(64)  NOT NULL COMMENT 'chunk business id',
-    physical_index_name VARCHAR(255) NOT NULL COMMENT 'physical index or collection name',
-    engine              VARCHAR(16)  NOT NULL COMMENT 'es/qdrant',
-    status              VARCHAR(32)  NOT NULL COMMENT 'PENDING/SYNCED/FAILED',
-    retry_count         INT          NOT NULL DEFAULT 0,
-    created_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version        INT          NOT NULL DEFAULT 0,
-    deleted             TINYINT      NOT NULL DEFAULT 0,
+    id                  BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    chunk_id            VARCHAR(64)  NOT NULL COMMENT '分片业务 id',
+    physical_index_name VARCHAR(255) NOT NULL COMMENT '物理索引名或集合名',
+    engine              VARCHAR(16)  NOT NULL COMMENT '引擎类型：es/qdrant',
+    status              VARCHAR(32)  NOT NULL COMMENT '同步状态：PENDING/SYNCED/FAILED',
+    retry_count         INT          NOT NULL DEFAULT 0 COMMENT '已重试次数',
+    created_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version        INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted             TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_chunk_index (chunk_id, physical_index_name),
     KEY idx_status (status),
     KEY idx_index_status (physical_index_name, status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='synchronization state per chunk and physical index';
+  COLLATE = utf8mb4_general_ci COMMENT ='分片在各物理索引上的同步状态';
 
 CREATE TABLE t_kb_index_registry
 (
-    id                  BIGINT       NOT NULL AUTO_INCREMENT,
-    kb_id               VARCHAR(64)  NOT NULL COMMENT 'owning knowledge base',
-    engine              VARCHAR(16)  NOT NULL COMMENT 'es/qdrant',
-    physical_index_name VARCHAR(255) NOT NULL COMMENT 'three segment physical name',
-    alias_name          VARCHAR(255) NOT NULL COMMENT 'alias every read and write goes through',
-    is_current          TINYINT      NOT NULL DEFAULT 0 COMMENT '1 when the alias points here',
-    embedding_provider  VARCHAR(64)           DEFAULT NULL,
-    embedding_model     VARCHAR(128)          DEFAULT NULL,
-    embedding_version   VARCHAR(64)           DEFAULT NULL COMMENT 'embedding segment of the physical name',
-    snapshot_version    VARCHAR(32)           DEFAULT NULL COMMENT 'snapshot segment, v1 in M1',
-    schema_version      VARCHAR(32)           DEFAULT NULL COMMENT 'engine field set version',
-    status              VARCHAR(32)  NOT NULL COMMENT 'BUILDING/ACTIVE/PENDING_CLEANUP',
-    task_id             VARCHAR(64)           DEFAULT NULL COMMENT 'task that created this index',
-    created_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version        INT          NOT NULL DEFAULT 0,
-    deleted             TINYINT      NOT NULL DEFAULT 0,
+    id                  BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    kb_id               VARCHAR(64)  NOT NULL COMMENT '所属知识库',
+    engine              VARCHAR(16)  NOT NULL COMMENT '引擎类型：es/qdrant',
+    physical_index_name VARCHAR(255) NOT NULL COMMENT '三段式物理索引名',
+    alias_name          VARCHAR(255) NOT NULL COMMENT '别名，所有读写都经由它',
+    is_current          TINYINT      NOT NULL DEFAULT 0 COMMENT '别名当前指向本行时置 1',
+    embedding_provider  VARCHAR(64)           DEFAULT NULL COMMENT '向量模型提供方',
+    embedding_model     VARCHAR(128)          DEFAULT NULL COMMENT '向量模型名称',
+    embedding_version   VARCHAR(64)           DEFAULT NULL COMMENT '物理索引名中的向量模型段',
+    snapshot_version    VARCHAR(32)           DEFAULT NULL COMMENT '物理索引名中的快照段，M1 固定为 v1',
+    schema_version      VARCHAR(32)           DEFAULT NULL COMMENT '引擎侧字段集版本',
+    status              VARCHAR(32)  NOT NULL COMMENT '索引状态：BUILDING/ACTIVE/PENDING_CLEANUP',
+    task_id             VARCHAR(64)           DEFAULT NULL COMMENT '创建本索引的任务 id',
+    created_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version        INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted             TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_physical_index_name (physical_index_name),
     KEY idx_kb_id (kb_id),
@@ -158,22 +158,22 @@ CREATE TABLE t_kb_index_registry
     KEY idx_status (status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='physical index and alias registry';
+  COLLATE = utf8mb4_general_ci COMMENT ='物理索引与别名注册表';
 
 CREATE TABLE t_kb_task
 (
-    id           BIGINT      NOT NULL AUTO_INCREMENT,
-    task_id      VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the API',
-    task_type    VARCHAR(32) NOT NULL COMMENT 'PARSE/INDEX/REBUILD/CLEANUP',
-    biz_id       VARCHAR(64) NOT NULL COMMENT 'entity the task operates on',
-    status       VARCHAR(32) NOT NULL COMMENT 'PENDING/RUNNING/SUCCESS/FAILED',
-    retry_count  INT         NOT NULL DEFAULT 0,
-    fail_reason  VARCHAR(1024)        DEFAULT NULL COMMENT 'classified failure cause',
-    progress     INT         NOT NULL DEFAULT 0 COMMENT 'completion percentage',
-    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT         NOT NULL DEFAULT 0,
-    deleted      TINYINT     NOT NULL DEFAULT 0,
+    id           BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    task_id      VARCHAR(64) NOT NULL COMMENT '对外暴露的业务标识',
+    task_type    VARCHAR(32) NOT NULL COMMENT '任务类型：PARSE/INDEX/REBUILD/CLEANUP',
+    biz_id       VARCHAR(64) NOT NULL COMMENT '任务操作的业务实体 id',
+    status       VARCHAR(32) NOT NULL COMMENT '任务状态：PENDING/RUNNING/SUCCESS/FAILED',
+    retry_count  INT         NOT NULL DEFAULT 0 COMMENT '已重试次数',
+    fail_reason  VARCHAR(1024)        DEFAULT NULL COMMENT '归类后的失败原因',
+    progress     INT         NOT NULL DEFAULT 0 COMMENT '完成百分比',
+    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_task_id (task_id),
     KEY idx_biz_id (biz_id),
@@ -181,56 +181,56 @@ CREATE TABLE t_kb_task
     KEY idx_type_status (task_type, status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='asynchronous task';
+  COLLATE = utf8mb4_general_ci COMMENT ='异步任务';
 
 CREATE TABLE t_kb_admin_user
 (
-    id                   BIGINT       NOT NULL AUTO_INCREMENT,
-    username             VARCHAR(64)  NOT NULL COMMENT 'login name',
-    password_hash        VARCHAR(128) NOT NULL COMMENT 'BCrypt hash, never returned by the API',
-    must_change_password TINYINT      NOT NULL DEFAULT 1 COMMENT '1 forces a rotation after login',
-    last_login_at        DATETIME              DEFAULT NULL,
-    created_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version         INT          NOT NULL DEFAULT 0,
-    deleted              TINYINT      NOT NULL DEFAULT 0,
+    id                   BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    username             VARCHAR(64)  NOT NULL COMMENT '登录名',
+    password_hash        VARCHAR(128) NOT NULL COMMENT 'BCrypt 摘要，接口永不回传',
+    must_change_password TINYINT      NOT NULL DEFAULT 1 COMMENT '置 1 时登录后强制改密',
+    last_login_at        DATETIME              DEFAULT NULL COMMENT '最近一次登录成功时间',
+    created_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version         INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted              TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_username (username)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='console administrator account';
+  COLLATE = utf8mb4_general_ci COMMENT ='控制台管理员账号';
 
 CREATE TABLE t_kb_system_config
 (
-    id           BIGINT       NOT NULL AUTO_INCREMENT,
-    config_key   VARCHAR(128) NOT NULL COMMENT 'configuration key',
-    config_value TEXT COMMENT 'configuration value, JSON for structured entries',
-    description  VARCHAR(512)          DEFAULT NULL,
-    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT          NOT NULL DEFAULT 0,
-    deleted      TINYINT      NOT NULL DEFAULT 0,
+    id           BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    config_key   VARCHAR(128) NOT NULL COMMENT '配置项键名',
+    config_value TEXT COMMENT '配置项值，结构化配置存 JSON',
+    description  VARCHAR(512)          DEFAULT NULL COMMENT '配置项说明',
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_config_key (config_key)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='global system settings';
+  COLLATE = utf8mb4_general_ci COMMENT ='全局系统配置';
 
 CREATE TABLE t_kb_login_audit
 (
-    id           BIGINT      NOT NULL AUTO_INCREMENT,
-    username     VARCHAR(64) NOT NULL COMMENT 'submitted user name, recorded even when unknown',
-    ip           VARCHAR(64)          DEFAULT NULL COMMENT 'source address',
-    success      TINYINT     NOT NULL DEFAULT 0,
-    reason       VARCHAR(32)          DEFAULT NULL COMMENT 'SUCCESS/USER_NOT_FOUND/BAD_PASSWORD/ACCOUNT_LOCKED',
-    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT         NOT NULL DEFAULT 0,
-    deleted      TINYINT     NOT NULL DEFAULT 0,
+    id           BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    username     VARCHAR(64) NOT NULL COMMENT '提交的用户名，账号不存在时也照样记录',
+    ip           VARCHAR(64)          DEFAULT NULL COMMENT '来源地址',
+    success      TINYINT     NOT NULL DEFAULT 0 COMMENT '本次登录是否成功，1 成功',
+    reason       VARCHAR(32)          DEFAULT NULL COMMENT '结果原因：SUCCESS/USER_NOT_FOUND/BAD_PASSWORD/ACCOUNT_LOCKED',
+    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     KEY idx_created_at (created_at),
     KEY idx_username_created (username, created_at),
     KEY idx_ip_created (ip, created_at)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='console login audit and brute force counter source';
+  COLLATE = utf8mb4_general_ci COMMENT ='控制台登录审计，同时是暴力破解计数的数据来源';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V2__ik_dict_and_retrieval_config.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V2__ik_dict_and_retrieval_config.sql
@@ -1,31 +1,31 @@
--- Milestone M2 schema increment.
--- Adds the ik dictionary table behind the tokenizer hot update channel and the knowledge base level
--- retrieval defaults column. The baseline file is never edited after release, so every later change
--- arrives as its own versioned migration.
+-- 里程碑 M2 的结构增量。
+-- 新增分词器热更新通道背后的 ik 词典表，以及知识库级别的检索默认参数列。
+-- 基线文件发布后不再修改，因此后续每一次变更都以独立的版本化迁移脚本落地。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_ik_dict
 (
-    id           BIGINT      NOT NULL AUTO_INCREMENT,
-    word         VARCHAR(64) NOT NULL COMMENT 'dictionary term served to the ik tokenizer',
-    dict_type    VARCHAR(16) NOT NULL COMMENT 'EXT/STOP',
-    status       VARCHAR(16) NOT NULL DEFAULT 'ENABLED' COMMENT 'ENABLED/DISABLED, only enabled terms are served',
-    remark       VARCHAR(512)         DEFAULT NULL COMMENT 'why the term was added',
-    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT         NOT NULL DEFAULT 0,
-    deleted      TINYINT     NOT NULL DEFAULT 0,
+    id           BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    word         VARCHAR(64) NOT NULL COMMENT '下发给 ik 分词器的词条',
+    dict_type    VARCHAR(16) NOT NULL COMMENT '词典类型：EXT 扩展词 / STOP 停用词',
+    status       VARCHAR(16) NOT NULL DEFAULT 'ENABLED' COMMENT '状态：ENABLED/DISABLED，只有启用的词条会被下发',
+    remark       VARCHAR(512)         DEFAULT NULL COMMENT '添加该词条的原因',
+    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
-    -- One term is one entry regardless of its kind: a word cannot be both an extension term and a
-    -- stop word, and the management API addresses an entry by its word alone.
+    -- 不分类型，一个词就是一条记录：同一个词不可能既是扩展词又是停用词，
+    -- 而且管理接口只用词本身来定位一条记录。
     UNIQUE KEY uk_word (word),
     KEY idx_type_status (dict_type, status),
-    -- The rendered dictionary is ordered by word, so the serving query reads this index directly.
+    -- 下发的词典按 word 排序，因此下发查询可以直接走这个索引。
     KEY idx_type_word (dict_type, word)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='ik tokenizer dictionary';
+  COLLATE = utf8mb4_general_ci COMMENT ='ik 分词器词典';
 
 ALTER TABLE t_kb_knowledge_base
     ADD COLUMN retrieval_config JSON DEFAULT NULL
-        COMMENT 'knowledge base level retrieval defaults, overridden by request parameters'
+        COMMENT '知识库级别的检索默认参数，可被请求参数覆盖'
         AFTER current_config_fingerprint;

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V3__image_asset_and_chat_source.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V3__image_asset_and_chat_source.sql
@@ -1,47 +1,46 @@
--- Milestone M3 schema increment: multimodal assets and the logical source identity of a document.
--- The baseline and V2 are never edited after release, so every later change arrives as its own migration.
+-- 里程碑 M3 的结构增量：多模态资产，以及文档的逻辑来源标识。
+-- 基线与 V2 发布后不再修改，因此后续每一次变更都以独立的迁移脚本落地。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_image_asset
 (
-    id                  BIGINT      NOT NULL AUTO_INCREMENT,
-    image_id            VARCHAR(64) NOT NULL COMMENT 'globally unique business identifier',
-    -- The parser numbers its images per document (img_1, img_2), which cannot carry a global unique key,
-    -- so the placeholder identifier lives in its own column next to the global one.
-    source_image_id     VARCHAR(64) NOT NULL COMMENT 'identifier used inside the [[IMAGE:id]] placeholder',
-    kb_id               VARCHAR(64) NOT NULL COMMENT 'owning knowledge base',
-    doc_id              VARCHAR(64) NOT NULL COMMENT 'owning document',
-    document_version_id VARCHAR(64) NOT NULL COMMENT 'owning document version',
-    page_no             INT                  DEFAULT NULL COMMENT 'one based page, null for formats without pages',
-    kind                VARCHAR(16) NOT NULL COMMENT 'EMBEDDED/PAGE_RENDER/STANDALONE',
-    object_key          VARCHAR(512) NOT NULL COMMENT 'object storage key of the binary',
-    media_type          VARCHAR(64)          DEFAULT NULL COMMENT 'MIME type of the binary',
-    bytes               BIGINT      NOT NULL DEFAULT 0 COMMENT 'size of the binary in bytes',
-    text_proxy          MEDIUMTEXT           DEFAULT NULL COMMENT 'description and transcription from the vision model',
-    status              VARCHAR(16) NOT NULL COMMENT 'PENDING/DONE/SKIPPED/FAILED',
-    fail_reason         VARCHAR(1024)        DEFAULT NULL COMMENT 'classified cause when status is FAILED',
-    created_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version        INT         NOT NULL DEFAULT 0,
-    deleted             TINYINT     NOT NULL DEFAULT 0,
+    id                  BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    image_id            VARCHAR(64) NOT NULL COMMENT '全局唯一的业务标识',
+    -- 解析器是按文档给图片编号的（img_1、img_2），这种编号扛不住全局唯一约束，
+    -- 因此占位符里的标识单独用一列存放，与全局标识并列。
+    source_image_id     VARCHAR(64) NOT NULL COMMENT '[[IMAGE:id]] 占位符中使用的标识',
+    kb_id               VARCHAR(64) NOT NULL COMMENT '所属知识库',
+    doc_id              VARCHAR(64) NOT NULL COMMENT '所属文档',
+    document_version_id VARCHAR(64) NOT NULL COMMENT '所属文档版本',
+    page_no             INT                  DEFAULT NULL COMMENT '页码，从 1 开始；无分页概念的格式为 null',
+    kind                VARCHAR(16) NOT NULL COMMENT '图片来源：EMBEDDED 内嵌 / PAGE_RENDER 整页渲染 / STANDALONE 独立文件',
+    object_key          VARCHAR(512) NOT NULL COMMENT '二进制内容的对象存储 key',
+    media_type          VARCHAR(64)          DEFAULT NULL COMMENT '二进制内容的 MIME 类型',
+    bytes               BIGINT      NOT NULL DEFAULT 0 COMMENT '二进制内容的字节数',
+    text_proxy          MEDIUMTEXT           DEFAULT NULL COMMENT '视觉模型产出的图片描述与文字转录',
+    status              VARCHAR(16) NOT NULL COMMENT '处理状态：PENDING/DONE/SKIPPED/FAILED',
+    fail_reason         VARCHAR(1024)        DEFAULT NULL COMMENT 'status 为 FAILED 时归类后的失败原因',
+    created_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version        INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted             TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_image_id (image_id),
-    -- The placeholder identifier only has to be unique inside one version, which is also the lookup the
-    -- pipeline performs when it splices the proxies back into the text.
+    -- 占位符标识只需在单个版本内唯一，而这也正是流水线把图片代理文本回填进正文时所做的查询。
     UNIQUE KEY uk_version_source (document_version_id, source_image_id),
     KEY idx_kb_id (kb_id),
     KEY idx_doc_id (doc_id),
     KEY idx_document_version_id (document_version_id),
-    -- A backfill pass walks the assets that carry no text yet, so the status is indexed like every other
-    -- column a scan drives itself from.
+    -- 补偿任务会扫描还没有代理文本的资产，因此 status 和其他被扫描驱动的列一样建索引。
     KEY idx_status (status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='image asset and its textual proxy';
+  COLLATE = utf8mb4_general_ci COMMENT ='图片资产及其文本代理';
 
--- A chat conversation is a logical document rather than a file: the identity has to survive a rename and a
--- second export, which the display file name cannot do.
+-- 一次聊天会话是逻辑文档而不是一个文件：它的身份要能扛住重命名和二次导出，
+-- 而用于展示的文件名做不到这一点。
 ALTER TABLE t_kb_document
     ADD COLUMN source_key VARCHAR(255) DEFAULT NULL
-        COMMENT 'logical source identity, chat:{session_id} for a chat import, null for a plain upload'
+        COMMENT '逻辑来源标识，聊天导入为 chat:{session_id}，普通上传为 null'
         AFTER fail_reason,
     ADD KEY idx_kb_source_key (kb_id, source_key);

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V4__annotation.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V4__annotation.sql
@@ -1,33 +1,33 @@
--- Milestone M4a schema increment: the audit trail of the manual chunk operations.
--- The baseline and V2/V3 are never edited after release, so every later change arrives as its own migration.
+-- 里程碑 M4a 的结构增量：人工分片操作的审计流水。
+-- 基线与 V2/V3 发布后不再修改，因此后续每一次变更都以独立的迁移脚本落地。
 --
--- t_kb_chunk needs no new column: parent_id, enabled and chunk_text_hash all exist since the baseline,
--- and the two knowledge base switches this milestone adds live inside the index_config JSON document
--- rather than in a column of their own, because they are configuration and not schema.
+-- t_kb_chunk 不需要新增列：parent_id、enabled 和 chunk_text_hash 从基线起就存在；
+-- 本里程碑引入的两个知识库开关放在 index_config 这个 JSON 文档里，而不是各占一列，
+-- 因为它们属于配置而不是表结构。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_annotation
 (
-    id                  BIGINT      NOT NULL AUTO_INCREMENT,
-    annotation_id       VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the API',
-    kb_id               VARCHAR(64) NOT NULL COMMENT 'owning knowledge base',
-    doc_id              VARCHAR(64) NOT NULL COMMENT 'owning document, stable across versions',
-    -- An annotation is only meaningful next to the chunks it was made against, because a new version may
-    -- cut the document differently; chunk_text_hash is what lets a disable decision still be recognised.
-    document_version_id VARCHAR(64) NOT NULL COMMENT 'document version the operation was performed against',
-    chunk_id            VARCHAR(64) NOT NULL COMMENT 'operation target, the first source for a merge or split',
-    annotation_type     VARCHAR(16) NOT NULL COMMENT 'EDIT/TOGGLE/MERGE/SPLIT',
-    payload             JSON                 DEFAULT NULL COMMENT 'source ids, split offsets, excerpts, enabled state',
-    chunk_text_hash     VARCHAR(64)          DEFAULT NULL COMMENT 'normalised text digest, drives cross version inheritance',
-    inherit_status      VARCHAR(16) NOT NULL COMMENT 'NOT_INHERITED/AUTO_INHERITED/REDONE',
-    -- Digest of target, kind and resulting content. Deliberately a plain index rather than a unique key:
-    -- annotations are soft deleted with their document, and a unique index would reject the identical
-    -- operation after the same file is uploaded again.
-    idempotency_key     VARCHAR(64) NOT NULL COMMENT 'recognises a resubmitted operation',
-    operator            VARCHAR(64) NOT NULL COMMENT 'console account that performed the operation',
-    created_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version        INT         NOT NULL DEFAULT 0,
-    deleted             TINYINT     NOT NULL DEFAULT 0,
+    id                  BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    annotation_id       VARCHAR(64) NOT NULL COMMENT '对外暴露的业务标识',
+    kb_id               VARCHAR(64) NOT NULL COMMENT '所属知识库',
+    doc_id              VARCHAR(64) NOT NULL COMMENT '所属文档，跨版本保持稳定',
+    -- 一条标注只有放在它当初针对的那批分片旁边才有意义，因为新版本可能会用不同的方式切分文档；
+    -- 靠 chunk_text_hash，一次「停用」决定在新版本里才仍然可以被识别出来。
+    document_version_id VARCHAR(64) NOT NULL COMMENT '执行本次操作时所针对的文档版本',
+    chunk_id            VARCHAR(64) NOT NULL COMMENT '操作目标分片；合并或拆分时为第一个源分片',
+    annotation_type     VARCHAR(16) NOT NULL COMMENT '操作类型：EDIT 编辑 / TOGGLE 启停 / MERGE 合并 / SPLIT 拆分',
+    payload             JSON                 DEFAULT NULL COMMENT '操作载荷：源分片 id、拆分偏移、摘录片段、启停状态',
+    chunk_text_hash     VARCHAR(64)          DEFAULT NULL COMMENT '归一化文本摘要，驱动跨版本的标注继承',
+    inherit_status      VARCHAR(16) NOT NULL COMMENT '继承状态：NOT_INHERITED 未继承 / AUTO_INHERITED 自动继承 / REDONE 已重做',
+    -- 由操作目标、操作类型和结果内容摘要而成。这里刻意用普通索引而不是唯一索引：
+    -- 标注会随文档一起被逻辑删除，唯一索引会让同一个文件二次上传后无法再执行同样的操作。
+    idempotency_key     VARCHAR(64) NOT NULL COMMENT '幂等键，用于识别重复提交的同一次操作',
+    operator            VARCHAR(64) NOT NULL COMMENT '执行本次操作的控制台账号',
+    created_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version        INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted             TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_annotation_id (annotation_id),
     KEY idx_kb_id (kb_id),
@@ -36,10 +36,10 @@ CREATE TABLE t_kb_annotation
     KEY idx_chunk_id (chunk_id),
     KEY idx_chunk_text_hash (chunk_text_hash),
     KEY idx_idempotency_key (idempotency_key),
-    -- The inheritance pass walks the toggles of one document and the review list walks the open items,
-    -- so both scans get the composite index they drive themselves from.
+    -- 继承任务扫描单个文档的启停标注，待办列表扫描单个文档的未处理项，
+    -- 两个扫描各自拿到能直接驱动自己的联合索引。
     KEY idx_doc_type (doc_id, annotation_type),
     KEY idx_doc_inherit (doc_id, inherit_status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='manual chunk operation audit trail';
+  COLLATE = utf8mb4_general_ci COMMENT ='人工分片操作审计流水';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V5__evaluation.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V5__evaluation.sql
@@ -1,48 +1,49 @@
--- Milestone M4b schema increment: the evaluation subsystem.
--- The baseline and V1-V4 are never edited after release, so every later change arrives as its own migration.
+-- 里程碑 M4b 的结构增量：评测子系统。
+-- 基线与 V1-V4 发布后不再修改，因此后续每一次变更都以独立的迁移脚本落地。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_eval_dataset
 (
-    id               BIGINT       NOT NULL AUTO_INCREMENT,
-    dataset_id       VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the API',
-    kb_id            VARCHAR(64)  NOT NULL COMMENT 'owning knowledge base',
-    name             VARCHAR(128) NOT NULL COMMENT 'display name',
-    description      VARCHAR(1024)         DEFAULT NULL COMMENT 'free text description',
-    -- Bumped on every case insert, edit, delete and status change; a run snapshots this value so the
-    -- compare endpoint can refuse to place two runs side by side once the case set moved between them.
-    dataset_revision INT          NOT NULL DEFAULT 0 COMMENT 'incremented on any case mutation',
-    case_count       INT          NOT NULL DEFAULT 0 COMMENT 'derived redundant count of non deprecated cases',
-    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version     INT          NOT NULL DEFAULT 0,
-    deleted          TINYINT      NOT NULL DEFAULT 0,
+    id               BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    dataset_id       VARCHAR(64)  NOT NULL COMMENT '对外暴露的业务标识',
+    kb_id            VARCHAR(64)  NOT NULL COMMENT '所属知识库',
+    name             VARCHAR(128) NOT NULL COMMENT '展示名称',
+    description      VARCHAR(1024)         DEFAULT NULL COMMENT '自由文本描述',
+    -- 用例的新增、编辑、删除和状态变更都会让它加一；每次评测运行会把这个值快照下来，
+    -- 于是当两次运行之间用例集发生了变动，对比接口就能拒绝把它们并排展示。
+    dataset_revision INT          NOT NULL DEFAULT 0 COMMENT '用例集修订号，任一用例变更即加一',
+    case_count       INT          NOT NULL DEFAULT 0 COMMENT '未废弃用例的冗余计数，派生字段',
+    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version     INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted          TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_dataset_id (dataset_id),
     KEY idx_kb_id (kb_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='evaluation data set';
+  COLLATE = utf8mb4_general_ci COMMENT ='评测数据集';
 
 CREATE TABLE t_kb_eval_case
 (
-    id               BIGINT      NOT NULL AUTO_INCREMENT,
-    case_id          VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the API',
-    dataset_id       VARCHAR(64) NOT NULL COMMENT 'owning data set',
-    query            TEXT        NOT NULL COMMENT 'user query',
-    -- Conversation history, requirement section 4.5 "multi turn case". NULL keeps the case single turn.
-    messages         JSON                 DEFAULT NULL COMMENT 'optional conversation history array',
-    expected_answer  TEXT                 DEFAULT NULL COMMENT 'reference answer, consumed only by LLM-as-judge',
-    anchor_type      VARCHAR(16) NOT NULL COMMENT 'SPAN/DOCUMENT',
-    -- Anchored to doc_id rather than to a chunk id so the case survives a split strategy change; span is
-    -- null for every element when anchor_type is DOCUMENT. See EvalEvidence.
-    evidences        JSON        NOT NULL COMMENT 'array of {doc_id, span, annotated_version_id}',
-    status           VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/EVIDENCE_STALE/DEPRECATED',
-    source           VARCHAR(16) NOT NULL DEFAULT 'MANUAL' COMMENT 'MANUAL/DEBUG_PAGE/IMPORTED',
-    note             VARCHAR(1024)        DEFAULT NULL COMMENT 'free text operator note',
-    created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version     INT         NOT NULL DEFAULT 0,
-    deleted          TINYINT     NOT NULL DEFAULT 0,
+    id               BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    case_id          VARCHAR(64) NOT NULL COMMENT '对外暴露的业务标识',
+    dataset_id       VARCHAR(64) NOT NULL COMMENT '所属数据集',
+    query            TEXT        NOT NULL COMMENT '用户查询',
+    -- 对话历史，对应需求文档 4.5 节「多轮用例」。为 NULL 时该用例是单轮的。
+    messages         JSON                 DEFAULT NULL COMMENT '可选的对话历史数组',
+    expected_answer  TEXT                 DEFAULT NULL COMMENT '参考答案，仅 LLM-as-judge 会用到',
+    anchor_type      VARCHAR(16) NOT NULL COMMENT '证据锚点类型：SPAN 片段级 / DOCUMENT 文档级',
+    -- 锚定到 doc_id 而不是 chunk id，这样切分策略变更后用例依然成立；
+    -- anchor_type 为 DOCUMENT 时每个元素的 span 都是 null。参见 EvalEvidence。
+    evidences        JSON        NOT NULL COMMENT '证据数组，元素为 {doc_id, span, annotated_version_id}',
+    status           VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT '用例状态：ACTIVE 生效 / EVIDENCE_STALE 证据失效 / DEPRECATED 已废弃',
+    source           VARCHAR(16) NOT NULL DEFAULT 'MANUAL' COMMENT '用例来源：MANUAL 手工 / DEBUG_PAGE 调试页转化 / IMPORTED 导入',
+    note             VARCHAR(1024)        DEFAULT NULL COMMENT '运营人员的自由文本备注',
+    created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version     INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted          TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_case_id (case_id),
     KEY idx_dataset_id (dataset_id),
@@ -50,36 +51,36 @@ CREATE TABLE t_kb_eval_case
     KEY idx_dataset_status (dataset_id, status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='evaluation case: query, optional history, evidence anchors';
+  COLLATE = utf8mb4_general_ci COMMENT ='评测用例：查询、可选对话历史与证据锚点';
 
 CREATE TABLE t_kb_eval_run
 (
-    id                   BIGINT       NOT NULL AUTO_INCREMENT,
-    run_id               VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the API',
-    dataset_id           VARCHAR(64)  NOT NULL COMMENT 'data set this run measures',
-    kb_id                VARCHAR(64)  NOT NULL COMMENT 'owning knowledge base, denormalised for listing',
-    dataset_revision     INT          NOT NULL COMMENT 'data set revision snapshotted at run creation',
-    -- Hash of the active version set plus the embedding version plus the dictionary version, requirement
-    -- section 4.6. Two runs only compare when both dataset_revision and this fingerprint match.
-    corpus_fingerprint   VARCHAR(64)  NOT NULL COMMENT 'active corpus state this run measured against',
-    -- One row of the EvalRetrievalConfig JSON, including its label and mode: the report page renders a
-    -- run's column back from this document without reassembling it from separate columns.
-    retrieval_config     JSON         NOT NULL COMMENT 'label, mode and retrieval parameters used by this run',
-    judge_model          VARCHAR(128)          DEFAULT NULL COMMENT 'LLM-as-judge model, null when judging was off',
-    judge_prompt_version VARCHAR(32)           DEFAULT NULL COMMENT 'judge prompt version, null when judging was off',
-    status               VARCHAR(16)  NOT NULL DEFAULT 'PENDING' COMMENT 'PENDING/RUNNING/SUCCESS/FAILED',
-    metrics              JSON                  DEFAULT NULL COMMENT 'grouped metrics with 95% CI, null until finished',
-    case_total           INT          NOT NULL DEFAULT 0 COMMENT 'cases in the data set at run start',
-    case_effective       INT          NOT NULL DEFAULT 0 COMMENT 'cases actually judged',
-    case_stale           INT          NOT NULL DEFAULT 0 COMMENT 'cases skipped for stale evidence',
-    case_degraded        INT          NOT NULL DEFAULT 0 COMMENT 'cases still degraded after the automatic retry',
-    fail_reason          VARCHAR(1024)         DEFAULT NULL COMMENT 'set only when status is FAILED',
-    started_at           DATETIME              DEFAULT NULL,
-    finished_at          DATETIME              DEFAULT NULL,
-    created_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version         INT          NOT NULL DEFAULT 0,
-    deleted              TINYINT      NOT NULL DEFAULT 0,
+    id                   BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    run_id               VARCHAR(64)  NOT NULL COMMENT '对外暴露的业务标识',
+    dataset_id           VARCHAR(64)  NOT NULL COMMENT '本次运行所测的数据集',
+    kb_id                VARCHAR(64)  NOT NULL COMMENT '所属知识库，为列表查询做的反范式冗余',
+    dataset_revision     INT          NOT NULL COMMENT '创建运行时快照下来的数据集修订号',
+    -- 由生效版本集合、向量模型版本和词典版本一起哈希而成，对应需求文档 4.6 节。
+    -- 只有 dataset_revision 与本指纹都一致，两次运行才可以对比。
+    corpus_fingerprint   VARCHAR(64)  NOT NULL COMMENT '语料指纹，标识本次运行所面对的生效语料状态',
+    -- 完整存下一份 EvalRetrievalConfig JSON，含它的标签与模式：报告页直接从这个文档还原出
+    -- 该运行对应的那一列，不需要再从若干个独立列拼装回去。
+    retrieval_config     JSON         NOT NULL COMMENT '本次运行使用的标签、模式与检索参数',
+    judge_model          VARCHAR(128)          DEFAULT NULL COMMENT 'LLM-as-judge 模型，未开启评判时为 null',
+    judge_prompt_version VARCHAR(32)           DEFAULT NULL COMMENT '评判提示词版本，未开启评判时为 null',
+    status               VARCHAR(16)  NOT NULL DEFAULT 'PENDING' COMMENT '运行状态：PENDING/RUNNING/SUCCESS/FAILED',
+    metrics              JSON                  DEFAULT NULL COMMENT '分组指标（含 95% 置信区间），运行结束前为 null',
+    case_total           INT          NOT NULL DEFAULT 0 COMMENT '运行开始时数据集内的用例总数',
+    case_effective       INT          NOT NULL DEFAULT 0 COMMENT '实际参与评判的用例数',
+    case_stale           INT          NOT NULL DEFAULT 0 COMMENT '因证据失效被跳过的用例数',
+    case_degraded        INT          NOT NULL DEFAULT 0 COMMENT '自动重试后仍处于降级状态的用例数',
+    fail_reason          VARCHAR(1024)         DEFAULT NULL COMMENT '仅当 status 为 FAILED 时写入的失败原因',
+    started_at           DATETIME              DEFAULT NULL COMMENT '运行开始时间',
+    finished_at          DATETIME              DEFAULT NULL COMMENT '运行结束时间',
+    created_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version         INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted              TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_run_id (run_id),
     KEY idx_dataset_id (dataset_id),
@@ -87,26 +88,26 @@ CREATE TABLE t_kb_eval_run
     KEY idx_dataset_created (dataset_id, id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='evaluation run: one retrieval configuration measured once';
+  COLLATE = utf8mb4_general_ci COMMENT ='评测运行：对单套检索配置的一次测量';
 
 CREATE TABLE t_kb_eval_result
 (
-    id                 BIGINT      NOT NULL AUTO_INCREMENT,
-    result_id          VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the API',
-    run_id             VARCHAR(64) NOT NULL COMMENT 'owning run',
-    case_id            VARCHAR(64) NOT NULL COMMENT 'case judged',
-    hit                TINYINT     NOT NULL DEFAULT 0 COMMENT '1 when the case was recalled in the top K',
-    hit_rank           INT                  DEFAULT NULL COMMENT 'one based rank of the first hit, null otherwise',
-    overlap_ratios     JSON                 DEFAULT NULL COMMENT 'best aggregate coverage ratio per evidence',
-    recalled_chunk_ids JSON                 DEFAULT NULL COMMENT 'chunk ids the top K returned for this case',
-    degraded           JSON                 DEFAULT NULL COMMENT 'degradation markers observed while judging',
-    retry_count        INT         NOT NULL DEFAULT 0 COMMENT 'automatic retries this case went through',
-    judge_score        INT                  DEFAULT NULL COMMENT 'LLM-as-judge score, null when not judged',
-    judge_reason       VARCHAR(2048)        DEFAULT NULL COMMENT 'LLM-as-judge free text rationale',
-    created_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version       INT         NOT NULL DEFAULT 0,
-    deleted            TINYINT     NOT NULL DEFAULT 0,
+    id                 BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    result_id          VARCHAR(64) NOT NULL COMMENT '对外暴露的业务标识',
+    run_id             VARCHAR(64) NOT NULL COMMENT '所属评测运行',
+    case_id            VARCHAR(64) NOT NULL COMMENT '被评判的用例',
+    hit                TINYINT     NOT NULL DEFAULT 0 COMMENT '用例在 Top K 内被召回时置 1',
+    hit_rank           INT                  DEFAULT NULL COMMENT '首个命中的名次（从 1 开始），未命中为 null',
+    overlap_ratios     JSON                 DEFAULT NULL COMMENT '每条证据的最佳聚合覆盖率',
+    recalled_chunk_ids JSON                 DEFAULT NULL COMMENT '本用例 Top K 返回的分片 id 列表',
+    degraded           JSON                 DEFAULT NULL COMMENT '评判过程中观察到的降级标记',
+    retry_count        INT         NOT NULL DEFAULT 0 COMMENT '本用例经历的自动重试次数',
+    judge_score        INT                  DEFAULT NULL COMMENT 'LLM-as-judge 打分，未评判时为 null',
+    judge_reason       VARCHAR(2048)        DEFAULT NULL COMMENT 'LLM-as-judge 给出的自由文本理由',
+    created_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version       INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted            TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_result_id (result_id),
     KEY idx_run_id (run_id),
@@ -114,4 +115,4 @@ CREATE TABLE t_kb_eval_result
     KEY idx_run_hit (run_id, hit)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='per case judgment of one evaluation run';
+  COLLATE = utf8mb4_general_ci COMMENT ='评测运行下逐用例的评判结果';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V6__app_release_and_open_api.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V6__app_release_and_open_api.sql
@@ -1,54 +1,52 @@
--- Milestone M4c schema increment: applications, version release with the evaluation gate, API keys
--- and the outbound call audit trail.
--- The baseline and V1-V5 are never edited after release, so every later change arrives as its own migration.
+-- 里程碑 M4c 的结构增量：应用、带评测门禁的版本发布、API Key，以及对外调用的审计流水。
+-- 基线与 V1-V5 发布后不再修改，因此后续每一次变更都以独立的迁移脚本落地。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_app
 (
-    id           BIGINT       NOT NULL AUTO_INCREMENT,
-    app_id       VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the API',
-    name         VARCHAR(128) NOT NULL COMMENT 'display name',
-    description  VARCHAR(1024)         DEFAULT NULL COMMENT 'free text description',
-    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT          NOT NULL DEFAULT 0,
-    deleted      TINYINT      NOT NULL DEFAULT 0,
+    id           BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    app_id       VARCHAR(64)  NOT NULL COMMENT '对外暴露的业务标识',
+    name         VARCHAR(128) NOT NULL COMMENT '展示名称',
+    description  VARCHAR(1024)         DEFAULT NULL COMMENT '自由文本描述',
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_app_id (app_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='knowledge base application';
+  COLLATE = utf8mb4_general_ci COMMENT ='知识库应用';
 
 CREATE TABLE t_kb_app_version
 (
-    id              BIGINT      NOT NULL AUTO_INCREMENT,
-    app_version_id  VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the API',
-    app_id          VARCHAR(64) NOT NULL COMMENT 'owning application',
-    version         VARCHAR(16) NOT NULL COMMENT 'display version, V1.0 then V2.0 and so on',
+    id              BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    app_version_id  VARCHAR(64) NOT NULL COMMENT '对外暴露的业务标识',
+    app_id          VARCHAR(64) NOT NULL COMMENT '所属应用',
+    version         VARCHAR(16) NOT NULL COMMENT '展示版本号，依次为 V1.0、V2.0 ……',
     status          VARCHAR(24) NOT NULL DEFAULT 'DRAFT'
-        COMMENT 'DRAFT/TESTING/GATING/GATE_PASSED/GATE_LOG_ONLY/GATE_BLOCKED/RELEASED/SUPERSEDED',
-    -- Frozen at release time and never re-read from the knowledge base afterwards, requirement
-    -- section 4.7 "configuration snapshot": single kb_id (multi base arrives with M5), the retrieval
-    -- parameters and the question answering prompt block.
-    config          JSON        NOT NULL COMMENT 'full retrieval and prompt configuration snapshot',
-    gate_dataset_id VARCHAR(64)          DEFAULT NULL COMMENT 'baseline evaluation data set, null skips the gate',
-    gate_run_ids    JSON                 DEFAULT NULL COMMENT 'the two run ids of the dual run, candidate first',
-    gate_verdict    VARCHAR(16)          DEFAULT NULL COMMENT 'PASS/BLOCKED/LOG_ONLY, three state gate outcome',
-    gate_reason     VARCHAR(32)          DEFAULT NULL COMMENT 'classified reason behind gate_verdict',
-    gate_report     JSON                 DEFAULT NULL COMMENT 'intersection metrics of both sides plus the tolerance',
-    force_released  TINYINT     NOT NULL DEFAULT 0 COMMENT '1 when an administrator forced the release',
-    force_operator  VARCHAR(64)          DEFAULT NULL COMMENT 'who forced the release, audit trail',
-    changelog       VARCHAR(1024)        DEFAULT NULL COMMENT 'version description',
-    released_at     DATETIME             DEFAULT NULL COMMENT 'last time this version became the released one',
-    -- Virtual column plus unique index is what enforces "at most one released version per application"
-    -- in the database rather than in application code, requirement section 4.7. It resolves to NULL for
-    -- every other status and for soft deleted rows, and MySQL allows any number of NULLs in a unique
-    -- index, so only the released rows compete for the slot.
+        COMMENT '版本状态：DRAFT/TESTING/GATING/GATE_PASSED/GATE_LOG_ONLY/GATE_BLOCKED/RELEASED/SUPERSEDED',
+    -- 发布时冻结，此后再也不会回到知识库重新读取，对应需求文档 4.7 节「配置快照」：
+    -- 单个 kb_id（多知识库在 M5 才引入）、检索参数，以及问答提示词块。
+    config          JSON        NOT NULL COMMENT '完整的检索与提示词配置快照',
+    gate_dataset_id VARCHAR(64)          DEFAULT NULL COMMENT '门禁基线评测数据集，为 null 时跳过门禁',
+    gate_run_ids    JSON                 DEFAULT NULL COMMENT '双跑的两个运行 id，候选版本在前',
+    gate_verdict    VARCHAR(16)          DEFAULT NULL COMMENT '门禁三态结论：PASS 通过 / BLOCKED 拦截 / LOG_ONLY 仅记录',
+    gate_reason     VARCHAR(32)          DEFAULT NULL COMMENT 'gate_verdict 背后归类后的原因',
+    gate_report     JSON                 DEFAULT NULL COMMENT '双方交集指标与容差阈值',
+    force_released  TINYINT     NOT NULL DEFAULT 0 COMMENT '管理员强制发布时置 1',
+    force_operator  VARCHAR(64)          DEFAULT NULL COMMENT '强制发布的操作人，用于审计',
+    changelog       VARCHAR(1024)        DEFAULT NULL COMMENT '版本说明',
+    released_at     DATETIME             DEFAULT NULL COMMENT '本版本最近一次成为发布版的时间',
+    -- 「一个应用最多一个发布版」这条约束靠虚拟列加唯一索引在数据库层强制，而不是放在应用代码里，
+    -- 对应需求文档 4.7 节。其余状态和逻辑删除行上它都求值为 NULL，而 MySQL 的唯一索引允许任意多个
+    -- NULL，因此只有处于发布状态的行才会去争这个槽位。
     released_slot   VARCHAR(64) GENERATED ALWAYS AS
-        (IF(status = 'RELEASED' AND deleted = 0, app_id, NULL)) VIRTUAL,
-    created_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version    INT         NOT NULL DEFAULT 0,
-    deleted         TINYINT     NOT NULL DEFAULT 0,
+        (IF(status = 'RELEASED' AND deleted = 0, app_id, NULL)) VIRTUAL COMMENT '发布槽位虚拟列，仅发布版求值为 app_id，其余为 NULL',
+    created_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version    INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted         TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_app_version_id (app_version_id),
     UNIQUE KEY uk_released_slot (released_slot),
@@ -56,55 +54,54 @@ CREATE TABLE t_kb_app_version
     KEY idx_status (status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='application version: configuration snapshot and release state machine';
+  COLLATE = utf8mb4_general_ci COMMENT ='应用版本：配置快照与发布状态机';
 
 CREATE TABLE t_kb_api_key
 (
-    id           BIGINT       NOT NULL AUTO_INCREMENT,
-    key_id       VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the API',
-    name         VARCHAR(128) NOT NULL COMMENT 'display name of the caller this key was issued to',
-    -- Only the digest is stored: the plaintext is shown once at creation and never again, so a database
-    -- dump cannot be replayed against the open API, requirement section 4.8.
-    key_hash     CHAR(64)     NOT NULL COMMENT 'SHA-256 of the plaintext key',
-    prefix       VARCHAR(32)  NOT NULL COMMENT 'display only form, leading segment plus the last 4 characters',
-    status       VARCHAR(16)  NOT NULL DEFAULT 'ENABLED' COMMENT 'ENABLED/DISABLED',
-    qps_limit    INT          NOT NULL DEFAULT 10 COMMENT 'token bucket rate of this key',
-    app_scope    JSON                  DEFAULT NULL COMMENT 'allowed app ids, null authorises every application',
-    last_used_at DATETIME              DEFAULT NULL COMMENT 'last successful authentication',
-    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT          NOT NULL DEFAULT 0,
-    deleted      TINYINT      NOT NULL DEFAULT 0,
+    id           BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    key_id       VARCHAR(64)  NOT NULL COMMENT '对外暴露的业务标识',
+    name         VARCHAR(128) NOT NULL COMMENT '该 Key 所签发给的调用方展示名称',
+    -- 只存摘要：明文仅在创建时展示一次、此后再也不会出现，因此即使数据库被拖库，
+    -- 也无法拿去重放开放接口，对应需求文档 4.8 节。
+    key_hash     CHAR(64)     NOT NULL COMMENT '明文 Key 的 SHA-256 摘要',
+    prefix       VARCHAR(32)  NOT NULL COMMENT '仅用于展示的形式：前缀段加末尾 4 位',
+    status       VARCHAR(16)  NOT NULL DEFAULT 'ENABLED' COMMENT '状态：ENABLED 启用 / DISABLED 停用',
+    qps_limit    INT          NOT NULL DEFAULT 10 COMMENT '该 Key 的令牌桶速率',
+    app_scope    JSON                  DEFAULT NULL COMMENT '授权的应用 id 列表，为 null 时授权全部应用',
+    last_used_at DATETIME              DEFAULT NULL COMMENT '最近一次认证成功的时间',
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_key_id (key_id),
     UNIQUE KEY uk_key_hash (key_hash),
     KEY idx_status (status)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT 'API key of the open API: hash storage, scope and quota';
+  COLLATE = utf8mb4_general_ci COMMENT ='开放接口的 API Key：摘要存储、授权范围与配额';
 
 CREATE TABLE t_kb_api_audit_log
 (
-    id             BIGINT      NOT NULL AUTO_INCREMENT,
-    audit_log_id   VARCHAR(64) NOT NULL COMMENT 'business identifier exposed by the console query API',
-    key_id         VARCHAR(64) NOT NULL COMMENT 'calling API key, never the plaintext key',
-    app_id         VARCHAR(64)          DEFAULT NULL COMMENT 'application called',
-    app_version_id VARCHAR(64)          DEFAULT NULL COMMENT 'application version served, null when rejected',
-    target_stage   VARCHAR(16)          DEFAULT NULL COMMENT 'RELEASE/BETA, the version stage that was called',
-    endpoint       VARCHAR(32)  NOT NULL COMMENT 'search/chat',
-    -- Masked by the section 4.2 rules and then truncated: an audit trail must stay readable without
-    -- becoming a second copy of the personal data the knowledge base already masks.
-    query_digest   VARCHAR(200)         DEFAULT NULL COMMENT 'masked and truncated query',
-    hit_doc_ids    JSON                 DEFAULT NULL COMMENT 'document ids of the returned nodes',
-    latency_ms     INT         NOT NULL DEFAULT 0 COMMENT 'server side duration',
-    degraded       JSON                 DEFAULT NULL COMMENT 'degradation markers of this call',
-    override_keys  JSON                 DEFAULT NULL COMMENT 'request level overrides applied, requirement section 5',
-    error_code     VARCHAR(32)          DEFAULT NULL COMMENT 'business error code when the call was rejected',
-    request_id     VARCHAR(64)          DEFAULT NULL COMMENT 'correlation id of the call',
-    created_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version   INT         NOT NULL DEFAULT 0,
-    deleted        TINYINT     NOT NULL DEFAULT 0,
+    id             BIGINT      NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    audit_log_id   VARCHAR(64) NOT NULL COMMENT '控制台查询接口对外暴露的业务标识',
+    key_id         VARCHAR(64) NOT NULL COMMENT '发起调用的 API Key 标识，绝不记录明文 Key',
+    app_id         VARCHAR(64)          DEFAULT NULL COMMENT '被调用的应用',
+    app_version_id VARCHAR(64)          DEFAULT NULL COMMENT '实际服务的应用版本，请求被拒绝时为 null',
+    target_stage   VARCHAR(16)          DEFAULT NULL COMMENT '被调用的版本阶段：RELEASE 正式 / BETA 灰度',
+    endpoint       VARCHAR(32)  NOT NULL COMMENT '被调用的端点：search/chat',
+    -- 先按 4.2 节规则脱敏再截断：审计流水既要保持可读，又不能变成知识库已经脱敏过的那份个人数据的副本。
+    query_digest   VARCHAR(200)         DEFAULT NULL COMMENT '脱敏并截断后的查询文本',
+    hit_doc_ids    JSON                 DEFAULT NULL COMMENT '返回结果所属的文档 id 列表',
+    latency_ms     INT         NOT NULL DEFAULT 0 COMMENT '服务端耗时，毫秒',
+    degraded       JSON                 DEFAULT NULL COMMENT '本次调用的降级标记',
+    override_keys  JSON                 DEFAULT NULL COMMENT '本次生效的请求级覆盖参数，对应需求文档第 5 节',
+    error_code     VARCHAR(32)          DEFAULT NULL COMMENT '调用被拒绝时的业务错误码',
+    request_id     VARCHAR(64)          DEFAULT NULL COMMENT '本次调用的链路追踪 id',
+    created_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version   INT         NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted        TINYINT     NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_audit_log_id (audit_log_id),
     KEY idx_key_id (key_id),
@@ -113,14 +110,14 @@ CREATE TABLE t_kb_api_audit_log
     KEY idx_version_stage (app_version_id, target_stage)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT 'outbound API call audit, archived to object storage after the retention window';
+  COLLATE = utf8mb4_general_ci COMMENT ='对外接口调用审计，超过保留期后归档到对象存储';
 
--- Additive columns on the M4b table: the release gate recomputes Recall@K on the intersection of the
--- effective cases of both runs, which needs the per case evidence counts the judgment already produced
--- and previously discarded. Deriving them back from overlap_ratios would compare a per evidence best
--- ratio against an aggregate coverage decision and silently disagree with the run's own metrics.
+-- 给 M4b 的表补两个增量列：发布门禁要在两次运行的有效用例交集上重算 Recall@K，
+-- 而这需要评判过程本来就算出、但之前被丢弃的逐用例证据计数。
+-- 若改为从 overlap_ratios 反推，等于拿「每条证据的最佳覆盖率」去比对「聚合覆盖判定」，
+-- 会与该次运行自己的指标悄悄对不上。
 ALTER TABLE t_kb_eval_result
     ADD COLUMN evidence_hit_count   INT NOT NULL DEFAULT 0
-        COMMENT 'evidences covered within the top K, gate intersection recomputation input',
+        COMMENT 'Top K 内被覆盖的证据数，门禁交集重算的输入',
     ADD COLUMN evidence_total_count INT NOT NULL DEFAULT 0
-        COMMENT 'evidences the case declares, gate intersection recomputation input';
+        COMMENT '该用例声明的证据总数，门禁交集重算的输入';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V7__app_index_snapshot.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V7__app_index_snapshot.sql
@@ -1,23 +1,22 @@
--- Milestone M6 schema increment: the index snapshot of an application version.
--- Two columns on the existing version table and no new table: the physical indices themselves are already
--- described by t_kb_index_registry, which the snapshot path registers a row in, so a second registry keyed by
--- application version would duplicate that description and could disagree with it.
--- V1-V6 are never edited after release, so every later change arrives as its own migration.
+-- 里程碑 M6 的结构增量：应用版本的索引快照。
+-- 只在既有的版本表上加两列，不新建表：物理索引本身已经由 t_kb_index_registry 描述，
+-- 快照链路也会往那张表里注册一行；若再按应用版本建一份注册表，只会重复这份描述并可能与它冲突。
+-- V1-V6 发布后不再修改，因此后续每一次变更都以独立的迁移脚本落地。
+SET NAMES utf8mb4;
 
 ALTER TABLE t_kb_app_version
-    -- {kb_id: [document_version_id, ...]} frozen at release time, requirement section 4.7 "version visibility
-    -- set". The mandatory engine side version filter of a released call takes its values from here instead of
-    -- from the current active version pointer: an old snapshot only contains the versions of its own release,
-    -- so filtering it by today's active versions would make a rollback recall nothing.
-    -- NULL for a version that was never released, for one released before this milestone, and for one whose
-    -- snapshot the retention pass already retired - all three fall back to the live alias.
+    -- 发布时冻结的 {kb_id: [document_version_id, ...]}，对应需求文档 4.7 节「版本可见集」。
+    -- 发布版调用在引擎侧必带的版本过滤条件取值于此，而不是取自当前的生效版本指针：
+    -- 旧快照里只有它自己发布那一刻的版本，若按今天的生效版本去过滤，回滚后将什么都召回不到。
+    -- 三种情况下为 NULL——从未发布过的版本、本里程碑之前发布的版本、快照已被保留期任务清理的版本，
+    -- 它们都回落到实时别名。
     ADD COLUMN visible_version_ids JSON DEFAULT NULL
-        COMMENT 'frozen document_version_id set per knowledge base, null falls back to the live alias'
+        COMMENT '按知识库冻结的 document_version_id 集合，为 null 时回落到实时别名'
         AFTER released_at,
-    -- [{kb_id, engine, physical_index_name}], one element per knowledge base and per engine: a full mode
-    -- deployment snapshots the BM25 index and the vector collection separately and a call has to address the
-    -- right one per recall route. The physical name is stored rather than recomputed, so an embedding model
-    -- switch after the release cannot repoint a historical version at an index it never held.
+    -- [{kb_id, engine, physical_index_name}]，每个知识库、每种引擎一个元素：全量模式部署会把 BM25
+    -- 索引和向量集合分别快照，调用时要按召回路由各自寻址到正确的那一个。
+    -- 这里存物理索引名而不是运行时重算，这样发布之后再换向量模型，也不会把历史版本重新指向一个
+    -- 它从未使用过的索引。
     ADD COLUMN index_snapshots JSON DEFAULT NULL
-        COMMENT 'frozen physical indexes of the release, null falls back to the live alias'
+        COMMENT '发布时冻结的物理索引集合，为 null 时回落到实时别名'
         AFTER visible_version_ids;

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V8__graph_extract_task.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V8__graph_extract_task.sql
@@ -1,12 +1,13 @@
--- M7 GraphRAG.
+-- M7 GraphRAG。
 --
--- The graph itself lives in Neo4j and is a derived store, so no table mirrors it: it is rebuildable from
--- t_kb_chunk exactly like the vector and full text indices are. The one thing MySQL has to remember is how
--- an extraction run went, and specifically how many chunks its output validation rejected - a count the
--- console shows next to a successful task, because "succeeded while silently dropping a third of the corpus"
--- is the failure mode this milestone has to make visible.
-ALTER TABLE t_kb_task
-    ADD COLUMN skipped_count INT DEFAULT NULL COMMENT 'chunks skipped by output validation, GRAPH_EXTRACT only';
+-- 图谱本身存在 Neo4j 里，属于派生存储，因此 MySQL 不做任何镜像表：它和向量、全文索引一样，
+-- 随时可以从 t_kb_chunk 重建。MySQL 唯一需要记住的是某次抽取运行的情况，特别是它的输出校验
+-- 拒掉了多少个分片——这个计数会展示在「成功」的任务旁边，因为「任务成功、却悄悄丢掉三分之一
+-- 语料」正是本里程碑必须暴露出来的失败模式。
+SET NAMES utf8mb4;
 
 ALTER TABLE t_kb_task
-    MODIFY COLUMN task_type VARCHAR(32) NOT NULL COMMENT 'PARSE/INDEX/REBUILD/CLEANUP/GRAPH_EXTRACT';
+    ADD COLUMN skipped_count INT DEFAULT NULL COMMENT '被输出校验跳过的分片数，仅 GRAPH_EXTRACT 任务使用';
+
+ALTER TABLE t_kb_task
+    MODIFY COLUMN task_type VARCHAR(32) NOT NULL COMMENT '任务类型：PARSE/INDEX/REBUILD/CLEANUP/GRAPH_EXTRACT';

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V9__source_mapping.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V9__source_mapping.sql
@@ -1,35 +1,33 @@
--- Milestone M8 schema increment: the chat import mapping profile table behind the console's import
--- mapping tab. The baseline and V1-V8 are never edited after release, so every later change arrives as
--- its own migration.
+-- 里程碑 M8 的结构增量：控制台「导入映射」页签背后的聊天导入映射模板表。
+-- 基线与 V1-V8 发布后不再修改，因此后续每一次变更都以独立的迁移脚本落地。
 --
--- The requirement document announced this table for the first phase, but no migration ever created it:
--- phase one carried the mapping profiles as yml files next to the parser instead. The migration therefore
--- creates the table rather than adding the columns M8 needs to an existing one.
+-- 需求文档在一期就提出了这张表，但当时没有任何迁移脚本创建过它：一期是把映射模板以 yml 文件的
+-- 形式放在解析器旁边的。因此这个迁移是新建表，而不是在既有表上补 M8 需要的列。
+SET NAMES utf8mb4;
 
 CREATE TABLE t_kb_source_mapping
 (
-    id           BIGINT       NOT NULL AUTO_INCREMENT,
-    mapping_id   VARCHAR(64)  NOT NULL COMMENT 'business identifier exposed by the API',
-    -- Also the value the mapping_profile import parameter carried while the profiles were yml files, so
-    -- an import addressing a built-in profile by its name keeps working after this table arrives.
-    name         VARCHAR(128) NOT NULL COMMENT 'profile name, unique across built-in and custom rows',
-    source_type  VARCHAR(16)  NOT NULL COMMENT 'CSV/XLSX/TXT/HTML, the export extension this profile reads',
-    -- No description column: the body carries its own comment header, the console edits it in a text
-    -- area, and a second field could only disagree with what the operator is already reading.
-    profile_yaml MEDIUMTEXT   NOT NULL COMMENT 'full yaml body forwarded to the parser on every parse call',
-    -- A seeded template is copied, never edited or deleted: the next release recalibrates it against a
-    -- real export sample, which would silently revert an in place edit.
-    is_builtin   TINYINT      NOT NULL DEFAULT 0 COMMENT '1 seeded template, 0 operator created',
-    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    lock_version INT          NOT NULL DEFAULT 0,
-    deleted      TINYINT      NOT NULL DEFAULT 0,
+    id           BIGINT       NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+    mapping_id   VARCHAR(64)  NOT NULL COMMENT '对外暴露的业务标识',
+    -- 模板还是 yml 文件的时候，导入参数 mapping_profile 传的也是这个值，
+    -- 因此按名称寻址内置模板的导入请求，在这张表落地之后依然可以正常工作。
+    name         VARCHAR(128) NOT NULL COMMENT '模板名称，内置与自建模板共用同一个命名空间且唯一',
+    source_type  VARCHAR(16)  NOT NULL COMMENT '本模板所读取的导出文件类型：CSV/XLSX/TXT/HTML',
+    -- 不设 description 列：yaml 正文自带注释头，控制台是在文本域里直接编辑它的，
+    -- 再来一个独立字段只会和运营人员正在读的内容对不上。
+    profile_yaml MEDIUMTEXT   NOT NULL COMMENT '完整 yaml 正文，每次解析调用都原样转发给解析器',
+    -- 内置模板只能被复制，不能被编辑或删除：下个版本会拿真实导出样本重新校准它，
+    -- 那会悄悄覆盖掉原地做的修改。
+    is_builtin   TINYINT      NOT NULL DEFAULT 0 COMMENT '1 内置模板，0 运营人员自建',
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    lock_version INT          NOT NULL DEFAULT 0 COMMENT '乐观锁版本号',
+    deleted      TINYINT      NOT NULL DEFAULT 0 COMMENT '逻辑删除标记，1 表示已删除',
     PRIMARY KEY (id),
     UNIQUE KEY uk_mapping_id (mapping_id),
-    -- The name is an address, not a label: the import parameter resolves a profile by it, so two rows
-    -- sharing one name would leave the resolution to pick between them arbitrarily.
+    -- 名称是地址而不是标签：导入参数靠它解析出模板，两行同名会让解析结果变成任意挑一个。
     UNIQUE KEY uk_name (name),
     KEY idx_source_type (source_type)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_general_ci COMMENT ='chat import mapping profile forwarded to the parser';
+  COLLATE = utf8mb4_general_ci COMMENT ='聊天导入映射模板，转发给解析器使用';


### PR DESCRIPTION
## 变更说明

把 `kb-api/src/main/resources/db/migration/` 下 V1~V15 全部 15 个 Flyway 迁移脚本的注释改为中文，并补齐此前**完全没有注释**的列。

**DDL 语义零改动**，只动注释文本、加 `SET NAMES utf8mb4`。表名、列名、类型、默认值、索引、约束、生成列表达式全部保持原样。

为什么需要：原脚本的注释全是英文，且相当一批列（审计与基础设施类字段）根本没有注释。DBA 和新同学看 `SHOW FULL COLUMNS` 或用客户端浏览表结构时，拿不到任何中文语义，只能回头翻 Java 实体类。

具体做了什么：

- **每个迁移文件开头加 `SET NAMES utf8mb4;`** —— 脱离应用、直接用 `mysql` 客户端执行这些脚本时也不会写入乱码
- **28 张表的表注释**全部改为中文
- **400 个列的列注释**全部为中文，且**无一为空**。原本没有任何注释的列包括：`id`、`created_at`、`updated_at`、`lock_version`、`deleted`、`retry_count`、`success`、`description`、`started_at`、`finished_at`、`embedding_provider`、`embedding_model`、`last_login_at`，以及 `t_kb_app_version.released_slot` 这个 `GENERATED ALWAYS AS ... VIRTUAL` 生成列
- 文件头和索引旁的 `--` 设计说明块一并译为中文，避免同一个文件里中英混杂
- 顺手修掉一处笔误：V6 里 `t_kb_api_key` 和 `t_kb_api_audit_log` 的表注释写成了 `COMMENT '...'`（漏了 `=`），统一为 `COMMENT ='...'`

## 涉及模块

- [ ] kb-common
- [ ] kb-domain
- [ ] kb-infrastructure
- [ ] kb-app
- [x] kb-api（仅 `src/main/resources/db/migration/`，无 Java 改动）

## 变更类型

- [ ] feat 新功能
- [ ] fix 缺陷修复
- [x] docs 文档（DDL 注释）
- [ ] refactor 重构（不改变行为）
- [ ] chore 构建/工具/依赖
- [x] schema 变更 —— **但不是新增迁移，是修改已发布脚本，见下方「与契约的偏离」**
- [ ] 契约变更

## ⚠️ 与契约的偏离

**本 PR 明知故犯地违反了自查清单里「不改已发布脚本」这一条**，这是需求方明确选择的方案，请 reviewer 重点评估。

| | 直接改历史脚本（本 PR 采用） | 新增 V16 用 ALTER 补注释（未采用） |
|---|---|---|
| CREATE TABLE 可读性 | 一眼看到中文 DDL | 建表语句仍是英文，看 DDL 要两处对照 |
| Flyway checksum | **全部改变** | 不变 |
| 已迁移的库 | 需重建或 repair | 无痛升级 |
| 后续新增列 | 不会漏 | 容易漏补注释 |

选了前者，理由是源头干净、后续不会漏；代价由下面两条兜住。

### reviewer 和部署方必须知道的两件事

**1. checksum 全变，已跑过迁移的库启动会直接失败。**

`application.yml` 里 `flyway.enabled: true` 且未关闭 `validate-on-migrate`（默认开）。任何已经执行过 V1~V15 的库，下次启动会报 `ValidateFailed`。本仓库既未装 flyway CLI 也未配 `flyway-maven-plugin`，开发环境最省事的处理是重建库：

```bash
docker exec -i kb-rag-mysql mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "DROP DATABASE kb_rag; CREATE DATABASE kb_rag DEFAULT CHARSET utf8mb4 COLLATE utf8mb4_general_ci; GRANT ALL ON kb_rag.* TO 'kbrag'@'%';"
```

**2. `flyway repair` 只对得上 checksum，不会把中文注释刷到已有的库上。**

repair 只改 `flyway_schema_history` 这张元数据表，不回放 DDL。所以已存在的库即使 repair 成功，表注释**仍然是英文的**。中文注释只对**全新初始化的库**生效。

如果存在不能重建的环境（生产/预发），需要再补一个 V16 用 `ALTER TABLE ... COMMENT` 把注释刷上去。当前假设是本项目尚无此类环境 —— **若判断有误请在评论里指出，我补 V16。**

### 另一处偏离

自查清单要求「注释与日志为英文」。该条针对 Java 代码，本 PR 未改任何 Java 文件；SQL 注释中文化是本次的明确需求。

## 测试方式

不只做了静态检查，在真实 MySQL 上完整跑过一遍：

1. 在 `kb-rag-mysql`（mysql:8.0.36）里新建临时库 `kb_rag_ddl_check`
2. 按 V1 → V15 顺序真实执行全部 15 个脚本 —— **全部成功，无语法错误**（`released_slot` 生成列上挂 `COMMENT` 也合法）
3. 回查 `information_schema`：**28 张表、400 列，空注释列数为 0**
4. 用 `HEX()` 确认落库字节是标准 UTF-8（`知识库` = `E79FA5E8AF86E5BA93`），排除乱码

   > 注：用 `mysql` 默认客户端编码回查会显示成 `?????`，那是终端输出编码问题不是存储问题，加 `--default-character-set=utf8mb4` 即正常。
5. 验证完 `DROP DATABASE kb_rag_ddl_check`，**`kb_rag` 库全程未被触碰**

可复现的核查语句：

```sql
SELECT COUNT(*) FROM information_schema.COLUMNS
WHERE TABLE_SCHEMA = 'kb_rag' AND (COLUMN_COMMENT = '' OR COLUMN_COMMENT IS NULL);
```

`mvn -B -ntp verify` 见下方补充评论（本机默认 JDK 为 8，需 `JAVA_HOME=$(/usr/libexec/java_home -v 17)` 才能构建）。

## 关联 Issue

无
