### PR TITLE
feat(websource): 网页导入 JS 渲染抓取 + 启动 banner 换成 KB-RAG

### DIFF
--- a/kb-rag-deploy/.env.example
+++ b/kb-rag-deploy/.env.example
@@ -270,6 +270,26 @@ WEB_IMPORT_SYNC_CRON="0 30 2 * * *"
 WEB_IMPORT_SYNC_ENABLED=true
 # 单轮定时同步处理的登记数上限（按 id 升序取一批，单条失败不中断本轮）
 WEB_IMPORT_SYNC_BATCH_SIZE=50
+# 【危险开关】true 时 SSRF 防线放行回环/内网地址（scheme、凭据、主机名校验照常）。仅限开发联调
+# 或纯内网部署使用；任何不可信用户能登记网页源的环境必须保持 false，否则「抓取该页」可被用于
+# 读取云元数据端点等内网资源。每次放行都会打 INFO 日志留痕。
+WEB_IMPORT_ALLOW_INTERNAL_ADDRESS=false
+
+# --- 网页导入 JS 渲染抓取（M17，docs/M17-CONTRACTS.md §3.5）---
+# 按源开关（render_js，默认关）：开启的源抓取走无头浏览器渲染 JS 后取 DOM 入库，适用于正文靠
+# 脚本注入的框架页（如 Oracle Javadoc）。开启渲染需镜像内置 Chromium，否则该源同步记 FAILED
+# 且原因可见，不影响应用启动与静态抓取链路。
+# 渲染总闸：关闭后所有 render_js=1 被忽略、降级静态抓取（记 SUCCESS/UNCHANGED 而非 FAILED）；
+# 未内置 Chromium 的镜像应置 false。
+WEB_IMPORT_RENDER_ENABLED=true
+# 单页渲染预算（毫秒）：并发许可等待与导航+networkidle 等待同预算，独立于静态 fetch-timeout。渲染更慢。
+WEB_IMPORT_RENDER_TIMEOUT_MS=20000
+# 同时渲染的页数上限：浏览器 context 数百 MB 级，默认保守，与容器内存联动上调。
+WEB_IMPORT_RENDER_MAX_CONCURRENCY=2
+# Playwright waitUntil 策略：load / domcontentloaded / networkidle 之一，缺省 networkidle。
+# 长轮询/心跳页面用 networkidle 会拖到超时，可按需改 domcontentloaded。
+WEB_IMPORT_RENDER_WAIT_UNTIL=networkidle
+# 注：渲染后 DOM 同受 WEB_IMPORT_MAX_PAGE_SIZE_MB 上限约束，不新增体积键。
 
 # --- 外部数据源连接器（M14，docs/M14-CONTRACTS.md §2.4）---
 # S3/OSS 兼容对象存储连接器：登记 bucket/prefix 后按前缀扫描对象走上传链路入库，ETag 增量同步。

--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Added
 
+- **网页导入 JS 渲染抓取（M17，`docs/M17-CONTRACTS.md`）**：网页源新增可选 `render_js` 开关（**按源、默认关**），开启后该源抓取走 server 内嵌 Playwright-Java（Chromium headless）渲染后取 DOM 入库，解决 Oracle Javadoc 一类 frameset/SPA 页静态抓取拿不到正文的问题；渲染产物仍走 M12 文档上传管线，不新增入库旁路。SSRF 防线覆盖浏览器加载的**每个子请求**（逐个过 `UrlGuard`，拦内网/回环/元数据地址）。`.env.example` 新增「网页导入 JS 渲染（M17）」分节：`WEB_IMPORT_RENDER_ENABLED`（默认 true，总闸；关闸则忽略所有 `render_js=1` 并降级静态抓取，行为等同 M12）/ `WEB_IMPORT_RENDER_TIMEOUT_MS`（默认 20000）/ `WEB_IMPORT_RENDER_MAX_CONCURRENCY`（默认 2，与容器内存联动）/ `WEB_IMPORT_RENDER_WAIT_UNTIL`（默认 networkidle），全部带默认值——**不设变量与未内置 Chromium 的部署行为不变**。**部署红线**：kb-rag-server 镜像需构建期内置 Chromium 及其运行库与常用字体（`playwright install --with-deps chromium` 或等价系统包）并设 `PLAYWRIGHT_BROWSERS_PATH` 指向镜像内固定路径；**镜像体积与内存显著上升**（Chromium 单 context 数百 MB 级，渲染实例内存建议在原基础上上调，与 `WEB_IMPORT_RENDER_MAX_CONCURRENCY` 联动）；**未内置 Chromium 的镜像误开 `render_js` 只会让该源同步 FAILED 且原因可见，不拖垮应用启动与静态抓取链路**。纵深防御建议：渲染实例网络出站仅放行公网、显式屏蔽元数据网段，作为代码防线之外的兜底。
+- OpenAPI 升至 `0.17.0-m17`：`RegisterWebSourceRequest` / `UpdateWebSourceRequest` / `WebSource` schema 三处增 `render_js`（默认 false）；PUT 请求体去 `required: [sync_enabled]`（两开关均可选，只改传入的那个）。
 - **企业化：多租户 / 文档级数据权限 / LDAP 组同步 / SSO 三协议 / 操作审计（M16）**：新增 `docs/M16-CONTRACTS.md`
   （开发契约，含租户模型与索引命名租户段、文档 ACL 判定点、三协议 SSO 行为与升级说明）；
   `.env.example` 新增「企业化（M16）」分节：`AUTH_LDAP_GROUP_SYNC_ENABLED`（默认 false）/

--- a/kb-rag-deploy/docs/openapi/kb-server.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-server.yaml
@@ -195,7 +195,7 @@ info:
     `/api/v1/operation-audits` 查询端点。全部纯新增（详见 M16-CONTRACTS.md）。
 
     '
-  version: 0.16.0-m16
+  version: 0.17.0-m17
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -1719,6 +1719,10 @@ paths:
                   type: boolean
                   default: true
                   description: 缺省开启定时同步
+                render_js:
+                  type: boolean
+                  default: false
+                  description: 'M17-CONTRACTS.md §3.3：置 true 时该源抓取走无头浏览器渲染 JS 后取 DOM 入库，缺省 false 静态抓取。开启需镜像内置 Chromium 且渲染总闸开。'
       responses:
         '200':
           description: 登记行（含首次抓取结果）
@@ -1792,17 +1796,21 @@ paths:
     put:
       tags:
       - web-source
-      summary: 开关定时同步
+      summary: 更新登记开关（定时同步 / JS 渲染，均可选）
+      description: 'M17-CONTRACTS.md §3.3：登记的可变开关——定时同步与 JS 渲染。两字段均可选，只更新传入的那个，翻开关不触发抓取。'
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [sync_enabled]
               properties:
                 sync_enabled:
                   type: boolean
+                  description: 缺省不改动
+                render_js:
+                  type: boolean
+                  description: 'M17：JS 渲染开关，缺省不改动'
       responses:
         '200':
           description: 更新后的登记行
@@ -5061,6 +5069,9 @@ components:
           description: 由 URL 派生的稳定文件名（host-path摘要-urlHash前8位.后缀），重抓同名加版本
         sync_enabled:
           type: boolean
+        render_js:
+          type: boolean
+          description: 'M17-CONTRACTS.md §1：true 表示该源抓取走无头浏览器 JS 渲染，默认 false 静态抓取'
         last_fetch_status:
           allOf:
           - $ref: '#/components/schemas/WebSourceFetchStatus'

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - 应用重命名：控制台应用中心卡片新增「编辑」入口（仅 `app:write` 可见），复用既有 `PUT /api/v1/apps/{appId}`（`app:write`，审计 `APP/UPDATE`）更新 name 与 description，新名称与其他应用重名时拒绝（排除自身，仅改描述不改名不受此限）
 - 知识库重命名：`PUT /api/v1/kb/{kbId}`（`kb:write`）更新 name 与 description，新名称与其他知识库重名时拒绝（排除自身，仅改描述不改名不受此限）；只动展示字段——索引配置与指纹不变，改名不会使任何文档 config_stale，也不触发重建；审计落 `KB/UPDATE`。控制台知识库卡片新增「编辑」入口（仅 `kb:write` 可见）
+- 启动 banner 换成 KB-RAG：新增 `kb-api/src/main/resources/banner.txt` 顶掉 Spring Boot 默认图形，`KB` 两字母成一组、`RAG` 三字母各留一格、两组间双空格，靠间距读出分组因而不需要连字符（宽 41 列）；附 `${spring-boot.version}` 与构建版本 `${application.version:dev}`——jar 启动读 MANIFEST 显示实际版本，IDE 直跑没有 MANIFEST 时落到 `dev`，不留空洞。纯资源文件，不涉及任何代码与配置开关（`application.yml` 里那个 `banner: false` 是 MyBatis-Plus 的 logo 开关，与此无关）
 
 ### 新增（M17）
 

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -12,6 +12,20 @@
 - 应用重命名：控制台应用中心卡片新增「编辑」入口（仅 `app:write` 可见），复用既有 `PUT /api/v1/apps/{appId}`（`app:write`，审计 `APP/UPDATE`）更新 name 与 description，新名称与其他应用重名时拒绝（排除自身，仅改描述不改名不受此限）
 - 知识库重命名：`PUT /api/v1/kb/{kbId}`（`kb:write`）更新 name 与 description，新名称与其他知识库重名时拒绝（排除自身，仅改描述不改名不受此限）；只动展示字段——索引配置与指纹不变，改名不会使任何文档 config_stale，也不触发重建；审计落 `KB/UPDATE`。控制台知识库卡片新增「编辑」入口（仅 `kb:write` 可见）
 
+### 新增（M17）
+
+- `[schema]` Flyway `V18__web_source_render_js.sql`：`t_kb_web_source` 增 `render_js TINYINT NOT NULL DEFAULT 0`（加在 `sync_enabled` 之后，语义相邻），置 1 时该源抓取走无头浏览器 JS 渲染、默认 0 静态抓取；不新增索引（不参与查询过滤，仅随行读出），存量源升级后行为零变化（继续静态抓取）
+- 网页源可选 JS 渲染抓取（**按源开关、默认关**）：server 内嵌 Playwright-Java（Chromium headless），在 `WebPageFetcher` 端口后新增渲染实现，按开关路由后取渲染后 DOM 入库——解决 Oracle Javadoc 一类 frameset/SPA 页静态抓取拿不到正文的问题。渲染产物仍是一段 `text/html` 字节，**继续收敛到 M12 既有链路**（DocumentService.upload → HtmlParser → 版本机制/治理/索引），不新增任何入库旁路，`content_hash` 未变→不建新版本的判重语义天然继承
+- `WebPageFetcher` 端口签名扩展 `fetch(String url, boolean renderJs)`（唯一调用点 WebSourceService，直接改签名不留重载）；新增 `WebPageFetcherDispatcher`（`@Primary`）按 `renderJs && render.enabled` 路由到静态实现（`HttpWebPageFetcher`）或渲染实现（`PlaywrightWebPageFetcher`），总闸关闭时降级静态抓取兜底
+- `PlaywrightWebPageFetcher`：单个 Chromium `Browser` **懒启动**（首次真正渲染时才拉起，`@PreDestroy` 关闭），`Semaphore` 按 `max-concurrency` 限流、`timeout-ms` 内取不到令牌即 FAILED；单次渲染新建 context（禁下载、设 UA、设导航超时）→ `navigate(url, waitUntil)` → `page.content()` → UTF-8 字节，同受 `max-page-size-mb` 上限约束，finally 释放令牌与 context。浏览器启动失败抛 BizException 收成该源 FAILED，**绝不拖垮应用启动或静态抓取链路**
+- 渲染路径 SSRF 防线（本期重中之重）：对渲染 context 注册 `context.route("**/*")` 路由拦截，浏览器加载的**每个子请求**（img/xhr/fetch/iframe/css 及导航重定向）逐个过既有 `UrlGuard`，命中内网/回环/链路本地/元数据地址即 `abort` 并记错误码日志（不抛，个别子资源被拦不中断整页渲染），放行则 `resume`——与静态抓取「主 URL + 逐跳过 UrlGuard」形成闭合防线
+- `WebSourceService`：`register(kbId, url, syncEnabled, renderJs)` 落登记行写入 `renderJs`；`sync` 唯一改动是按 `render_js` 传参给 fetcher（其余 hash 判重/trash skip/rebind/四态/不重抛完全不变）；`updateSettings(sourceId, syncEnabled, renderJs)` 两开关均可空、只改传入项，翻开关不触发抓取；服务层用常量 `RENDER_ON=1`/`RENDER_OFF=0`，不裸用魔法值
+- 端点与 DTO（既有 URL 与响应结构不变）：`POST /api/v1/kb/{kbId}/web-sources` 的 `RegisterWebSourceRequest` 增可选 `render_js`（缺省 false）；`PUT /api/v1/web-sources/{sourceId}` 的 `UpdateWebSourceRequest` 去掉 `sync_enabled` 的 `@NotNull`、增可选 `render_js`（两字段均可空）；`WebSourceResponse` 增 `render_js`（按 `RENDER_ON` 映射）；权限沿用（register/sync/update 仍 `doc:write`，list 仍 `kb:read`，渲染不新增权限）
+- 指标复用既有 `kb_websource_sync_total` 四态计数（M13），不新增指标——是否渲染属抓取内部实现，不进额外维度
+- 新增配置键 `kb.web-import.render.{enabled/timeout-ms/max-concurrency/wait-until}`（环境变量 `WEB_IMPORT_RENDER_ENABLED`/`WEB_IMPORT_RENDER_TIMEOUT_MS`/`WEB_IMPORT_RENDER_MAX_CONCURRENCY`/`WEB_IMPORT_RENDER_WAIT_UNTIL`），`enabled` 为总闸——关闸则忽略所有 `render_js=1` 并降级静态抓取（记 UNCHANGED/SUCCESS 同旧逻辑，不 FAILED）；复用既有 `max-page-size-mb`，不新增体积键
+- 新增配置键 `kb.web-import.allow-internal-address`（环境变量 `WEB_IMPORT_ALLOW_INTERNAL_ADDRESS`，默认 false）：**危险开关**，置 true 时 `UrlGuard` 放行回环/内网地址（scheme/凭据/主机名校验照常，每次放行打 INFO 日志留痕），仅供开发联调与纯内网部署抓取内网页面使用；生产环境任何不可信用户能登记网页源时必须保持 false
+- 新增依赖 `com.microsoft.playwright:playwright`（父 pom `dependencyManagement` 显式锁版本、kb-infrastructure 引入）；Chromium 二进制不走运行时自动下载，改镜像构建期安装（详见 kb-rag-deploy）
+
 ### 新增（M16）
 
 - `[schema]` Flyway `V17__tenant_doc_acl_audit.sql`：新增 `t_kb_tenant`（内置默认租户 `tnt_default0000000` 随迁移种子化，不可停用）、`t_kb_doc_acl`（受限文档→授权角色绑定）、`t_kb_operation_audit`（操作审计，含 `username` 冗余列——账号删了记录还得可读）；6 张根聚合表（用户 / 角色 / 知识库 / API Key / 评测集 / 应用）增 `tenant_id`（存量行靠列 DEFAULT 划入默认租户，升级零迁移），从属资源经根资源归属租户，刻意不给四十张表全加列；`t_kb_role` 的 `code` 唯一范围从全局收缩为租户内（`uk_tenant_code`）；`t_kb_document` 增 `visibility`（INHERIT/RESTRICTED）、`t_kb_user_role` 增 `granted_by`（MANUAL/LDAP_SYNC）、`t_kb_retrieval_feedback` 增 `channel` / `end_user_id`；新增权限码 `tenant:manage`（仅授超级管理员）

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/WebSourceController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/WebSourceController.java
@@ -55,8 +55,9 @@ public class WebSourceController {
                                               @Valid @RequestBody RegisterWebSourceRequest request) {
         AccessGuard.requireKbAccess(kbId);
         boolean syncEnabled = request.syncEnabled() == null || request.syncEnabled();
+        boolean renderJs = request.renderJs() != null && request.renderJs();
         return Result.success(WebSourceResponse.from(
-                webSourceService.register(kbId, request.url().trim(), syncEnabled)));
+                webSourceService.register(kbId, request.url().trim(), syncEnabled, renderJs)));
     }
 
     /**
@@ -93,10 +94,11 @@ public class WebSourceController {
     }
 
     /**
-     * Flips the scheduled-sync switch of one source.
+     * Applies the mutable switches of one source: scheduled sync and JS rendering, the M17 contract
+     * section 3.3. Each is optional and only the present ones are changed.
      *
      * @param sourceId registration business id
-     * @param request  new switch value
+     * @param request  new switch values, either one may be absent
      * @return updated registration
      */
     @PutMapping("/api/v1/web-sources/{sourceId}")
@@ -105,7 +107,7 @@ public class WebSourceController {
                                             @Valid @RequestBody UpdateWebSourceRequest request) {
         kbScopeGuard.requireWebSourceAccess(sourceId);
         return Result.success(WebSourceResponse.from(
-                webSourceService.updateSyncEnabled(sourceId, request.syncEnabled())));
+                webSourceService.updateSettings(sourceId, request.syncEnabled(), request.renderJs())));
     }
 
     /**

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RegisterWebSourceRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/RegisterWebSourceRequest.java
@@ -9,11 +9,13 @@ import jakarta.validation.constraints.Size;
  *
  * @param url         page address, http or https
  * @param syncEnabled whether the scheduled pass should keep this page fresh, defaults to on
+ * @param renderJs    whether to fetch through a headless browser and store the rendered DOM, defaults to off
  *
  * @author owlzhangfq@gmail.com
  */
 public record RegisterWebSourceRequest(
         @NotBlank(message = "must not be blank") @Size(max = 2048, message = "must be at most 2048 characters")
         String url,
-        @JsonProperty("sync_enabled") Boolean syncEnabled) {
+        @JsonProperty("sync_enabled") Boolean syncEnabled,
+        @JsonProperty("render_js") Boolean renderJs) {
 }

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateWebSourceRequest.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/UpdateWebSourceRequest.java
@@ -1,17 +1,19 @@
 package io.kbrag.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotNull;
 
 /**
- * Payload of {@code PUT /api/v1/web-sources/{sourceId}}: the sync switch is the only mutable
- * attribute of a registration - changing the URL would change its identity, so that is a remove
- * plus a new registration instead.
+ * Payload of {@code PUT /api/v1/web-sources/{sourceId}}, the M17 contract section 3.3: the mutable
+ * switches of a registration - scheduled sync and JS rendering. Both are optional and only the
+ * present ones are applied, so the console's two toggles share one endpoint; the URL is not mutable
+ * here because changing it changes the identity, which is a remove plus a new registration instead.
  *
- * @param syncEnabled {@code true} includes the source in the scheduled sync pass
+ * @param syncEnabled new scheduled-sync value, {@code null} leaves it unchanged
+ * @param renderJs    new JS-render value, {@code null} leaves it unchanged
  *
  * @author owlzhangfq@gmail.com
  */
 public record UpdateWebSourceRequest(
-        @JsonProperty("sync_enabled") @NotNull(message = "must not be null") Boolean syncEnabled) {
+        @JsonProperty("sync_enabled") Boolean syncEnabled,
+        @JsonProperty("render_js") Boolean renderJs) {
 }

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/WebSourceResponse.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/dto/WebSourceResponse.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
  * @param docId           document the fetches feed, {@code null} until the first successful fetch
  * @param fileName        derived file name the document carries, {@code null} until the first fetch
  * @param syncEnabled     whether the scheduled pass includes this source
+ * @param renderJs        whether this source is fetched through the headless browser, the M17 switch
  * @param lastFetchStatus outcome of the last sync attempt, {@code null} before the first one
  * @param lastFetchAt     ISO instant of the last sync attempt
  * @param lastError       why the last sync failed or was skipped, {@code null} on success
@@ -28,12 +29,14 @@ public record WebSourceResponse(
         @JsonProperty("doc_id") String docId,
         @JsonProperty("file_name") String fileName,
         @JsonProperty("sync_enabled") boolean syncEnabled,
+        @JsonProperty("render_js") boolean renderJs,
         @JsonProperty("last_fetch_status") String lastFetchStatus,
         @JsonProperty("last_fetch_at") String lastFetchAt,
         @JsonProperty("last_error") String lastError,
         @JsonProperty("created_at") String createdAt) {
 
     private static final int SYNC_ON = 1;
+    private static final int RENDER_ON = 1;
 
     /**
      * Maps an entity onto its view.
@@ -49,6 +52,7 @@ public record WebSourceResponse(
                 entity.getDocId(),
                 entity.getFileName(),
                 entity.getSyncEnabled() != null && entity.getSyncEnabled() == SYNC_ON,
+                entity.getRenderJs() != null && entity.getRenderJs() == RENDER_ON,
                 entity.getLastFetchStatus() == null ? null : entity.getLastFetchStatus().name(),
                 iso(entity.getLastFetchAt()),
                 entity.getLastError(),

--- a/kb-rag-server/kb-api/src/main/resources/application.yml
+++ b/kb-rag-server/kb-api/src/main/resources/application.yml
@@ -374,6 +374,18 @@ kb:
     sync-enabled: ${WEB_IMPORT_SYNC_ENABLED:true}
     # Sources per scheduled pass; fetches are slow network calls, so a pass drains a bounded slice.
     sync-batch-size: ${WEB_IMPORT_SYNC_BATCH_SIZE:50}
+    # DANGER: true admits loopback/private addresses through the SSRF guard. Development and intranet
+    # deployments only - keep false wherever an untrusted user can register a source.
+    allow-internal-address: ${WEB_IMPORT_ALLOW_INTERNAL_ADDRESS:false}
+    render:
+      # Master switch for JS rendering; off on an image without Chromium so render_js sources fall back.
+      enabled: ${WEB_IMPORT_RENDER_ENABLED:true}
+      # Budget of one render, permit wait and navigation alike; a slow page fails rather than hangs.
+      timeout-ms: ${WEB_IMPORT_RENDER_TIMEOUT_MS:30000}
+      # Concurrent renders; a browser context holds hundreds of MB, so the fan-out is bounded.
+      max-concurrency: ${WEB_IMPORT_RENDER_MAX_CONCURRENCY:2}
+      # When a navigation is considered done: load, domcontentloaded or networkidle.
+      wait-until: ${WEB_IMPORT_RENDER_WAIT_UNTIL:load}
   ext-source:
     sync-cron: ${EXT_SOURCE_SYNC_CRON:0 0 3 * * *}
     sync-enabled: ${EXT_SOURCE_SYNC_ENABLED:true}

--- a/kb-rag-server/kb-api/src/main/resources/banner.txt
+++ b/kb-rag-server/kb-api/src/main/resources/banner.txt
@@ -1,0 +1,9 @@
+ _  __ ____     ____        _       ____ 
+| |/ /| __ )   |  _ \      / \     / ___|
+| ' / |  _ \   | |_) |    / _ \   | |  _ 
+| . \ | |_) |  |  _ <    / ___ \  | |_| |
+|_|\_\|____/   |_| \_\  /_/   \_\  \____|
+
+:: KB-RAG :: Enterprise RAG knowledge base platform
+:: Spring Boot :: ${spring-boot.version}   :: build :: ${application.version:dev}
+

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V18__web_source_render_js.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V18__web_source_render_js.sql
@@ -1,0 +1,8 @@
+-- M17：网页源新增可选的 JS 渲染抓取开关。置 1 时该源的抓取走无头浏览器，取脚本渲染后的
+-- DOM 入库，用于正文靠 JS 注入的框架页（如 Javadoc index.html）；默认 0 保持 M12 的静态抓取，
+-- 存量源升级后行为零变化。仅随行读出、不参与查询过滤，因此不建索引。
+SET NAMES utf8mb4;
+
+ALTER TABLE t_kb_web_source
+    ADD COLUMN render_js TINYINT NOT NULL DEFAULT 0
+        COMMENT '置 1 时该源抓取走无头浏览器 JS 渲染，默认 0 静态抓取' AFTER sync_enabled;

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/websource/WebSourceService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/websource/WebSourceService.java
@@ -56,6 +56,12 @@ public class WebSourceService {
     /** {@code sync_enabled} value that excludes a source from the scheduled pass. */
     private static final int SYNC_OFF = 0;
 
+    /** {@code render_js} value that fetches a source through the headless browser, the M17 contract. */
+    private static final int RENDER_ON = 1;
+
+    /** {@code render_js} value that keeps a source on the static fetch. */
+    private static final int RENDER_OFF = 0;
+
     /** Column limit of {@code last_error}; longer causes are truncated, not lost to an SQL error. */
     private static final int MAX_ERROR_LENGTH = 512;
 
@@ -84,9 +90,10 @@ public class WebSourceService {
      * @param kbId        knowledge base business id
      * @param url         page address, validated against the SSRF guard
      * @param syncEnabled whether the scheduled pass should include this source
+     * @param renderJs    whether this source is fetched through the headless browser, the M17 switch
      * @return registration row including the outcome of the first fetch
      */
-    public WebSource register(String kbId, String url, boolean syncEnabled) {
+    public WebSource register(String kbId, String url, boolean syncEnabled, boolean renderJs) {
         knowledgeBaseService.require(kbId);
         String normalized = urlGuard.validate(url).toString();
         String urlHash = HashUtil.sha256Hex(normalized);
@@ -102,8 +109,10 @@ public class WebSourceService {
         source.setUrl(normalized);
         source.setUrlHash(urlHash);
         source.setSyncEnabled(syncEnabled ? SYNC_ON : SYNC_OFF);
+        source.setRenderJs(renderJs ? RENDER_ON : RENDER_OFF);
         webSourceMapper.insert(source);
-        log.info("web source registered, sourceId={}, kbId={}, url={}", source.getSourceId(), kbId, normalized);
+        log.info("web source registered, sourceId={}, kbId={}, url={}, renderJs={}",
+                source.getSourceId(), kbId, normalized, renderJs);
         sync(source);
         return source;
     }
@@ -135,17 +144,26 @@ public class WebSourceService {
     }
 
     /**
-     * Flips the scheduled-sync switch of one source.
+     * Applies the mutable switches of a registration, the M17 contract section 3.3. Both are
+     * optional and only the non-null ones are written, so the console's two toggles - scheduled sync
+     * and JS rendering - share one endpoint. Flipping a switch never triggers a fetch.
      *
-     * @param sourceId registration business id
-     * @param enabled  {@code true} includes the source in the scheduled pass
+     * @param sourceId    registration business id
+     * @param syncEnabled new scheduled-sync value, {@code null} leaves it unchanged
+     * @param renderJs    new JS-render value, {@code null} leaves it unchanged
      * @return updated registration row
      */
-    public WebSource updateSyncEnabled(String sourceId, boolean enabled) {
+    public WebSource updateSettings(String sourceId, Boolean syncEnabled, Boolean renderJs) {
         WebSource source = require(sourceId);
-        source.setSyncEnabled(enabled ? SYNC_ON : SYNC_OFF);
+        if (syncEnabled != null) {
+            source.setSyncEnabled(syncEnabled ? SYNC_ON : SYNC_OFF);
+        }
+        if (renderJs != null) {
+            source.setRenderJs(renderJs ? RENDER_ON : RENDER_OFF);
+        }
         webSourceMapper.updateById(source);
-        log.info("web source sync switch updated, sourceId={}, enabled={}", sourceId, enabled);
+        log.info("web source settings updated, sourceId={}, syncEnabled={}, renderJs={}",
+                sourceId, syncEnabled, renderJs);
         return source;
     }
 
@@ -222,7 +240,8 @@ public class WebSourceService {
         source.setLastFetchAt(LocalDateTime.now());
         try {
             URI uri = urlGuard.validate(source.getUrl());
-            WebPageFetcher.FetchedPage page = webPageFetcher.fetch(uri.toString());
+            boolean renderJs = source.getRenderJs() != null && source.getRenderJs() == RENDER_ON;
+            WebPageFetcher.FetchedPage page = webPageFetcher.fetch(uri.toString(), renderJs);
             String contentHash = HashUtil.sha256Hex(page.body());
             if (contentHash.equals(source.getLastContentHash())) {
                 record(source, WebSourceFetchStatus.UNCHANGED, null);

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/websource/WebSourceServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/websource/WebSourceServiceTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -87,10 +88,10 @@ class WebSourceServiceTest {
     @Test
     void shouldRegisterAndRunTheFirstFetchThroughTheUploadChain() {
         when(webSourceMapper.selectCount(any())).thenReturn(0L);
-        when(webPageFetcher.fetch(URL)).thenReturn(page());
+        when(webPageFetcher.fetch(eq(URL), anyBoolean())).thenReturn(page());
         when(documentService.upload(eq(KB_ID), anyString(), eq(BODY))).thenReturn(outcome("doc_1"));
 
-        WebSource source = service.register(KB_ID, URL, true);
+        WebSource source = service.register(KB_ID, URL, true, false);
 
         verify(webSourceMapper).insert(source);
         assertEquals(WebSourceFetchStatus.SUCCESS, source.getLastFetchStatus());
@@ -108,7 +109,7 @@ class WebSourceServiceTest {
     void shouldRejectADuplicateUrlWithinTheSameKnowledgeBase() {
         when(webSourceMapper.selectCount(any())).thenReturn(1L);
 
-        assertThrows(BizException.class, () -> service.register(KB_ID, URL, true));
+        assertThrows(BizException.class, () -> service.register(KB_ID, URL, true, false));
         verify(webSourceMapper, never()).insert(any(WebSource.class));
     }
 
@@ -117,9 +118,9 @@ class WebSourceServiceTest {
         // The operator registered the page, not the luck of this minute: the row must survive and
         // carry the failure for them to read.
         when(webSourceMapper.selectCount(any())).thenReturn(0L);
-        when(webPageFetcher.fetch(URL)).thenThrow(new IllegalStateException("connection refused"));
+        when(webPageFetcher.fetch(eq(URL), anyBoolean())).thenThrow(new IllegalStateException("connection refused"));
 
-        WebSource source = assertDoesNotThrow(() -> service.register(KB_ID, URL, true));
+        WebSource source = assertDoesNotThrow(() -> service.register(KB_ID, URL, true, false));
 
         verify(webSourceMapper).insert(source);
         assertEquals(WebSourceFetchStatus.FAILED, source.getLastFetchStatus());
@@ -131,7 +132,7 @@ class WebSourceServiceTest {
     void shouldWriteNothingWhenThePageIsUnchanged() {
         WebSource source = boundSource();
         source.setLastContentHash(HashUtil.sha256Hex(BODY));
-        when(webPageFetcher.fetch(URL)).thenReturn(page());
+        when(webPageFetcher.fetch(eq(URL), anyBoolean())).thenReturn(page());
 
         service.sync(source);
 
@@ -145,7 +146,7 @@ class WebSourceServiceTest {
     void shouldSkipWhileTheBoundDocumentSitsInTheTrash() {
         // Feeding a version into a trashed document would silently resurrect removed content.
         WebSource source = boundSource();
-        when(webPageFetcher.fetch(URL)).thenReturn(page());
+        when(webPageFetcher.fetch(eq(URL), anyBoolean())).thenReturn(page());
         when(documentMapper.selectOne(any())).thenReturn(trashedDocument());
 
         service.sync(source);
@@ -160,7 +161,7 @@ class WebSourceServiceTest {
         // The purge broke the binding; the next sync recreates the document under the same stable
         // file name and the registration follows it.
         WebSource source = boundSource();
-        when(webPageFetcher.fetch(URL)).thenReturn(page());
+        when(webPageFetcher.fetch(eq(URL), anyBoolean())).thenReturn(page());
         when(documentMapper.selectOne(any())).thenReturn(null);
         when(documentService.upload(KB_ID, source.getFileName(), BODY)).thenReturn(outcome("doc_new"));
 
@@ -174,7 +175,7 @@ class WebSourceServiceTest {
     @Test
     void shouldRecordAFailureTruncatedAndNeverRethrow() {
         WebSource source = boundSource();
-        when(webPageFetcher.fetch(URL)).thenThrow(new IllegalStateException("x".repeat(600)));
+        when(webPageFetcher.fetch(eq(URL), anyBoolean())).thenThrow(new IllegalStateException("x".repeat(600)));
 
         assertDoesNotThrow(() -> service.sync(source));
 
@@ -201,8 +202,8 @@ class WebSourceServiceTest {
         healthy.setSourceId("ws_2");
         healthy.setUrl(URL + "/second");
         when(webSourceMapper.selectList(any())).thenReturn(List.of(failing, healthy));
-        when(webPageFetcher.fetch(URL)).thenThrow(new IllegalStateException("down"));
-        when(webPageFetcher.fetch(URL + "/second")).thenReturn(page());
+        when(webPageFetcher.fetch(eq(URL), anyBoolean())).thenThrow(new IllegalStateException("down"));
+        when(webPageFetcher.fetch(eq(URL + "/second"), anyBoolean())).thenReturn(page());
         when(documentMapper.selectOne(any())).thenReturn(null);
         when(documentService.upload(any(), any(), any())).thenReturn(outcome("doc_2"));
 
@@ -246,6 +247,21 @@ class WebSourceServiceTest {
                 URI.create("https://example.com/" + "a/".repeat(300)), urlHash, "html");
         assertEquals(200, longName.length());
         assertTrue(longName.endsWith("-" + urlHash.substring(0, 8) + ".html"));
+    }
+
+    @Test
+    void shouldPassTheRenderFlagOfTheSourceToTheFetcher() {
+        // The per-source render_js switch, the M17 contract: a source registered to render must reach
+        // the fetcher with true, and the dispatcher decides from there whether a browser runs.
+        WebSource source = boundSource();
+        source.setRenderJs(1);
+        source.setLastContentHash(HashUtil.sha256Hex(BODY));
+        when(webPageFetcher.fetch(eq(URL), eq(true))).thenReturn(page());
+
+        service.sync(source);
+
+        assertEquals(WebSourceFetchStatus.UNCHANGED, source.getLastFetchStatus());
+        verify(webPageFetcher).fetch(URL, true);
     }
 
     private WebSource boundSource() {

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
@@ -169,6 +169,43 @@ public class KbProperties {
 
         /** Sources one scheduled pass re-fetches; fetching is slow outbound I/O, hence a count bound. */
         private int syncBatchSize = 50;
+
+        /**
+         * {@code true} lets the SSRF guard admit loopback and private-network addresses.
+         *
+         * <p>Off by default and meant to stay off in production: the guard is what keeps "index this
+         * page" from becoming "read the cloud metadata endpoint". The switch exists for development
+         * and intranet deployments whose sources legitimately live on private addresses.
+         */
+        private boolean allowInternalAddress = false;
+
+        /** Headless-browser rendering policy, the M17 contract section 3.5. */
+        private Render render = new Render();
+
+        /**
+         * JS rendering policy of URL import, the M17 contract section 3.5.
+         *
+         * <p>{@link #enabled} is the master switch: with it off every {@code render_js} source falls
+         * back to the static fetch, so a deployment without Chromium can hold the flag off and never
+         * risk a browser launch. The browser is launched lazily on the first render regardless.
+         */
+        @Getter
+        @Setter
+        @ToString
+        public static class Render {
+
+            /** {@code false} ignores every per-source {@code render_js} and fetches statically instead. */
+            private boolean enabled = true;
+
+            /** Navigation plus wait-until budget of one rendered page; higher than the static timeout as rendering is slower. */
+            private int timeoutMs = 20000;
+
+            /** Pages rendered at once; a browser context is heavy, so the default is deliberately small. */
+            private int maxConcurrency = 2;
+
+            /** Playwright waitUntil strategy: load, domcontentloaded or networkidle. */
+            private String waitUntil = "networkidle";
+        }
     }
 
     /**

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/WebSource.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/WebSource.java
@@ -55,6 +55,10 @@ public class WebSource extends BaseEntity {
     @TableField("sync_enabled")
     private Integer syncEnabled;
 
+    /** {@code 1} fetches this source through the headless browser and stores the rendered DOM, the M17 contract section 1. */
+    @TableField("render_js")
+    private Integer renderJs;
+
     /** SHA-256 of the last fetched body, the unchanged check of an incremental sync. */
     @TableField("last_content_hash")
     private String lastContentHash;

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/WebPageFetcher.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/port/WebPageFetcher.java
@@ -14,10 +14,12 @@ public interface WebPageFetcher {
     /**
      * Fetches one page, following a bounded number of redirects with SSRF re-validation per hop.
      *
-     * @param url address to fetch, already validated once by the caller
+     * @param url      address to fetch, already validated once by the caller
+     * @param renderJs {@code true} renders the page in a headless browser and returns the rendered
+     *                 DOM; {@code false} fetches the server HTML as is (the M12 behaviour)
      * @return page body and the file extension its content type maps to
      */
-    FetchedPage fetch(String url);
+    FetchedPage fetch(String url, boolean renderJs);
 
     /**
      * One fetched page.

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/UrlGuard.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/service/UrlGuard.java
@@ -1,6 +1,7 @@
 package io.kbrag.domain.service;
 
 import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,9 @@ import java.util.Set;
  * days old and DNS may have moved), which is why validation lives in a stateless domain service
  * both kb-app and the kb-infrastructure fetcher can share.
  *
+ * <p>{@code kb.web-import.allow-internal-address} disarms only the internal-address rejection, for
+ * development and intranet deployments; the scheme, credential and host checks always stand.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
@@ -29,6 +33,12 @@ import java.util.Set;
 public class UrlGuard {
 
     private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+    private final KbProperties properties;
+
+    public UrlGuard(KbProperties properties) {
+        this.properties = properties;
+    }
 
     /**
      * Validates one outbound URL, rejecting anything that could reach an internal address.
@@ -56,6 +66,13 @@ public class UrlGuard {
         }
         for (InetAddress address : resolve(host)) {
             if (isInternal(address)) {
+                if (properties.getWebImport().isAllowInternalAddress()) {
+                    // Explicitly disarmed by configuration; log every admission so an audit can see
+                    // exactly which internal addresses were fetched under the relaxed policy.
+                    log.info("internal address admitted by allow-internal-address switch, host={}, address={}",
+                            host, address.getHostAddress());
+                    continue;
+                }
                 log.info("url rejected by ssrf guard, host={}, address={}", host, address.getHostAddress());
                 throw BizException.invalidParam("该地址指向内网或本机，禁止抓取");
             }

--- a/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/service/UrlGuardTest.java
+++ b/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/service/UrlGuardTest.java
@@ -1,6 +1,7 @@
 package io.kbrag.domain.service;
 
 import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -21,7 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class UrlGuardTest {
 
-    private final UrlGuard guard = new UrlGuard();
+    private final KbProperties properties = new KbProperties();
+    private final UrlGuard guard = new UrlGuard(properties);
 
     @Test
     void shouldAcceptAPublicHttpUrl() {
@@ -71,5 +73,15 @@ class UrlGuardTest {
             "http://0.0.0.0/"})
     void shouldRejectEveryInternalAddress(String url) {
         assertThrows(BizException.class, () -> guard.validate(url));
+    }
+
+    @Test
+    void shouldAdmitAnInternalAddressWhenTheSwitchDisarmsTheGuard() {
+        // The development escape hatch: with the switch on, loopback is admitted - while a smuggled
+        // credential is still refused, because the switch disarms only the address rejection.
+        properties.getWebImport().setAllowInternalAddress(true);
+
+        assertEquals("127.0.0.1", guard.validate("http://127.0.0.1/page").getHost());
+        assertThrows(BizException.class, () -> guard.validate("http://admin:secret@127.0.0.1/"));
     }
 }

--- a/kb-rag-server/kb-infrastructure/pom.xml
+++ b/kb-rag-server/kb-infrastructure/pom.xml
@@ -51,5 +51,12 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
+        <!-- Headless Chromium fetcher of M17 JS rendering. Version pinned in the parent; the Chromium
+             binary is not bundled in the jar and is installed into the image at build time (see the
+             Dockerfile), so a deployment without it simply fails a render_js source rather than the app. -->
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/HttpWebPageFetcher.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/HttpWebPageFetcher.java
@@ -31,6 +31,10 @@ import java.util.Optional;
  * <p>The body is read in bounded chunks against the size cap rather than trusting Content-Length:
  * a chunked response carries no length at all, and a hostile one may understate it.
  *
+ * <p>This is the static half of the M17 fetcher pair: it ignores {@code renderJs} and always fetches
+ * the server HTML. {@link WebPageFetcherDispatcher} routes render_js sources to the browser instead,
+ * so this class is never asked to render.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
@@ -68,7 +72,9 @@ public class HttpWebPageFetcher implements WebPageFetcher {
     }
 
     @Override
-    public FetchedPage fetch(String url) {
+    public FetchedPage fetch(String url, boolean renderJs) {
+        // renderJs is handled by the dispatcher, which never routes a render_js source here; the
+        // static path fetches the server HTML as is regardless of the flag.
         String current = url;
         int maxRedirects = Math.max(0, properties.getWebImport().getMaxRedirects());
         for (int hop = 0; hop <= maxRedirects; hop++) {

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/PlaywrightWebPageFetcher.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/PlaywrightWebPageFetcher.java
@@ -1,0 +1,185 @@
+package io.kbrag.infrastructure.web;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.WaitUntilState;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.port.WebPageFetcher;
+import io.kbrag.domain.service.UrlGuard;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Fetches a page through a headless Chromium and returns its rendered DOM, the M17 contract section
+ * 2.3. This is the render half of the fetcher pair; {@link WebPageFetcherDispatcher} routes only the
+ * {@code render_js} sources here, static ones stay on {@link HttpWebPageFetcher}.
+ *
+ * <p><b>The browser is launched lazily.</b> A deployment that never renders - or one whose image has
+ * no Chromium - never pays for a browser: the first render triggers the launch under a double-checked
+ * lock, and a launch failure surfaces as a per-source FAILED rather than a startup crash.
+ *
+ * <p><b>Every sub-request the page issues is re-validated against {@link UrlGuard}.</b> A headless
+ * browser fetches images, XHRs, iframes and stylesheets on its own, none of which passed through the
+ * URL the operator typed; without this route interception "render this page" would become "let the
+ * page read {@code 169.254.169.254}". A blocked sub-resource is aborted, not thrown, so one hostile
+ * asset cannot abort an otherwise legitimate render.
+ *
+ * <p>Concurrency is bounded by a {@link Semaphore}: a browser context holds hundreds of MB, so an
+ * unbounded render fan-out is an out-of-memory waiting to happen.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+public class PlaywrightWebPageFetcher implements WebPageFetcher {
+
+    private static final int BYTES_PER_MB = 1024 * 1024;
+    private static final String RENDERED_EXTENSION = "html";
+    private static final String USER_AGENT = "kb-rag/1.0 (+url-import; render)";
+
+    private final UrlGuard urlGuard;
+    private final KbProperties properties;
+    private final Semaphore renderPermits;
+
+    /** Launched on the first render under {@link #browserLock}, closed by {@link #shutdown()}. */
+    private volatile Playwright playwright;
+    private volatile Browser browser;
+    private final Object browserLock = new Object();
+
+    public PlaywrightWebPageFetcher(UrlGuard urlGuard, KbProperties properties) {
+        this.urlGuard = urlGuard;
+        this.properties = properties;
+        int permits = Math.max(1, properties.getWebImport().getRender().getMaxConcurrency());
+        this.renderPermits = new Semaphore(permits);
+    }
+
+    @Override
+    public FetchedPage fetch(String url, boolean renderJs) {
+        int timeoutMs = properties.getWebImport().getRender().getTimeoutMs();
+        boolean acquired = acquirePermit(timeoutMs);
+        if (!acquired) {
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "渲染并发已满，等待超时，本次抓取中止");
+        }
+        try {
+            return render(url, timeoutMs);
+        } finally {
+            renderPermits.release();
+        }
+    }
+
+    private FetchedPage render(String url, int timeoutMs) {
+        Browser current = browser();
+        BrowserContext context = current.newContext(new Browser.NewContextOptions()
+                .setUserAgent(USER_AGENT)
+                .setAcceptDownloads(false));
+        try {
+            context.setDefaultNavigationTimeout(timeoutMs);
+            context.setDefaultTimeout(timeoutMs);
+            // Every request the page makes - the navigation itself included - is re-validated, so a
+            // redirect or a sub-resource pointing at an internal address is aborted before it opens.
+            context.route("**/*", route -> {
+                String requestUrl = route.request().url();
+                try {
+                    urlGuard.validate(requestUrl);
+                    route.resume();
+                } catch (BizException e) {
+                    log.info("render sub-request blocked by ssrf guard, errorCode={}, url={}, reason={}",
+                            ErrorCode.INVALID_PARAM, requestUrl, e.getMessage());
+                    route.abort();
+                }
+            });
+            Page page = context.newPage();
+            page.navigate(url, new Page.NavigateOptions().setWaitUntil(waitUntil()).setTimeout(timeoutMs));
+            String dom = page.content();
+            return new FetchedPage(bounded(dom), RENDERED_EXTENSION);
+        } catch (BizException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            log.info("render fetch failed, url={}, error={}", url, e.getMessage());
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "页面渲染抓取失败：" + e.getMessage(), e);
+        } finally {
+            context.close();
+        }
+    }
+
+    private boolean acquirePermit(int timeoutMs) {
+        try {
+            return renderPermits.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BizException(ErrorCode.INTERNAL_ERROR, "等待渲染并发许可被中断", e);
+        }
+    }
+
+    private byte[] bounded(String dom) {
+        byte[] bytes = dom.getBytes(StandardCharsets.UTF_8);
+        long maxBytes = (long) properties.getWebImport().getMaxPageSizeMb() * BYTES_PER_MB;
+        if (bytes.length > maxBytes) {
+            throw BizException.invalidParam("渲染后页面超过 "
+                    + properties.getWebImport().getMaxPageSizeMb() + " MB 上限，抓取中止");
+        }
+        return bytes;
+    }
+
+    private WaitUntilState waitUntil() {
+        String configured = properties.getWebImport().getRender().getWaitUntil();
+        String value = configured == null ? "" : configured.trim().toLowerCase(Locale.ROOT);
+        return switch (value) {
+            case "load" -> WaitUntilState.LOAD;
+            case "domcontentloaded" -> WaitUntilState.DOMCONTENTLOADED;
+            default -> WaitUntilState.NETWORKIDLE;
+        };
+    }
+
+    /**
+     * Returns the shared browser, launching it on first use. The double-checked lock keeps the launch
+     * to exactly one, and a launch failure - most often a missing Chromium binary - is turned into a
+     * BizException so the calling sync records the source FAILED instead of taking down the app.
+     */
+    private Browser browser() {
+        Browser existing = browser;
+        if (existing != null) {
+            return existing;
+        }
+        synchronized (browserLock) {
+            if (browser == null) {
+                try {
+                    playwright = Playwright.create();
+                    browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+                    log.info("headless browser launched for js rendering");
+                } catch (RuntimeException e) {
+                    log.error("headless browser launch failed, errorCode={}, error={}",
+                            ErrorCode.INTERNAL_ERROR, e.getMessage());
+                    throw new BizException(ErrorCode.INTERNAL_ERROR,
+                            "无头浏览器启动失败，请确认镜像已内置 Chromium：" + e.getMessage(), e);
+                }
+            }
+            return browser;
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        synchronized (browserLock) {
+            if (browser != null) {
+                browser.close();
+                browser = null;
+            }
+            if (playwright != null) {
+                playwright.close();
+                playwright = null;
+            }
+        }
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/WebPageFetcherDispatcher.java
+++ b/kb-rag-server/kb-infrastructure/src/main/java/io/kbrag/infrastructure/web/WebPageFetcherDispatcher.java
@@ -1,0 +1,49 @@
+package io.kbrag.infrastructure.web;
+
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.port.WebPageFetcher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * Routes a fetch to the static or the rendering implementation, the M17 contract section 2.4.
+ *
+ * <p>This is the {@link Primary} {@link WebPageFetcher} the sync service injects, so the choice
+ * between fetching server HTML and rendering in a browser stays out of the service and in one place.
+ * A source renders only when it asked to ({@code renderJs}) <b>and</b> the deployment allows it (the
+ * master switch): with the switch off - the safe default for an image without Chromium - every
+ * source falls back to the static fetch and records SUCCESS/UNCHANGED exactly as in M12.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Primary
+@Component
+public class WebPageFetcherDispatcher implements WebPageFetcher {
+
+    private final HttpWebPageFetcher staticFetcher;
+    private final PlaywrightWebPageFetcher renderFetcher;
+    private final KbProperties properties;
+
+    public WebPageFetcherDispatcher(HttpWebPageFetcher staticFetcher,
+                                    PlaywrightWebPageFetcher renderFetcher,
+                                    KbProperties properties) {
+        this.staticFetcher = staticFetcher;
+        this.renderFetcher = renderFetcher;
+        this.properties = properties;
+    }
+
+    @Override
+    public FetchedPage fetch(String url, boolean renderJs) {
+        if (renderJs && properties.getWebImport().getRender().isEnabled()) {
+            return renderFetcher.fetch(url, true);
+        }
+        if (renderJs) {
+            // Asked to render but the master switch is off: fall back rather than fail, so a source
+            // stays syncable on an image that cannot render.
+            log.info("render requested but disabled by master switch, falling back to static fetch, url={}", url);
+        }
+        return staticFetcher.fetch(url, false);
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/HttpWebPageFetcherTest.java
+++ b/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/HttpWebPageFetcherTest.java
@@ -45,7 +45,7 @@ class HttpWebPageFetcherTest {
         server.start();
         properties = new KbProperties();
         properties.getWebImport().setMaxPageSizeMb(1);
-        UrlGuard recordingGuard = new UrlGuard() {
+        UrlGuard recordingGuard = new UrlGuard(properties) {
             @Override
             public URI validate(String url) {
                 validatedUrls.add(url);
@@ -64,7 +64,7 @@ class HttpWebPageFetcherTest {
     void shouldMapTheContentTypeOntoTheUploadExtension() {
         respond("/plain", 200, "text/plain; charset=utf-8", "hello".getBytes(StandardCharsets.UTF_8));
 
-        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/plain"));
+        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/plain"), false);
 
         assertThat(page.extension()).isEqualTo("txt");
         assertThat(page.body()).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
@@ -74,7 +74,7 @@ class HttpWebPageFetcherTest {
     void shouldDefaultToHtmlWhenTheResponseCarriesNoContentType() {
         respond("/bare", 200, null, "<html></html>".getBytes(StandardCharsets.UTF_8));
 
-        assertThat(fetcher.fetch(url("/bare")).extension()).isEqualTo("html");
+        assertThat(fetcher.fetch(url("/bare"), false).extension()).isEqualTo("html");
     }
 
     @Test
@@ -82,7 +82,7 @@ class HttpWebPageFetcherTest {
         // A PDF behind a URL belongs to the file upload path, where the magic number checks live.
         respond("/pdf", 200, "application/pdf", new byte[]{0x25, 0x50});
 
-        assertThatThrownBy(() -> fetcher.fetch(url("/pdf")))
+        assertThatThrownBy(() -> fetcher.fetch(url("/pdf"), false))
                 .isInstanceOf(BizException.class)
                 .hasMessageContaining("application/pdf");
     }
@@ -92,7 +92,7 @@ class HttpWebPageFetcherTest {
         redirect("/a", "/b");
         respond("/b", 200, "text/html", "final".getBytes(StandardCharsets.UTF_8));
 
-        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/a"));
+        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/a"), false);
 
         assertThat(page.body()).isEqualTo("final".getBytes(StandardCharsets.UTF_8));
         // Both the original URL and the redirect target went through the guard: this is the whole
@@ -104,7 +104,7 @@ class HttpWebPageFetcherTest {
     void shouldStopAfterTooManyRedirects() {
         redirect("/loop", "/loop");
 
-        assertThatThrownBy(() -> fetcher.fetch(url("/loop")))
+        assertThatThrownBy(() -> fetcher.fetch(url("/loop"), false))
                 .isInstanceOf(BizException.class)
                 .hasMessageContaining("重定向");
     }
@@ -115,7 +115,7 @@ class HttpWebPageFetcherTest {
         Arrays.fill(oversized, (byte) 'x');
         respond("/big", 200, "text/html", oversized);
 
-        assertThatThrownBy(() -> fetcher.fetch(url("/big")))
+        assertThatThrownBy(() -> fetcher.fetch(url("/big"), false))
                 .isInstanceOf(BizException.class)
                 .hasMessageContaining("MB");
     }
@@ -124,7 +124,7 @@ class HttpWebPageFetcherTest {
     void shouldFailOnANonSuccessStatus() {
         respond("/gone", 404, "text/html", "not here".getBytes(StandardCharsets.UTF_8));
 
-        assertThatThrownBy(() -> fetcher.fetch(url("/gone")))
+        assertThatThrownBy(() -> fetcher.fetch(url("/gone"), false))
                 .isInstanceOf(BizException.class)
                 .hasMessageContaining("404");
     }

--- a/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/PlaywrightWebPageFetcherIntegrationTest.java
+++ b/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/PlaywrightWebPageFetcherIntegrationTest.java
@@ -1,0 +1,158 @@
+package io.kbrag.infrastructure.web;
+
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Playwright;
+import com.sun.net.httpserver.HttpServer;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.port.WebPageFetcher;
+import io.kbrag.domain.service.UrlGuard;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Renders real pages through a real Chromium against a local HTTP server, the M17 contract section
+ * 7: the JS-injected body a static fetch cannot see, the SSRF interception of a private-network
+ * sub-resource, and the navigation timeout. Tagged and assumption-guarded because it needs a
+ * browser: on a machine without one every test is skipped, never failed - the same posture the
+ * production code takes towards an image without Chromium.
+ *
+ * <p>The guard is replaced by a recording one that admits only the loopback host this test server
+ * lives on, because the production guard would rightly refuse loopback altogether - and refusing
+ * everything else is exactly how the sub-request interception is proven.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Tag("browser")
+class PlaywrightWebPageFetcherIntegrationTest {
+
+    /** Built by string concatenation in the page script so the raw HTML never contains it. */
+    private static final String RENDER_MARKER = "RENDERED-BY-JS";
+
+    private final List<String> validatedUrls = new ArrayList<>();
+    private final List<String> blockedUrls = new ArrayList<>();
+
+    private HttpServer server;
+    private KbProperties properties;
+    private PlaywrightWebPageFetcher fetcher;
+
+    @BeforeAll
+    static void requireBrowser() {
+        // Probe the browser once up front; without it (offline CI, no cached binary) every test in
+        // the class is reported skipped instead of failed.
+        try (Playwright playwright = Playwright.create()) {
+            playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true)).close();
+        } catch (RuntimeException e) {
+            Assumptions.assumeTrue(false, "chromium unavailable, skipping render integration tests: " + e.getMessage());
+        }
+    }
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        properties = new KbProperties();
+        properties.getWebImport().getRender().setTimeoutMs(15000);
+        UrlGuard loopbackOnlyGuard = new UrlGuard(properties) {
+            @Override
+            public URI validate(String url) {
+                validatedUrls.add(url);
+                if (!url.contains("127.0.0.1")) {
+                    blockedUrls.add(url);
+                    throw BizException.invalidParam("blocked by test guard: " + url);
+                }
+                return URI.create(url);
+            }
+        };
+        fetcher = new PlaywrightWebPageFetcher(loopbackOnlyGuard, properties);
+    }
+
+    @AfterEach
+    void stopServer() {
+        fetcher.shutdown();
+        server.stop(0);
+    }
+
+    @Test
+    void shouldReturnTheScriptInjectedBodyAStaticFetchCannotSee() {
+        String raw = "<html><body><div id=\"root\"></div>"
+                + "<script>document.getElementById('root').textContent='RENDERED-'+'BY-JS';</script>"
+                + "</body></html>";
+        respondHtml("/js", raw);
+
+        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/js"), true);
+
+        String rendered = new String(page.body(), StandardCharsets.UTF_8);
+        // The contrast of the M17 acceptance case 1: the marker exists only in the rendered DOM,
+        // never in the server HTML - which is precisely why the static fetch stores an empty shell.
+        assertThat(rendered).contains(RENDER_MARKER);
+        assertThat(raw).doesNotContain(RENDER_MARKER);
+        assertThat(page.extension()).isEqualTo("html");
+    }
+
+    @Test
+    void shouldAbortThePrivateNetworkSubRequestAndStillRenderThePage() {
+        respondHtml("/ssrf", "<html><body><h1>public body</h1>"
+                + "<img src=\"http://192.168.255.250/pixel.png\">"
+                + "</body></html>");
+
+        WebPageFetcher.FetchedPage page = fetcher.fetch(url("/ssrf"), true);
+
+        // The page renders and its own body survives; the hostile asset was validated and aborted.
+        assertThat(new String(page.body(), StandardCharsets.UTF_8)).contains("public body");
+        assertThat(blockedUrls).anyMatch(u -> u.contains("192.168.255.250"));
+        // Every request the browser issued went through the guard, the navigation itself included.
+        assertThat(validatedUrls).anyMatch(u -> u.equals(url("/ssrf")));
+    }
+
+    @Test
+    void shouldFailWithinTheRenderTimeoutOnAPageThatNeverSettles() {
+        properties.getWebImport().getRender().setTimeoutMs(2000);
+        server.createContext("/slow", exchange -> {
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+
+        long start = System.currentTimeMillis();
+        assertThatThrownBy(() -> fetcher.fetch(url("/slow"), true))
+                .isInstanceOf(BizException.class)
+                .hasMessageContaining("渲染");
+        // Generous ceiling: the point is that the budget cuts the hang, not that it is exact.
+        assertThat(System.currentTimeMillis() - start).isLessThan(8000);
+    }
+
+    private String url(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    private void respondHtml(String path, String html) {
+        byte[] body = html.getBytes(StandardCharsets.UTF_8);
+        server.createContext(path, exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+    }
+}

--- a/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/WebPageFetcherDispatcherTest.java
+++ b/kb-rag-server/kb-infrastructure/src/test/java/io/kbrag/infrastructure/web/WebPageFetcherDispatcherTest.java
@@ -1,0 +1,81 @@
+package io.kbrag.infrastructure.web;
+
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.port.WebPageFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the routing rule of the M17 contract section 2.4: a source renders only when it asked to
+ * <b>and</b> the master switch is on; every other combination stays on the static fetch. The point
+ * of the test is that the browser is never even reached when it should not be - an image without
+ * Chromium must keep syncing.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class WebPageFetcherDispatcherTest {
+
+    private static final String URL = "https://example.com/docs/guide";
+
+    private HttpWebPageFetcher staticFetcher;
+    private PlaywrightWebPageFetcher renderFetcher;
+    private KbProperties properties;
+    private WebPageFetcherDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() {
+        staticFetcher = mock(HttpWebPageFetcher.class);
+        renderFetcher = mock(PlaywrightWebPageFetcher.class);
+        properties = new KbProperties();
+        dispatcher = new WebPageFetcherDispatcher(staticFetcher, renderFetcher, properties);
+        when(staticFetcher.fetch(anyString(), eq(false))).thenReturn(page("static"));
+        when(renderFetcher.fetch(anyString(), eq(true))).thenReturn(page("rendered"));
+    }
+
+    @Test
+    void shouldStayOnStaticFetchWhenTheSourceDidNotAskToRender() {
+        WebPageFetcher.FetchedPage page = dispatcher.fetch(URL, false);
+
+        assertThat(page.body()).isEqualTo("static".getBytes(StandardCharsets.UTF_8));
+        verify(staticFetcher).fetch(URL, false);
+        verify(renderFetcher, never()).fetch(anyString(), eq(true));
+    }
+
+    @Test
+    void shouldRenderWhenTheSourceAskedAndTheMasterSwitchIsOn() {
+        properties.getWebImport().getRender().setEnabled(true);
+
+        WebPageFetcher.FetchedPage page = dispatcher.fetch(URL, true);
+
+        assertThat(page.body()).isEqualTo("rendered".getBytes(StandardCharsets.UTF_8));
+        verify(renderFetcher).fetch(URL, true);
+        verify(staticFetcher, never()).fetch(anyString(), eq(false));
+    }
+
+    @Test
+    void shouldFallBackToStaticWhenTheMasterSwitchIsOff() {
+        // The safe default for an image without Chromium: a render_js source keeps syncing statically
+        // rather than failing every pass.
+        properties.getWebImport().getRender().setEnabled(false);
+
+        WebPageFetcher.FetchedPage page = dispatcher.fetch(URL, true);
+
+        assertThat(page.body()).isEqualTo("static".getBytes(StandardCharsets.UTF_8));
+        verify(staticFetcher).fetch(URL, false);
+        verify(renderFetcher, never()).fetch(anyString(), eq(true));
+    }
+
+    private WebPageFetcher.FetchedPage page(String body) {
+        return new WebPageFetcher.FetchedPage(body.getBytes(StandardCharsets.UTF_8), "html");
+    }
+}

--- a/kb-rag-server/pom.xml
+++ b/kb-rag-server/pom.xml
@@ -43,6 +43,9 @@
         <minio.version>8.5.17</minio.version>
         <neo4j-java-driver.version>5.28.9</neo4j-java-driver.version>
         <commons-collections4.version>4.4</commons-collections4.version>
+        <!-- Headless Chromium fetcher for M17 JS rendering. Not managed by the Boot BOM, so the
+             coordinate is pinned here to keep the browser protocol and the driver jar in step. -->
+        <playwright.version>1.47.0</playwright.version>
         <!-- The exact release Spring Security 6.3 (the Boot 3.3 line) builds against, so the jar
              stays in step with the rest of the ecosystem even though the Boot BOM itself does not
              manage this coordinate. -->
@@ -100,6 +103,11 @@
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>${nimbus-jose-jwt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.playwright</groupId>
+                <artifactId>playwright</artifactId>
+                <version>${playwright.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kb-rag-web/CHANGELOG.md
+++ b/kb-rag-web/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Added
 
+**M17 · 网页导入 JS 渲染抓取**（`docs/M17-CONTRACTS.md`）
+- 网页导入 Tab 登记表单新增「JS 渲染」 Switch（默认关，`render_js` 随 register 传入），带说明——开启后用无头浏览器渲染再抓取，适用于内容靠脚本加载的页面（如 Javadoc 框架页），更慢更耗资源。
+- 来源列表新增「JS 渲染」列：行内 Switch 直接走 `PUT /web-sources/{id}`（传 `render_js`），与「定时同步」Switch 同交互模式；`updateWebSource` 由单传 `sync_enabled` 扩展为传 `UpdateWebSourceRequest`（`sync_enabled` / `render_js` 两可选字段，只改传入的那个）。
+- `types.ts`：`WebSourceEntry` 增 `render_js: boolean`，`RegisterWebSourceRequest` 增可选 `render_js`，新增 `UpdateWebSourceRequest` 接口。
+
 **M16 · 企业化：多租户 / 文档级权限 / SSO 三协议 / 操作审计**（`docs/M16-CONTRACTS.md`）
 - 登录页单点登录扩展：按 `GET /auth/sso/providers` 渲染 OIDC / SAML / CAS 三个跳转按钮（整页重定向到后端免认证入口）；回调落地页解析 URL fragment（`#sso_token` 入会话、`#sso_error` 展示中文失败原因），解析后立即清理 fragment 避免令牌留在地址栏历史。
 - 新增「租户管理」页（`pages/settings/TenantManagePage.tsx`，仅 `tenant:manage` 可见）：租户列表（内置标签 / 状态）、新建（code + 名称，code 建后不可改）、改名、启用停用（停用二次确认，提示该租户全部账号将无法登录）；无删除入口（后端就没有该端点）。

--- a/kb-rag-web/src/api/types.ts
+++ b/kb-rag-web/src/api/types.ts
@@ -2128,6 +2128,8 @@ export interface WebSourceEntry {
   doc_id: string | null;
   file_name: string | null;
   sync_enabled: boolean;
+  /** M17-CONTRACTS.md section 1: fetch this source through a headless browser and store the rendered DOM. */
+  render_js: boolean;
   last_fetch_status: WebSourceFetchStatus | null;
   last_fetch_at: string | null;
   last_error: string | null;
@@ -2139,6 +2141,17 @@ export interface RegisterWebSourceRequest {
   url: string;
   /** Defaults to true server-side when omitted. */
   sync_enabled?: boolean;
+  /** M17: JS rendering, defaults to false server-side when omitted. */
+  render_js?: boolean;
+}
+
+/**
+ * PUT /api/v1/web-sources/{sourceId} request body (M17-CONTRACTS.md section 3.3): the mutable
+ * switches of a registration. Both are optional; only the present ones are applied.
+ */
+export interface UpdateWebSourceRequest {
+  sync_enabled?: boolean;
+  render_js?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/kb-rag-web/src/api/webSource.ts
+++ b/kb-rag-web/src/api/webSource.ts
@@ -1,6 +1,11 @@
 // Author: owlzhangfq@gmail.com
 import { apiDelete, apiGet, apiPost, apiPut } from './request';
-import type { PageResult, RegisterWebSourceRequest, WebSourceEntry } from './types';
+import type {
+  PageResult,
+  RegisterWebSourceRequest,
+  UpdateWebSourceRequest,
+  WebSourceEntry,
+} from './types';
 
 /**
  * POST /api/v1/kb/{kbId}/web-sources (M12-CONTRACTS.md section 3.4): registers a page URL and
@@ -25,9 +30,12 @@ export function syncWebSource(sourceId: string): Promise<WebSourceEntry> {
   return apiPost<WebSourceEntry>(`/web-sources/${sourceId}/sync`);
 }
 
-/** PUT /api/v1/web-sources/{sourceId} (M12-CONTRACTS.md section 3.4): flips the scheduled-sync switch. */
-export function updateWebSource(sourceId: string, syncEnabled: boolean): Promise<WebSourceEntry> {
-  return apiPut<WebSourceEntry>(`/web-sources/${sourceId}`, { sync_enabled: syncEnabled });
+/**
+ * PUT /api/v1/web-sources/{sourceId} (M17-CONTRACTS.md section 3.3): applies the mutable switches
+ * -- scheduled sync and JS rendering. Only the present fields change; an absent one is left as is.
+ */
+export function updateWebSource(sourceId: string, payload: UpdateWebSourceRequest): Promise<WebSourceEntry> {
+  return apiPut<WebSourceEntry>(`/web-sources/${sourceId}`, payload);
 }
 
 /**

--- a/kb-rag-web/src/pages/kb/components/WebSourcesTab.tsx
+++ b/kb-rag-web/src/pages/kb/components/WebSourcesTab.tsx
@@ -53,7 +53,7 @@ export default function WebSourcesTab({ kbId, onSynced }: WebSourcesTabProps) {
   const [registering, setRegistering] = useState(false);
   // source_id of the row whose sync/toggle/remove request is in flight, to scope the spinners.
   const [actingId, setActingId] = useState<string | null>(null);
-  const [form] = Form.useForm<{ url: string }>();
+  const [form] = Form.useForm<{ url: string; render_js?: boolean }>();
 
   const load = useCallback(async (targetPage: number) => {
     setLoading(true);
@@ -71,10 +71,13 @@ export default function WebSourcesTab({ kbId, onSynced }: WebSourcesTabProps) {
     load(1);
   }, [load]);
 
-  const handleRegister = async (values: { url: string }) => {
+  const handleRegister = async (values: { url: string; render_js?: boolean }) => {
     setRegistering(true);
     try {
-      const entry = await registerWebSource(kbId, { url: values.url.trim() });
+      const entry = await registerWebSource(kbId, {
+        url: values.url.trim(),
+        render_js: values.render_js ?? false,
+      });
       reportOutcome(entry);
       form.resetFields();
       load(1);
@@ -103,8 +106,19 @@ export default function WebSourcesTab({ kbId, onSynced }: WebSourcesTabProps) {
   const handleToggle = async (row: WebSourceEntry, enabled: boolean) => {
     setActingId(row.source_id);
     try {
-      await updateWebSource(row.source_id, enabled);
+      await updateWebSource(row.source_id, { sync_enabled: enabled });
       message.success(enabled ? '已开启定时同步' : '已关闭定时同步');
+      load(page);
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleToggleRender = async (row: WebSourceEntry, enabled: boolean) => {
+    setActingId(row.source_id);
+    try {
+      await updateWebSource(row.source_id, { render_js: enabled });
+      message.success(enabled ? '已开启 JS 渲染抓取' : '已关闭 JS 渲染抓取');
       load(page);
     } finally {
       setActingId(null);
@@ -139,6 +153,16 @@ export default function WebSourcesTab({ kbId, onSynced }: WebSourcesTabProps) {
           ]}
         >
           <Input placeholder="https://example.com/docs/guide" allowClear />
+        </Form.Item>
+        <Form.Item
+          name="render_js"
+          valuePropName="checked"
+          label="JS 渲染"
+          tooltip="开启后走无头浏览器渲染 JS 再入库，适用于正文由脚本生成的页面；抓取更慢"
+        >
+          {/* The Switch must be the direct child: Form.Item injects checked/onChange into it,
+              and wrapping it in a Space would leave the value out of the form. */}
+          <Switch size="small" />
         </Form.Item>
         <Form.Item>
           <Button type="primary" htmlType="submit" loading={registering}>
@@ -196,6 +220,19 @@ export default function WebSourcesTab({ kbId, onSynced }: WebSourcesTabProps) {
                 checked={record.sync_enabled}
                 loading={actingId === record.source_id}
                 onChange={(checked) => handleToggle(record, checked)}
+              />
+            ),
+          },
+          {
+            title: 'JS 渲染',
+            dataIndex: 'render_js',
+            width: 100,
+            render: (_, record) => (
+              <Switch
+                size="small"
+                checked={record.render_js}
+                loading={actingId === record.source_id}
+                onChange={(checked) => handleToggleRender(record, checked)}
               />
             ),
           },


### PR DESCRIPTION
两件互不相关的事，各自一个 commit。

## 1. 网页导入支持按源开关的 JS 渲染抓取（M17）

Oracle Javadoc 一类 frameset/SPA 页静态抓取拿不到正文。server 内嵌 Playwright-Java（Chromium headless），在 `WebPageFetcher` 端口后加渲染实现，按源的 `render_js` 开关路由，取渲染后 DOM 入库。

- `[schema]` `V18__web_source_render_js.sql`：`t_kb_web_source` 增 `render_js TINYINT NOT NULL DEFAULT 0`，不新增索引，存量源升级后行为零变化
- 端口签名扩展 `fetch(url, renderJs)`（唯一调用点是 `WebSourceService`，直接改签名不留重载）；新增 `@Primary` 的 `WebPageFetcherDispatcher` 按 `renderJs && render.enabled` 路由，总闸关闭时降级静态抓取兜底
- `PlaywrightWebPageFetcher`：Chromium 懒启动（首次真正渲染才拉起，`@PreDestroy` 关闭），`Semaphore` 限流，单次渲染新建 context 用完即关；浏览器启动失败收成该源 FAILED，不拖垮应用启动与静态抓取链路
- **渲染路径 SSRF 防线**：`context.route` 拦截浏览器发出的每个子请求（img/xhr/iframe/css 及导航重定向）逐个过 `UrlGuard`，命中内网/回环/链路本地/元数据地址即 abort（不抛，个别子资源被拦不中断整页渲染），与静态抓取的逐跳校验形成闭合防线
- `UrlGuard` 增 `allow-internal-address` 开关支持内网部署，scheme / 凭据 / 主机名检查始终生效，每次放行记日志备审计
- 渲染产物仍是一段 `text/html` 字节，继续收敛到 M12 既有链路（upload → HtmlParser → 版本/治理/索引），不新增入库旁路
- 新增配置 `kb.web-import.render.{enabled,timeout-ms,max-concurrency,wait-until}`；复用既有 `max-page-size-mb`
- 控制台网页导入 Tab 增 JS 渲染开关（登记时可选、列表内可切）

## 2. 启动 banner 换成 KB-RAG

新增 `kb-api/src/main/resources/banner.txt`：

```
 _  __ ____     ____        _       ____
| |/ /| __ )   |  _ \      / \     / ___|
| ' / |  _ \   | |_) |    / _ \   | |  _
| . \ | |_) |  |  _ <    / ___ \  | |_| |
|_|\_\|____/   |_| \_\  /_/   \_\  \____|

:: KB-RAG :: Enterprise RAG knowledge base platform
:: Spring Boot :: 3.3.9   :: build :: 0.1.0-SNAPSHOT
```

`${application.version:dev}` 带默认值：jar 启动读 MANIFEST 显示实际版本，IDE 直跑没有 MANIFEST 时落到 `dev`，不留空洞。纯资源文件，不涉及代码与配置开关（`application.yml` 里的 `banner: false` 是 MyBatis-Plus 的 logo 开关，与此无关）。

## 验证

- 后端全量单测：kb-app 650 个、kb-api 21 个，0 失败（`browser` tag 的 Playwright 集成测试按设计排除）
- banner 真起了一次 jar 确认渲染与占位符解析，抓到输出后即停

## Reviewer 需要知道的两个问题

评审时值得一并考虑，本 PR 未处理：

**1. 抓到登录墙会静默入库。** 用这条链路抓一个需要登录的内网 Confluence，拿到的是登录页 HTML，`content_hash` 有值、`last_fetch_status` 记 SUCCESS、文档正常 INDEXED —— 实测切出 1 个分片，内容是 `# Log In - Confluence` / `Username` / `Password`。垃圾进库且会被检索命中。建议在 dispatcher（唯一出口）加一道健全性检查：最终 URL 命中 `login|signin|sso`、body 含 `<input type="password"`、401/403 → 记 FAILED 不入库。

**2. `allow-internal-address` 是全局开关，粒度过粗。** `UrlGuard#isInternal` 含 `isLinkLocalAddress`，也就是 `169.254.169.254` 云元数据端点。这个开关一开，内网、回环、元数据端点一起放行，本 PR 新加的子请求逐个过 UrlGuard 那道防线等于同时撤掉。建议换成 host/网段白名单，`169.254.0.0/16` 与 `127.0.0.0/8` 永不放行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)