### PR TITLE
docs(readme): 补全架构图与核心流程图（记忆库 M19 + MCP 协议层 M20）

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # kb-rag
 
 可自托管、开箱即用的企业知识库 / RAG（检索增强生成）系统：上传文档 → 自动解析切分 →
-双引擎混合检索（向量 + BM25）→ 标注与评测闭环 → 对外开放平台。
+双引擎混合检索（向量 + BM25）→ 标注与评测闭环 → 对外开放平台（REST + MCP），
+并内置面向 Agent 的记忆库（长期记忆抽取 / 画像 / 记忆检索）。
 
 **一句话架构**：Java 主服务（检索/管理编排）+ Python 解析服务（文档转 Markdown）+
 React 管理台，三者围绕 MySQL（事实源）/ Elasticsearch 与 Qdrant（检索引擎）/
@@ -16,11 +17,12 @@ MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过 dock
 flowchart TB
     subgraph clients["接入层"]
         WEB["kb-rag-web<br/>React 18 + AntD 5（dev :20002）"]
-        AGENT["智能体应用<br/>REST + API Key"]
+        AGENT["智能体应用<br/>REST + API Key / Memory Key"]
+        MCPC["MCP 客户端<br/>Claude Desktop / Cursor / 自研 Agent"]
     end
 
     subgraph server["kb-rag-server（Java 17 / Spring Boot 3，:20000）"]
-        API["kb-api<br/>HTTP 边界与装配点"]
+        API["kb-api<br/>HTTP 边界与装配点<br/>REST + MCP JSON-RPC 引擎"]
         APP["kb-app<br/>应用编排（索引管线 / 检索链路 / 评测发布）"]
         DOMAIN["kb-domain<br/>实体 + 出站端口 + 领域算法"]
         INFRA["kb-infrastructure<br/>端口实现（引擎 / 存储 / 模型 Provider）"]
@@ -32,7 +34,7 @@ flowchart TB
 
     subgraph middleware["中间件（docker-compose 一键拉起）"]
         MYSQL[("MySQL :13306<br/>唯一事实源")]
-        ES[("Elasticsearch :9200<br/>BM25（lite 模式兼向量）")]
+        ES[("Elasticsearch :9200<br/>BM25（lite 模式兼向量）<br/>+ 记忆检索副本")]
         QDRANT[("Qdrant :6333<br/>向量检索（full 模式）")]
         MINIO[("MinIO :9000<br/>原件 / 解析产物 / 归档")]
         NEO4J[("Neo4j :7687<br/>图检索（可选）")]
@@ -41,15 +43,18 @@ flowchart TB
     LLM["大模型服务（DashScope）<br/>嵌入 / 重排 / 对话 / 视觉<br/>零 Key 可降级运行"]
 
     WEB -- "/api（Vite 代理 / Nginx 反代）" --> API
-    AGENT -- "/api/v1/knowledge/*" --> API
+    AGENT -- "/api/v1/knowledge/*（kb-sk-*）<br/>/api/v1/memory/*（kb-mk-*）" --> API
+    MCPC -- "JSON-RPC 2.0 over HTTP<br/>/api/v1/knowledge/mcp · /api/v1/memory/mcp" --> API
     INFRA -- "HTTP multipart" --> PARSER
     INFRA --> MYSQL & ES & QDRANT & MINIO & NEO4J
     INFRA --> LLM
 ```
 
-- **kb-rag-server**：唯一业务中枢，负责管理台 API、对外开放 API、索引管线编排、检索链路与全部大模型调用。
+- **kb-rag-server**：唯一业务中枢，负责管理台 API、对外开放 API（REST + MCP）、索引管线编排、检索链路、记忆库与全部大模型调用。
 - **kb-rag-parser**：纯解析微服务，只做文件解析与图片抽取，不调用任何大模型。
 - **MySQL 是唯一事实源**：ES / Qdrant / Neo4j 均为派生索引，可从 MySQL 幂等重建。
+- **三条独立鉴权链**：管理台 Bearer Token、知识库 API Key（`kb-sk-*`）、记忆库 Memory Key（`kb-mk-*`）；
+  MCP 端点刻意落在既有过滤器前缀之下，零改动复用同一条鉴权 / 限流 / 审计管线。
 
 ## 核心流程图
 
@@ -83,7 +88,50 @@ flowchart LR
 ```
 
 每级均可选且带明确降级语义（`degraded` 原因码透出）；各路召回强制过滤版本可见集与 `enabled=1`。
-更完整的架构说明与全量流程图（状态机、双写补偿、应用发布门禁等），见
+
+### 应用发布：门禁双跑 → 快照冻结 → RELEASED
+
+```mermaid
+flowchart LR
+    T["TESTING 版本发起正式发布"] --> G["门禁双跑<br/>（候选配置 vs 当前正式版，<br/>同语料同时刻各跑一份评测）"]
+    G --> J["三态裁决<br/>通过 / 拦截（可 force 放行留痕）/<br/>样本不足仅记录不拦截"]
+    J --> SN["冻结发布快照<br/>（快照索引 + 可见版本集同时固化，<br/>门禁所测索引 = 发布后所用索引）"]
+    SN --> REL["RELEASED（单应用唯一）<br/>原正式版退位 SUPERSEDED，可秒级回滚"]
+```
+
+RELEASED 版本的对外调用永远命中冻结快照，后续文档增删不影响线上应用，直到发布新版本。
+
+### 记忆库：写入抽取与检索（`/api/v1/memory/*`，Memory Key 鉴权）
+
+```mermaid
+flowchart LR
+    subgraph write["写入（memory_add）"]
+        A["messages / custom_content<br/>二选一"] --> X["LLM 片段抽取<br/>（ADD / UPDATE，参考最近 50 条旧记忆；<br/>custom_content 直写不经 LLM）"]
+        X --> W["MySQL 事实源 + ES 检索副本<br/>（嵌入失败该节点降级 BM25）"]
+        X --> PF["画像字段抽取<br/>（规则绑定时幂等 upsert）"]
+    end
+    subgraph search["检索（memory_search）"]
+        Q["user_id + query"] --> I["意图识别可 veto<br/>→ query 改写（失败降级原 query）"]
+        I --> SE["kNN + BM25 并联召回<br/>（零 Key 降级 BM25 单路）"]
+        SE --> R["rerank + 阈值过滤 → 回事实源 hydrate<br/>强制 filter：library_id + user_id + 未过期"]
+    end
+```
+
+一把 Memory Key 绑定一个记忆库，库内按 `user_id` 隔离；隔离是查询谓词，越权一律 404。
+
+### MCP 协议层：一个 URL + 一把既有 Key 直接接入
+
+```mermaid
+flowchart LR
+    C["MCP 客户端<br/>（Claude Desktop / Cursor /<br/>Cline / 自研 Agent）"] -- "POST JSON-RPC 2.0<br/>Bearer kb-sk-* / kb-mk-*" --> FL["既有过滤器链<br/>（鉴权 / 限流 / 审计零改动复用）"]
+    FL --> EN["McpServerEngine（无状态，零依赖手写）<br/>initialize / ping / tools/list / tools/call"]
+    EN --> TK["知识库：knowledge_search · knowledge_chat<br/>记忆库：memory_add · search · list ·<br/>update · delete · get_profile"]
+    TK --> RS["复用 REST 孪生服务，返回结构同源<br/>业务失败 → isError:true 工具结果<br/>协议违规 → JSON-RPC error"]
+```
+
+接入配置与工具目录见 [`MCP接入指南.md`](MCP接入指南.md)、[`记忆库接入指南.md`](记忆库接入指南.md)。
+
+更完整的架构说明与全量流程图（文档/版本状态机、双写补偿、索引重建、评测运行、图路、备份恢复等），见
 [`../kb-rag-deploy/docs/ARCHITECTURE.md`](../kb-rag-deploy/docs/ARCHITECTURE.md) 与
 [`../kb-rag-deploy/docs/FLOWS.md`](../kb-rag-deploy/docs/FLOWS.md)。
 
@@ -91,7 +139,7 @@ flowchart LR
 
 | 子目录 | 职责 | 技术栈 |
 | --- | --- | --- |
-| [`kb-rag-server`](kb-rag-server/) | Java 主服务：知识库与文档生命周期、索引管线编排、检索融合、标注评测、应用发布、对外 API，以及全部大模型调用 | Java + Spring Boot + MyBatis |
+| [`kb-rag-server`](kb-rag-server/) | Java 主服务：知识库与文档生命周期、索引管线编排、检索融合、标注评测、应用发布、记忆库、对外 API（REST + MCP），以及全部大模型调用 | Java + Spring Boot + MyBatis |
 | [`kb-rag-parser`](kb-rag-parser/) | Python 解析微服务：文档转结构化 Markdown + 按页文本 + 图片，聊天记录导出转结构化会话 | Python 3.11 + FastAPI |
 | [`kb-rag-web`](kb-rag-web/) | React 管理台 | Vite + React 18 + TypeScript + Ant Design 5 |
 | [`kb-rag-deploy`](kb-rag-deploy/) | 部署与契约：docker-compose 编排、环境变量模板、跨服务 OpenAPI 契约、备份与预检脚本、总体文档 | Docker Compose + Shell |


### PR DESCRIPTION
## 背景

docs/README.md 的架构图与核心流程图基线停在 PR #28（M18 时期），之后合并的记忆库（M19）与 MCP 协议层（M20，PR #29）在图中完全没有体现。

## 变更内容

**架构图**
- 接入层新增 MCP 客户端（Claude Desktop / Cursor / 自研 Agent），JSON-RPC 2.0 over HTTP 直连两个 MCP 端点
- 智能体应用通道补充 `/api/v1/memory/*`（Memory Key `kb-mk-*`）
- kb-api 标注 "REST + MCP JSON-RPC 引擎"，ES 标注记忆检索副本
- 新增要点：三条独立鉴权链，MCP 端点零改动复用既有过滤器管线

**核心流程图（新增三张）**
- 应用发布：门禁双跑 → 三态裁决 → 快照冻结 → RELEASED
- 记忆库：写入抽取（LLM 片段 / 画像）与检索（意图 veto → 并联召回 → rerank → hydrate）
- MCP 协议层：过滤器链 → McpServerEngine → 8 个工具 → REST 孪生服务，两个失败平面

**其他**
- 简介与目录结构表同步记忆库 / REST + MCP 职责描述
- 结尾外链段落更新为实际仍只在 FLOWS.md 中的内容（状态机、双写补偿等）

## 验证

- 全部 6 张 Mermaid 图经 mermaid-cli 11.16.0 渲染校验通过
- 图内容逐项对照 `kb-rag-deploy/docs/ARCHITECTURE.md`、`FLOWS.md` 与 M19/M20 契约

🤖 Generated with [Claude Code](https://claude.com/claude-code)