### PR TITLE
feat(kb): 知识库支持重命名与描述编辑

### DIFF
--- a/kb-rag-deploy/docs/openapi/kb-server.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-server.yaml
@@ -1057,6 +1057,29 @@ paths:
                 $ref: '#/components/schemas/KnowledgeBaseResult'
         '404':
           $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+      - knowledge-base
+      summary: 更新知识库（重命名/改描述）
+      description: '仅更新展示字段 name 与 description：不触碰索引配置与指纹，不会使任何文档
+        变为 config_stale。新名称与其他知识库重名时拒绝（INVALID_PARAM），仅改描述不改名不受此限。 '
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateKbRequest'
+      responses:
+        '200':
+          description: 更新成功，返回最新知识库信息
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeBaseResult'
+        '400':
+          $ref: '#/components/responses/InvalidParam'
+        '404':
+          $ref: '#/components/responses/NotFound'
     delete:
       tags:
       - knowledge-base
@@ -4809,6 +4832,16 @@ components:
             items:
               $ref: '#/components/schemas/PermissionEntry'
     CreateKbRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+    UpdateKbRequest:
       type: object
       required:
       - name

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 尚未打过 tag，以下条目全部属于首个发布版本的内容，按里程碑倒序排列。
 
+### 新增
+
+- 知识库重命名：`PUT /api/v1/kb/{kbId}`（`kb:write`）更新 name 与 description，新名称与其他知识库重名时拒绝（排除自身，仅改描述不改名不受此限）；只动展示字段——索引配置与指纹不变，改名不会使任何文档 config_stale，也不触发重建；审计落 `KB/UPDATE`。控制台知识库卡片新增「编辑」入口（仅 `kb:write` 可见）
+
 ### 新增（M16）
 
 - `[schema]` Flyway `V17__tenant_doc_acl_audit.sql`：新增 `t_kb_tenant`（内置默认租户 `tnt_default0000000` 随迁移种子化，不可停用）、`t_kb_doc_acl`（受限文档→授权角色绑定）、`t_kb_operation_audit`（操作审计，含 `username` 冗余列——账号删了记录还得可读）；6 张根聚合表（用户 / 角色 / 知识库 / API Key / 评测集 / 应用）增 `tenant_id`（存量行靠列 DEFAULT 划入默认租户，升级零迁移），从属资源经根资源归属租户，刻意不给四十张表全加列；`t_kb_role` 的 `code` 唯一范围从全局收缩为租户内（`uk_tenant_code`）；`t_kb_document` 增 `visibility`（INHERIT/RESTRICTED）、`t_kb_user_role` 增 `granted_by`（MANUAL/LDAP_SYNC）、`t_kb_retrieval_feedback` 增 `channel` / `end_user_id`；新增权限码 `tenant:manage`（仅授超级管理员）

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/KnowledgeBaseController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/KnowledgeBaseController.java
@@ -12,6 +12,7 @@ import io.kbrag.api.dto.RebuildRequest;
 import io.kbrag.api.dto.RebuildStatusResponse;
 import io.kbrag.api.dto.UpdateIndexConfigRequest;
 import io.kbrag.api.dto.UpdateKbGovernanceRequest;
+import io.kbrag.api.dto.UpdateKnowledgeBaseRequest;
 import io.kbrag.app.auth.AccessGuard;
 import io.kbrag.app.chat.ChatImportService;
 import io.kbrag.app.document.DocumentPreviewService;
@@ -84,6 +85,23 @@ public class KnowledgeBaseController {
     public Result<KnowledgeBaseResponse> create(@Valid @RequestBody CreateKnowledgeBaseRequest request) {
         KnowledgeBase created = knowledgeBaseService.create(request.name(), request.description());
         return Result.success(toResponse(created));
+    }
+
+    /**
+     * Renames a knowledge base and updates its description.
+     *
+     * @param kbId    business identifier
+     * @param request update payload
+     * @return updated knowledge base
+     */
+    @PutMapping("/{kbId}")
+    @RequiresPermission(PermissionCodes.KB_WRITE)
+    @AuditedOperation(module = "KB", action = "UPDATE", targetType = "KNOWLEDGE_BASE", targetId = "#kbId")
+    public Result<KnowledgeBaseResponse> update(@PathVariable String kbId,
+                                                @Valid @RequestBody UpdateKnowledgeBaseRequest request) {
+        AccessGuard.requireKbAccess(kbId);
+        KnowledgeBase updated = knowledgeBaseService.update(kbId, request.name(), request.description());
+        return Result.success(toResponse(updated));
     }
 
     /**

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateKnowledgeBaseRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateKnowledgeBaseRequest.java
@@ -1,0 +1,18 @@
+package io.kbrag.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Knowledge base rename/update payload.
+ *
+ * @param name        display name
+ * @param description free text description
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public record UpdateKnowledgeBaseRequest(
+        @NotBlank(message = "must not be blank") @Size(max = 128, message = "must be at most 128 characters")
+        String name,
+        @Size(max = 1024, message = "must be at most 1024 characters") String description) {
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/kb/KnowledgeBaseService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/kb/KnowledgeBaseService.java
@@ -107,6 +107,32 @@ public class KnowledgeBaseService {
     }
 
     /**
+     * Renames a knowledge base and updates its description.
+     *
+     * <p>Only the display fields change: the index configuration, the fingerprint and the physical
+     * indices are untouched, so a rename never marks a document stale or costs a rebuild.
+     *
+     * @param kbId        business id
+     * @param name        new display name
+     * @param description new free text description
+     * @return updated aggregate
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public KnowledgeBase update(String kbId, String name, String description) {
+        KnowledgeBase knowledgeBase = require(kbId);
+        if (knowledgeBaseMapper.exists(new LambdaQueryWrapper<KnowledgeBase>()
+                .eq(KnowledgeBase::getName, name)
+                .ne(KnowledgeBase::getKbId, kbId))) {
+            throw BizException.invalidParam("knowledge base name already exists");
+        }
+        knowledgeBase.setName(name);
+        knowledgeBase.setDescription(description);
+        knowledgeBaseMapper.updateById(knowledgeBase);
+        log.info("knowledge base updated, kbId={}, name={}", kbId, name);
+        return knowledgeBase;
+    }
+
+    /**
      * Lists the knowledge bases the caller may see, newest first.
      *
      * <p>Trimmed here rather than in the controller because this listing feeds every knowledge base picker

--- a/kb-rag-web/src/api/kb.ts
+++ b/kb-rag-web/src/api/kb.ts
@@ -10,6 +10,7 @@ import type {
   RebuildRequest,
   RebuildStatus,
   UpdateIndexConfigRequest,
+  UpdateKbRequest,
 } from './types';
 
 export function listKnowledgeBases(): Promise<KnowledgeBase[]> {
@@ -22,6 +23,11 @@ export function getKnowledgeBase(kbId: string): Promise<KnowledgeBase> {
 
 export function createKnowledgeBase(payload: CreateKbRequest): Promise<KnowledgeBase> {
   return apiPost<KnowledgeBase>('/kb', payload);
+}
+
+/** PUT /api/v1/kb/{kbId}: renames the base and updates its description, nothing else. */
+export function updateKnowledgeBase(kbId: string, payload: UpdateKbRequest): Promise<KnowledgeBase> {
+  return apiPut<KnowledgeBase>(`/kb/${kbId}`, payload);
 }
 
 export function deleteKnowledgeBase(kbId: string): Promise<void> {

--- a/kb-rag-web/src/api/types.ts
+++ b/kb-rag-web/src/api/types.ts
@@ -349,6 +349,12 @@ export interface CreateKbRequest {
   description?: string;
 }
 
+/** PUT /api/v1/kb/{kbId} request body: rename and re-describe, nothing else. */
+export interface UpdateKbRequest {
+  name: string;
+  description?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Document / chunk
 // ---------------------------------------------------------------------------

--- a/kb-rag-web/src/pages/kb/KbListPage.tsx
+++ b/kb-rag-web/src/pages/kb/KbListPage.tsx
@@ -8,11 +8,13 @@ import type { DemoStatus, KnowledgeBase } from '../../api/types';
 import { useAuth } from '../../auth/AuthContext';
 import { PERMISSIONS } from '../../auth/permissions';
 import CreateKbModal from './components/CreateKbModal';
+import EditKbModal from './components/EditKbModal';
 
 export default function KbListPage() {
   const [kbs, setKbs] = useState<KnowledgeBase[]>([]);
   const [loading, setLoading] = useState(true);
   const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [editingKb, setEditingKb] = useState<KnowledgeBase | null>(null);
   const [demoStatus, setDemoStatus] = useState<DemoStatus | null>(null);
   const [demoImporting, setDemoImporting] = useState(false);
   const navigate = useNavigate();
@@ -116,6 +118,15 @@ export default function KbListPage() {
                     </span>,
                     ...(canWrite
                       ? [
+                          <span
+                            key="edit"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditingKb(kb);
+                            }}
+                          >
+                            编辑
+                          </span>,
                           <Popconfirm
                             key="delete"
                             title="确认删除该知识库？"
@@ -150,6 +161,15 @@ export default function KbListPage() {
         onClose={() => setCreateModalOpen(false)}
         onCreated={() => {
           setCreateModalOpen(false);
+          loadKbs();
+        }}
+      />
+
+      <EditKbModal
+        kb={editingKb}
+        onClose={() => setEditingKb(null)}
+        onUpdated={() => {
+          setEditingKb(null);
           loadKbs();
         }}
       />

--- a/kb-rag-web/src/pages/kb/components/EditKbModal.tsx
+++ b/kb-rag-web/src/pages/kb/components/EditKbModal.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { Form, Input, Modal, message } from 'antd';
+import { updateKnowledgeBase } from '../../../api/kb';
+import type { KnowledgeBase, UpdateKbRequest } from '../../../api/types';
+
+interface EditKbModalProps {
+  /** The base being edited; null keeps the modal closed. */
+  kb: KnowledgeBase | null;
+  onClose: () => void;
+  onUpdated: (kb: KnowledgeBase) => void;
+}
+
+export default function EditKbModal({ kb, onClose, onUpdated }: EditKbModalProps) {
+  const [form] = Form.useForm<UpdateKbRequest>();
+  const [submitting, setSubmitting] = useState(false);
+
+  // Refill on every open: the same modal instance is reused across cards, so stale
+  // values from the previously edited base must not leak into the next one.
+  useEffect(() => {
+    if (kb) {
+      form.setFieldsValue({ name: kb.name, description: kb.description ?? undefined });
+    }
+  }, [kb, form]);
+
+  const handleOk = async () => {
+    if (!kb) {
+      return;
+    }
+    const values = await form.validateFields();
+    setSubmitting(true);
+    try {
+      const updated = await updateKnowledgeBase(kb.kb_id, values);
+      message.success('知识库已更新');
+      form.resetFields();
+      onUpdated(updated);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    form.resetFields();
+    onClose();
+  };
+
+  return (
+    <Modal
+      title="编辑知识库"
+      open={!!kb}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      confirmLoading={submitting}
+      okText="保存"
+      cancelText="取消"
+      destroyOnClose
+    >
+      <Form<UpdateKbRequest> form={form} layout="vertical">
+        <Form.Item
+          name="name"
+          label="知识库名称"
+          rules={[{ required: true, message: '请输入知识库名称' }]}
+        >
+          <Input placeholder="例如：产品文档知识库" maxLength={64} />
+        </Form.Item>
+        <Form.Item name="description" label="描述">
+          <Input.TextArea placeholder="选填，简单描述知识库用途" maxLength={256} rows={3} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## 变更内容

知识库支持重命名与描述编辑。

### 后端
- 新增 `PUT /api/v1/kb/{kbId}` 端点（`kb:write` 权限 + 数据范围校验，审计落 `KB/UPDATE`）
- 新增 `UpdateKnowledgeBaseRequest` DTO，校验规则与创建接口一致（name 必填 ≤128，description ≤1024）
- `KnowledgeBaseService.update`：重名校验排除自身（允许只改描述不改名）；只更新展示字段——索引配置与指纹不变，改名不会使任何文档 config_stale，也不触发重建

### 前端
- `api/kb.ts` 新增 `updateKnowledgeBase`，`types.ts` 新增 `UpdateKbRequest`
- 新增 `EditKbModal` 编辑弹窗，打开时回填当前名称与描述
- 知识库列表卡片在「查看详情」与「删除」之间新增「编辑」入口（仅 `kb:write` 可见）

### 文档同步
- `kb-rag-deploy/docs/openapi/kb-server.yaml`：补 `PUT /api/v1/kb/{kbId}` 与 `UpdateKbRequest` schema
- `kb-rag-server/CHANGELOG.md`：新增条目

## 验证
- 后端 `mvn compile -pl kb-api,kb-app -am` 通过
- 前端 `tsc --noEmit` 通过
