### PR TITLE
fix(docs): 修正自测步骤文档中的配置参数错误

### DIFF
--- a/docs/自测步骤.md
+++ b/docs/自测步骤.md
@@ -24,7 +24,7 @@ $JAVA_HOME/bin/java -jar ../kb-rag-server/kb-api/target/kb-rag-server.jar
 ```text
 # 2.1 idea 
 如果你是jetbrains idea启动的 edit Configuration里面 新建 Program Arguments加上下面这行去读你的环境文件
---spring.config.import=optional:file:/User/AI/kb-rag/kb-rag-deploy/.env[.properties]
+--spring.config.import=optional:file:/UserPath/AI/kb-rag/kb-rag-deploy/.env[.properties]
 
 ```
 


### PR DESCRIPTION
- 将示例配置参数中的路径前缀由'-'改为'--'
- 更新路径中的用户目录名占位符为更通用的'/UserPath/'
- 保证配置行格式符合预期以避免启动错误