### PR TITLE
feat(app): 应用中心支持编辑名称与描述

### DIFF
--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 新增
 
+- 应用重命名：控制台应用中心卡片新增「编辑」入口（仅 `app:write` 可见），复用既有 `PUT /api/v1/apps/{appId}`（`app:write`，审计 `APP/UPDATE`）更新 name 与 description，新名称与其他应用重名时拒绝（排除自身，仅改描述不改名不受此限）
 - 知识库重命名：`PUT /api/v1/kb/{kbId}`（`kb:write`）更新 name 与 description，新名称与其他知识库重名时拒绝（排除自身，仅改描述不改名不受此限）；只动展示字段——索引配置与指纹不变，改名不会使任何文档 config_stale，也不触发重建；审计落 `KB/UPDATE`。控制台知识库卡片新增「编辑」入口（仅 `kb:write` 可见）
 
 ### 新增（M16）

--- a/kb-rag-web/src/pages/apps/AppListPage.tsx
+++ b/kb-rag-web/src/pages/apps/AppListPage.tsx
@@ -8,12 +8,14 @@ import type { KbApp } from '../../api/types';
 import { useAuth } from '../../auth/AuthContext';
 import { PERMISSIONS } from '../../auth/permissions';
 import CreateAppModal from './components/CreateAppModal';
+import EditAppModal from './components/EditAppModal';
 
 /** 应用中心顶级菜单落点：应用列表 + 新建（M4c-CONTRACTS.md section 4）. */
 export default function AppListPage() {
   const [apps, setApps] = useState<KbApp[]>([]);
   const [loading, setLoading] = useState(true);
   const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [editingApp, setEditingApp] = useState<KbApp | null>(null);
   const navigate = useNavigate();
   const { can } = useAuth();
   // app:read opens the list and the detail screens; creating or removing an application is app:write.
@@ -79,6 +81,15 @@ export default function AppListPage() {
                     </span>,
                     ...(canWrite
                       ? [
+                          <span
+                            key="edit"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditingApp(app);
+                            }}
+                          >
+                            编辑
+                          </span>,
                           <Popconfirm
                             key="delete"
                             title="确认删除该应用？"
@@ -114,6 +125,15 @@ export default function AppListPage() {
         onCreated={(app) => {
           setCreateModalOpen(false);
           navigate(`/apps/${app.app_id}`);
+        }}
+      />
+
+      <EditAppModal
+        app={editingApp}
+        onClose={() => setEditingApp(null)}
+        onUpdated={() => {
+          setEditingApp(null);
+          loadApps();
         }}
       />
     </div>

--- a/kb-rag-web/src/pages/apps/components/EditAppModal.tsx
+++ b/kb-rag-web/src/pages/apps/components/EditAppModal.tsx
@@ -1,0 +1,69 @@
+// Author: owlzhangfq@gmail.com
+import { useEffect, useState } from 'react';
+import { Form, Input, Modal, message } from 'antd';
+import { updateApp } from '../../../api/app';
+import type { KbApp, UpdateAppRequest } from '../../../api/types';
+
+interface EditAppModalProps {
+  /** The app being edited; null keeps the modal closed. */
+  app: KbApp | null;
+  onClose: () => void;
+  onUpdated: (app: KbApp) => void;
+}
+
+/** App rename/description modal, sibling of CreateAppModal (AppController#update). */
+export default function EditAppModal({ app, onClose, onUpdated }: EditAppModalProps) {
+  const [form] = Form.useForm<UpdateAppRequest>();
+  const [submitting, setSubmitting] = useState(false);
+
+  // Refill on every open: the same modal instance is reused across cards, so stale
+  // values from the previously edited app must not leak into the next one.
+  useEffect(() => {
+    if (app) {
+      form.setFieldsValue({ name: app.name, description: app.description ?? undefined });
+    }
+  }, [app, form]);
+
+  const handleOk = async () => {
+    if (!app) {
+      return;
+    }
+    const values = await form.validateFields();
+    setSubmitting(true);
+    try {
+      const updated = await updateApp(app.app_id, values);
+      message.success('应用已更新');
+      form.resetFields();
+      onUpdated(updated);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    form.resetFields();
+    onClose();
+  };
+
+  return (
+    <Modal
+      title="编辑应用"
+      open={!!app}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      confirmLoading={submitting}
+      okText="保存"
+      cancelText="取消"
+      destroyOnClose
+    >
+      <Form<UpdateAppRequest> form={form} layout="vertical">
+        <Form.Item name="name" label="应用名称" rules={[{ required: true, message: '请输入应用名称' }]}>
+          <Input placeholder="例如：产品客服问答应用" maxLength={64} />
+        </Form.Item>
+        <Form.Item name="description" label="描述">
+          <Input.TextArea placeholder="选填，简单描述应用用途" maxLength={256} rows={3} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## 变更内容

应用中心的应用支持编辑名称与描述，与知识库改名保持一致的交互。

## 关键发现

后端此前**已完整实现**，本次为纯前端补全：
- `PUT /api/v1/apps/{appId}`（`AppController#update`，`app:write`，审计 `APP/UPDATE`）已存在
- `AppService.update` 已含重名校验（排除自身，仅改描述不改名不受限）
- 前端 `api/app.ts` 的 `updateApp` 与 `UpdateAppRequest` 类型已存在
- OpenAPI 契约 `kb-server.yaml` 已文档化该端点

缺的只是前端编辑弹窗与卡片入口。

## 前端改动
- 新增 `EditAppModal`：打开时回填当前名称与描述（镜像知识库的 `EditKbModal`）
- `AppListPage` 卡片在「查看详情」与「删除」之间新增「编辑」入口（仅 `app:write` 可见），保存后刷新列表

## 文档
- `kb-rag-server/CHANGELOG.md`：新增应用重命名条目

## 验证
- 前端 `tsc --noEmit` 通过
- 后端无改动（接口与契约此前已具备）
