### PR TITLE
fix(kb): 重建进度改由服务端派生，离开详情页不再丢失

### DIFF
--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/KnowledgeBaseController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/KnowledgeBaseController.java
@@ -9,6 +9,7 @@ import io.kbrag.api.dto.CreateKnowledgeBaseRequest;
 import io.kbrag.api.dto.DocumentBatchRequest;
 import io.kbrag.api.dto.KnowledgeBaseResponse;
 import io.kbrag.api.dto.RebuildRequest;
+import io.kbrag.api.dto.RebuildStatusResponse;
 import io.kbrag.api.dto.UpdateIndexConfigRequest;
 import io.kbrag.api.dto.UpdateKbGovernanceRequest;
 import io.kbrag.app.auth.AccessGuard;
@@ -152,6 +153,24 @@ public class KnowledgeBaseController {
         AccessGuard.requireKbAccess(kbId);
         List<String> queued = rebuildService.submit(kbId, request == null ? null : request.docIds());
         return Result.success(Map.of(FIELD_QUEUED_DOC_IDS, queued));
+    }
+
+    /**
+     * Reports how far the knowledge base is from running entirely on the current configuration.
+     *
+     * <p>Separate from the rebuild submission on purpose: a rebuild survives the page that started it,
+     * so the console has to be able to ask for the state rather than remember it. Counting is scoped to
+     * the whole base, not one page of documents, because a stale document on page two is just as much
+     * work as one on page one.
+     *
+     * @param kbId business identifier
+     * @return stale, in progress and failed document counts
+     */
+    @GetMapping("/{kbId}/rebuild-status")
+    @RequiresPermission(PermissionCodes.KB_READ)
+    public Result<RebuildStatusResponse> rebuildStatus(@PathVariable String kbId) {
+        AccessGuard.requireKbAccess(kbId);
+        return Result.success(RebuildStatusResponse.from(rebuildService.status(kbId)));
     }
 
     /**

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RebuildStatusResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RebuildStatusResponse.java
@@ -1,0 +1,33 @@
+package io.kbrag.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kbrag.app.index.RebuildService;
+
+/**
+ * Rebuild catch-up view of a knowledge base.
+ *
+ * <p>The console polls this instead of remembering what it submitted. A rebuild outlives the page that
+ * started it - it runs on the index executor and reports through the database - so the only state that
+ * survives a navigation, a refresh or a second operator opening the same base is the one derived here.
+ *
+ * @param staleCount      documents still awaiting a rebuild under the current configuration
+ * @param inProgressCount those currently running through the pipeline
+ * @param failedCount     those whose rebuild failed and need an operator
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record RebuildStatusResponse(
+        @JsonProperty("stale_count") int staleCount,
+        @JsonProperty("in_progress_count") int inProgressCount,
+        @JsonProperty("failed_count") int failedCount) {
+
+    /**
+     * Maps the application view onto its response.
+     *
+     * @param status rebuild catch-up status
+     * @return view
+     */
+    public static RebuildStatusResponse from(RebuildService.RebuildStatus status) {
+        return new RebuildStatusResponse(status.staleCount(), status.inProgressCount(), status.failedCount());
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/RebuildService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/RebuildService.java
@@ -3,6 +3,7 @@ package io.kbrag.app.index;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import io.kbrag.app.document.DocumentService;
 import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.enums.ProcessStatus;
 import io.kbrag.domain.mapper.DocumentMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +11,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -37,9 +39,49 @@ public class RebuildService {
 
     private static final int STALE = 1;
 
+    /**
+     * 重建过程中文档会经过的状态，与 {@link IndexPipelineService#rebuild(String)} 实际写入的一致：
+     * 先 PARSING/PARSED（复用解析产物时可能一闪而过），再 INDEXING，成功后才清掉 config_stale。
+     */
+    private static final Collection<ProcessStatus> IN_PROGRESS = List.of(
+            ProcessStatus.PARSING, ProcessStatus.PARSED, ProcessStatus.INDEXING);
+
+    /** 重建失败停留的状态：文档仍是 stale，必须单独报出来，否则计数不动会被看成卡住。 */
+    private static final Collection<ProcessStatus> FAILED = List.of(
+            ProcessStatus.PARSE_FAILED, ProcessStatus.INDEX_FAILED);
+
     private final DocumentMapper documentMapper;
     private final DocumentService documentService;
     private final IndexPipelineService indexPipelineService;
+
+    /**
+     * 汇报整个知识库的配置追平情况，供控制台还原"重建中"的展示。
+     *
+     * <p>控制台此前把重建进度记在页面内存里，操作员一离开详情页状态就没了：进度条消失、完成提示
+     * 永远不再出现、按钮回到可点击态引来重复提交，而后端任务其实一直在线程池里跑。进度的事实只在
+     * 库里，所以这里按 {@code config_stale} 与 {@code process_status} 现算——任何时刻打开页面，
+     * 甚至换一个人来看，看到的都是同一份真实状态。
+     *
+     * <p>统计口径与 {@link #submit(String, List)} 的可重建集合对齐（要求有活跃版本），否则分母里会
+     * 混进永远重建不了的文档，让追平进度永远差一截。
+     *
+     * @param kbId knowledge base business id
+     * @return 追平状态
+     */
+    public RebuildStatus status(String kbId) {
+        int stale = count(kbId, null);
+        int inProgress = count(kbId, IN_PROGRESS);
+        int failed = count(kbId, FAILED);
+        return new RebuildStatus(stale, inProgress, failed);
+    }
+
+    private int count(String kbId, Collection<ProcessStatus> statuses) {
+        LambdaQueryWrapper<Document> wrapper = staleScope(kbId);
+        if (CollectionUtils.isNotEmpty(statuses)) {
+            wrapper.in(Document::getProcessStatus, statuses);
+        }
+        return Math.toIntExact(documentMapper.selectCount(wrapper));
+    }
 
     /**
      * Queues a rebuild for a knowledge base.
@@ -68,8 +110,24 @@ public class RebuildService {
         if (CollectionUtils.isNotEmpty(docIds)) {
             return documentService.requireAllInKb(kbId, docIds);
         }
-        return documentMapper.selectList(new LambdaQueryWrapper<Document>()
+        return documentMapper.selectList(staleScope(kbId));
+    }
+
+    /** 待追平文档的取数口径，提交与统计共用一处，避免两边口径漂移。 */
+    private LambdaQueryWrapper<Document> staleScope(String kbId) {
+        return new LambdaQueryWrapper<Document>()
                 .eq(Document::getKbId, kbId)
-                .eq(Document::getConfigStale, STALE));
+                .eq(Document::getConfigStale, STALE)
+                .isNotNull(Document::getCurrentVersionId);
+    }
+
+    /**
+     * 知识库的配置追平状态。
+     *
+     * @param staleCount      仍需按新配置重建的文档数，归零即全部追平
+     * @param inProgressCount 其中正在跑重建管线的文档数
+     * @param failedCount     其中重建失败、需要人工介入的文档数
+     */
+    public record RebuildStatus(int staleCount, int inProgressCount, int failedCount) {
     }
 }

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/index/RebuildServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/index/RebuildServiceTest.java
@@ -1,0 +1,74 @@
+package io.kbrag.app.index;
+
+import io.kbrag.app.document.DocumentService;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.mapper.DocumentMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the catch-up status the console renders instead of remembering what it submitted.
+ *
+ * <p>The three counts are read from three queries over the same stale scope, so the risk worth a test is
+ * not the SQL - it is the mapping: an in-progress count reported as the failed one would tell an operator
+ * a running rebuild has broken, and a stale count that includes documents {@link RebuildService#submit}
+ * refuses to queue would leave the warning banner up forever.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class RebuildServiceTest {
+
+    private static final String KB_ID = "kb_test";
+    private static final String VERSION_ID = "dv_test";
+
+    private DocumentMapper documentMapper;
+    private DocumentService documentService;
+    private IndexPipelineService indexPipelineService;
+    private RebuildService rebuildService;
+
+    @BeforeEach
+    void setUp() {
+        documentMapper = mock(DocumentMapper.class);
+        documentService = mock(DocumentService.class);
+        indexPipelineService = mock(IndexPipelineService.class);
+        rebuildService = new RebuildService(documentMapper, documentService, indexPipelineService);
+    }
+
+    @Test
+    void shouldReportStaleInProgressAndFailedCountsInThatOrder() {
+        // Stale is the whole outstanding set; in-progress and failed are subsets of it.
+        when(documentMapper.selectCount(any())).thenReturn(5L, 2L, 1L);
+
+        RebuildService.RebuildStatus status = rebuildService.status(KB_ID);
+
+        assertEquals(5, status.staleCount());
+        assertEquals(2, status.inProgressCount());
+        assertEquals(1, status.failedCount());
+    }
+
+    @Test
+    void shouldQueueEveryStaleDocumentThatHasAnActiveVersion() {
+        Document withVersion = new Document();
+        withVersion.setDocId("doc_1");
+        withVersion.setCurrentVersionId(VERSION_ID);
+        // 没有活跃版本就没有可重建的内容：既不该提交，也不该被 status 计入分母。
+        Document withoutVersion = new Document();
+        withoutVersion.setDocId("doc_2");
+        when(documentMapper.selectList(any())).thenReturn(List.of(withVersion, withoutVersion));
+
+        List<String> queued = rebuildService.submit(KB_ID, null);
+
+        assertEquals(List.of("doc_1"), queued);
+        verify(indexPipelineService).submitRebuild(VERSION_ID);
+        verify(documentService, never()).requireAllInKb(any(), any());
+    }
+}

--- a/kb-rag-web/src/api/kb.ts
+++ b/kb-rag-web/src/api/kb.ts
@@ -8,6 +8,7 @@ import type {
   DocumentBatchRequest,
   KnowledgeBase,
   RebuildRequest,
+  RebuildStatus,
   UpdateIndexConfigRequest,
 } from './types';
 
@@ -49,12 +50,21 @@ export function updateIndexConfig(
 
 /**
  * POST /api/v1/kb/{kbId}/rebuild (M2-CONTRACTS.md section 4). Body omitted/empty means
- * "all config_stale documents". Progress is not exposed via a dedicated task-status endpoint
- * anywhere in M1/M2-CONTRACTS.md, so the caller tracks completion by re-polling the existing
- * document list and watching config_stale flip back to false (see KbDetailPage).
+ * "all config_stale documents" —— 配置追平就该按整库来，传当前页的 doc_ids 会漏掉翻页外的
+ * 待重建文档。进度用 {@link getRebuildStatus} 轮询，不要在调用方记账。
  */
 export function rebuildKb(kbId: string, payload?: RebuildRequest): Promise<void> {
   return apiPost<void>(`/kb/${kbId}/rebuild`, payload);
+}
+
+/**
+ * GET /api/v1/kb/{kbId}/rebuild-status：整库的配置追平状态。
+ *
+ * 重建跑在服务端线程池里，比发起它的那个页面活得久：调用方离开详情页再回来、刷新、换个人打开，
+ * 都必须能看到同一份进度，所以状态只能问服务端，不能存在组件里。
+ */
+export function getRebuildStatus(kbId: string): Promise<RebuildStatus> {
+  return apiGet<RebuildStatus>(`/kb/${kbId}/rebuild-status`);
 }
 
 /**

--- a/kb-rag-web/src/api/types.ts
+++ b/kb-rag-web/src/api/types.ts
@@ -458,6 +458,20 @@ export interface RebuildRequest {
   doc_ids?: string[];
 }
 
+/**
+ * GET /api/v1/kb/{kbId}/rebuild-status response：整库口径的配置追平状态。
+ *
+ * 三个计数都是服务端现算的，与文档列表的分页无关——待重建的文档落在第几页不影响它是不是活儿。
+ */
+export interface RebuildStatus {
+  /** 仍需按新配置重建的文档数，归零即全部追平。 */
+  stale_count: number;
+  /** 其中正在跑重建管线的文档数。 */
+  in_progress_count: number;
+  /** 其中重建失败、需要人工介入的文档数。 */
+  failed_count: number;
+}
+
 // ---------------------------------------------------------------------------
 // Retrieval
 // ---------------------------------------------------------------------------

--- a/kb-rag-web/src/pages/kb/KbDetailPage.tsx
+++ b/kb-rag-web/src/pages/kb/KbDetailPage.tsx
@@ -39,11 +39,12 @@ import {
   batchReindexDocuments,
   confirmKbDocuments,
   getKnowledgeBase,
+  getRebuildStatus,
   rebuildKb,
   updateKbGovernance,
 } from '../../api/kb';
 import { PUBLISH_STATUS_META } from '../../api/types';
-import type { KbDocument, KnowledgeBase } from '../../api/types';
+import type { KbDocument, KnowledgeBase, RebuildStatus } from '../../api/types';
 import { useAuth } from '../../auth/AuthContext';
 import { PERMISSIONS } from '../../auth/permissions';
 import { formatFileSize } from '../../utils/format';
@@ -63,9 +64,9 @@ import VisibilityDrawer from './components/VisibilityDrawer';
 import WebSourcesTab from './components/WebSourcesTab';
 
 // Document list is polled every 3s while this page stays mounted, per M1-CONTRACTS.md section 7.
-// The same poll loop is reused to track rebuild progress (M2-CONTRACTS.md section 4): there is
-// no dedicated task-status endpoint in the contract, so completion is derived from watching
-// each targeted document's config_stale flag flip back to false.
+// 同一个轮询顺带拉 GET /kb/{kbId}/rebuild-status（M2-CONTRACTS.md section 4 的追平状态）：重建跑在
+// 服务端线程池里，比这个页面活得久，所以"是否在重建、还差多少"只能问服务端。早先版本把它记在组件
+// state 里，操作员一离开详情页进度条就没了、完成提示再也不出现、按钮回到可点击态引来重复提交。
 const POLL_INTERVAL_MS = 3000;
 
 // 与 DocumentController 的 DEFAULT_PAGE_SIZE 对齐：首屏不传 size 时服务端就按 20 返回，
@@ -90,9 +91,10 @@ export default function KbDetailPage() {
   const [versionDocId, setVersionDocId] = useState<string | null>(null);
   const [chatImportOpen, setChatImportOpen] = useState(false);
   const [indexConfigOpen, setIndexConfigOpen] = useState(false);
-  const [rebuilding, setRebuilding] = useState(false);
-  const [rebuildTargetIds, setRebuildTargetIds] = useState<string[]>([]);
-  const [rebuildInitialCount, setRebuildInitialCount] = useState(0);
+  // 追平状态由服务端派生，null 表示还没拉到第一份（首屏别急着下"无需重建"的结论）
+  const [rebuildStatus, setRebuildStatus] = useState<RebuildStatus | null>(null);
+  // 仅用于按钮的即时反馈：提交请求在飞的那一小段，服务端还看不到 in_progress
+  const [rebuildSubmitting, setRebuildSubmitting] = useState(false);
   // 表格只有一套勾选：批量删除、批量重建作用于全部勾选项，批量确认取其中还在等确认的那部分。
   const [selectedDocIds, setSelectedDocIds] = useState<string[]>([]);
   const [batchConfirming, setBatchConfirming] = useState(false);
@@ -111,6 +113,11 @@ export default function KbDetailPage() {
     if (!kbId) return;
     const detail = await getKnowledgeBase(kbId);
     setKb(detail);
+  }, [kbId]);
+
+  const loadRebuildStatus = useCallback(async () => {
+    if (!kbId) return;
+    setRebuildStatus(await getRebuildStatus(kbId));
   }, [kbId]);
 
   /**
@@ -144,24 +151,28 @@ export default function KbDetailPage() {
   useEffect(() => {
     if (!kbId) return;
     setLoading(true);
-    Promise.all([loadKb(), loadDocuments()]).finally(() => setLoading(false));
-  }, [kbId, loadKb, loadDocuments]);
+    Promise.all([loadKb(), loadDocuments(), loadRebuildStatus()]).finally(() => setLoading(false));
+  }, [kbId, loadKb, loadDocuments, loadRebuildStatus]);
 
   useEffect(() => {
     pollTimerRef.current = setInterval(() => {
       loadDocuments();
+      loadRebuildStatus();
     }, POLL_INTERVAL_MS);
     return () => {
       if (pollTimerRef.current) {
         clearInterval(pollTimerRef.current);
       }
     };
-  }, [loadDocuments]);
+  }, [loadDocuments, loadRebuildStatus]);
 
-  const staleDocs = useMemo(() => documents.filter((doc) => doc.config_stale), [documents]);
-  const remainingRebuildCount = useMemo(
-    () => documents.filter((doc) => rebuildTargetIds.includes(doc.doc_id) && doc.config_stale).length,
-    [documents, rebuildTargetIds],
+  const staleCount = rebuildStatus?.stale_count ?? 0;
+  const rebuildInProgress = (rebuildStatus?.in_progress_count ?? 0) > 0;
+  const rebuildFailedCount = rebuildStatus?.failed_count ?? 0;
+  // 排队中 = 待追平里既没在跑、也没失败的那部分：线程池并发有限，提交一批后大多数文档在这里等着
+  const rebuildQueuedCount = Math.max(
+    0,
+    staleCount - (rebuildStatus?.in_progress_count ?? 0) - rebuildFailedCount,
   );
   // M3-CONTRACTS.md section 3.4/4: documents paused on parse-preview confirmation.
   const pendingConfirmDocs = useMemo(
@@ -175,15 +186,20 @@ export default function KbDetailPage() {
     [documents, versionDocId],
   );
 
-  // Once every targeted document's config_stale flag clears, consider the rebuild finished.
+  /**
+   * 待追平数从有到无就是重建收尾。只提示一次、且只在本次驻留期间观察到这个跳变时提示——离开又回来
+   * 时上一份计数不可知，此时告警条直接消失本身就是完成信号，硬补一句 toast 反而像凭空冒出来。
+   * 重建失败的文档仍是 stale，所以计数不会归零，不存在把失败说成成功的路径。
+   */
+  const prevStaleCountRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!rebuilding || rebuildTargetIds.length === 0) return;
-    if (remainingRebuildCount === 0) {
-      setRebuilding(false);
-      setRebuildTargetIds([]);
+    if (!rebuildStatus) return;
+    const prev = prevStaleCountRef.current;
+    prevStaleCountRef.current = rebuildStatus.stale_count;
+    if (prev !== null && prev > 0 && rebuildStatus.stale_count === 0) {
       message.success('重建完成，新分片配置已生效');
     }
-  }, [rebuilding, rebuildTargetIds, remainingRebuildCount]);
+  }, [rebuildStatus]);
 
   // 勾选项里"还在等预览确认"的那部分：批量确认只该作用于它们，而删除与重建作用于全部勾选项。
   const selectedPendingConfirmIds = useMemo(
@@ -222,20 +238,26 @@ export default function KbDetailPage() {
     }
   };
 
+  /**
+   * 提交整库追平。不传 doc_ids 让服务端自己圈定全部 config_stale 文档：早先传的是当前页那几篇，
+   * 翻页外的待重建文档因此永远追不平。
+   */
   const handleRebuildStale = async () => {
-    if (!kbId || staleDocs.length === 0) return;
-    const targetIds = staleDocs.map((doc) => doc.doc_id);
-    await rebuildKb(kbId, { doc_ids: targetIds });
-    message.success('已提交按新配置重建任务');
-    setRebuildTargetIds(targetIds);
-    setRebuildInitialCount(targetIds.length);
-    setRebuilding(true);
-    loadDocuments();
+    if (!kbId || staleCount === 0) return;
+    setRebuildSubmitting(true);
+    try {
+      await rebuildKb(kbId);
+      message.success('已提交按新配置重建任务');
+      await Promise.all([loadDocuments(), loadRebuildStatus()]);
+    } finally {
+      setRebuildSubmitting(false);
+    }
   };
 
   const handleIndexConfigSaved = () => {
     loadKb();
     loadDocuments();
+    loadRebuildStatus();
   };
 
   const handlePreviewConfirmed = () => {
@@ -406,25 +428,43 @@ export default function KbDetailPage() {
             label: '文档管理',
             children: (
               <>
-                {staleDocs.length > 0 && (
+                {staleCount > 0 && (
                   <Alert
                     type="warning"
                     showIcon
-                    message={`${staleDocs.length} 篇文档使用旧配置`}
+                    message={`${staleCount} 篇文档使用旧配置`}
                     description={
-                      rebuilding ? (
-                        <Progress
-                          percent={Math.round(((rebuildInitialCount - remainingRebuildCount) / rebuildInitialCount) * 100)}
-                          size="small"
-                          status="active"
-                        />
+                      rebuildInProgress ? (
+                        <>
+                          <Typography.Text type="secondary">
+                            {`正在按新配置重建：${rebuildStatus?.in_progress_count} 篇处理中`}
+                            {rebuildQueuedCount > 0 ? `，${rebuildQueuedCount} 篇排队中` : ''}
+                            {rebuildFailedCount > 0 ? `，${rebuildFailedCount} 篇失败` : ''}
+                          </Typography.Text>
+                          {/* 进度是"整库有多少文档已按当前配置建好"，服务端现算，刷新或换人看都一致 */}
+                          {docTotal > 0 && (
+                            <Progress
+                              percent={Math.round(((docTotal - staleCount) / docTotal) * 100)}
+                              size="small"
+                              status="active"
+                            />
+                          )}
+                        </>
+                      ) : rebuildFailedCount > 0 ? (
+                        `${rebuildFailedCount} 篇文档重建失败，可在下方列表查看失败原因后重试；其余待重建文档可再次提交`
                       ) : (
                         '索引配置已变更，需要按新配置重建后才能生效'
                       )
                     }
                     action={
-                      <Button size="small" type="primary" loading={rebuilding} disabled={rebuilding} onClick={handleRebuildStale}>
-                        {rebuilding ? '重建中' : '按新配置重建'}
+                      <Button
+                        size="small"
+                        type="primary"
+                        loading={rebuildSubmitting || rebuildInProgress}
+                        disabled={rebuildSubmitting || rebuildInProgress}
+                        onClick={handleRebuildStale}
+                      >
+                        {rebuildInProgress ? '重建中' : '按新配置重建'}
                       </Button>
                     }
                     style={{ marginBottom: 16 }}


### PR DESCRIPTION
## 问题

点「按新配置重建」后离开知识库详情页再回来：进度条消失、告警条退回「索引配置已变更…」、按钮回到可点击态（很容易重复提交）、「重建完成」提示再也不出现。

后端任务并没有被取消——`RebuildService#submit` 投给 `@Async(INDEX_EXECUTOR)`，`IndexPipelineService#rebuild` 全程写库，HTTP 响应返回后照跑到底。丢的只是前端的进度显示。

根因：进度记在 `KbDetailPage` 的组件 state 里（`rebuilding` / `rebuildTargetIds` / `rebuildInitialCount`），组件一卸载就全丢。

## 同源的另外两个缺陷

- `staleDocs` 与完成判定都只在**当前页的 20 条**文档里过滤：第二页的待重建文档既不显示告警条，重建中翻页还会让剩余数虚假归零、误报「重建完成，新分片配置已生效」
- 提交重建时传的是当前页那几篇的 `doc_ids`，翻页外的待重建文档永远追不平

三者是同一个根因的三面：把服务端的真实状态当成前端的一次性快照在管。

## 改动

**后端**
- 新增 `GET /api/v1/kb/{kbId}/rebuild-status`，返回 `stale_count` / `in_progress_count` / `failed_count`，按整库口径现算，与文档列表分页无关
- 统计口径抽成 `RebuildService#staleScope`，与 `submit` 的可重建集合共用（要求有活跃版本）——否则分母里会混进永远重建不了的文档，让追平进度永远差一截

**前端**
- Alert 与进度条完全由新端点派生，跟着已有的 3s 轮询刷新
- 提交重建不再传 `doc_ids`，交给服务端圈定全部 stale 文档
- 进度条语义换成「整库已按当前配置建好的比例」：服务端可算、刷新与换人查看一致，不再依赖前端记的本轮初始数
- 完成提示改为观察「待追平数从有到无」，失败的文档仍是 stale 所以计数不归零，不存在把失败说成成功的路径
- 新增失败态文案：`N 篇文档重建失败，可在下方列表查看失败原因后重试`

## 验证

- 新增 `RebuildServiceTest`（2 个用例：三个计数的映射顺序、只提交有活跃版本的 stale 文档），通过
- 前端 `tsc -b` + `oxlint` 干净
- 端到端：本地起后端 + parser + vite，新建 `test-rebuild-progress` 知识库传 3 篇 80KB txt 建好索引 → 改索引配置制造 3 篇 stale → 点重建后立刻切到应用中心再返回，告警条仍显示「正在按新配置重建：3 篇处理中」、按钮仍是禁用的「重建中」（修复前此处会全部丢失）→ 重建完成后 `stale_count` 归零、告警条消失。测试知识库已删除

🤖 Generated with [Claude Code](https://claude.com/claude-code)