### PR TITLE
fix(async): 修复 @Async 自调用失效，异步入口改为显式提交到容器线程池

### DIFF
--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/appcenter/ReleaseGateService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/appcenter/ReleaseGateService.java
@@ -27,15 +27,15 @@ import io.kbrag.domain.port.EmbeddingProvider;
 import io.kbrag.domain.port.RerankProvider;
 import io.kbrag.domain.service.GateMetricsRecomputer;
 import io.kbrag.domain.service.ReleaseGateJudge;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Runs the release gate and drives the release itself, requirement section 4.7 "evaluation gate".
@@ -52,13 +52,15 @@ import java.util.List;
  *
  * <p><b>Asynchronous with a synchronous shortcut.</b> A version with no data set bound is decided inline and
  * the caller gets its verdict immediately; a version with a data set enters {@code GATING} and the dual run
- * proceeds on its own executor, which is what the console's progress display exists for.
+ * proceeds on its own executor, which is what the console's progress display exists for. The executor is
+ * injected rather than reached through {@code @Async}: the gate is submitted from {@link #release}, this
+ * bean calling itself, where a proxied annotation runs inline and would park the whole dual run - two
+ * evaluation runs and the polling that waits for them - on the releasing HTTP thread.
  *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ReleaseGateService {
 
     private static final String CANDIDATE_LABEL = "候选配置";
@@ -74,6 +76,29 @@ public class ReleaseGateService {
     private final EmbeddingProvider embeddingProvider;
     private final RerankProvider rerankProvider;
     private final KbProperties properties;
+    private final Executor gateExecutor;
+
+    public ReleaseGateService(AppVersionService appVersionService,
+                              AppReleaseSnapshotService releaseSnapshotService,
+                              EvalRunService evalRunService,
+                              EvalResultMapper evalResultMapper,
+                              GateMetricsRecomputer gateMetricsRecomputer,
+                              ReleaseGateJudge releaseGateJudge,
+                              EmbeddingProvider embeddingProvider,
+                              RerankProvider rerankProvider,
+                              KbProperties properties,
+                              @Qualifier(AsyncConfig.GATE_EXECUTOR) Executor gateExecutor) {
+        this.appVersionService = appVersionService;
+        this.releaseSnapshotService = releaseSnapshotService;
+        this.evalRunService = evalRunService;
+        this.evalResultMapper = evalResultMapper;
+        this.gateMetricsRecomputer = gateMetricsRecomputer;
+        this.releaseGateJudge = releaseGateJudge;
+        this.embeddingProvider = embeddingProvider;
+        this.rerankProvider = rerankProvider;
+        this.properties = properties;
+        this.gateExecutor = gateExecutor;
+    }
 
     /**
      * Releases a version, running the gate first when one applies.
@@ -126,7 +151,7 @@ public class ReleaseGateService {
             return version;
         }
         appVersionService.markGating(version);
-        runGateAsync(appVersionId);
+        submitGate(appVersionId);
         return appVersionService.require(appVersionId);
     }
 
@@ -170,15 +195,16 @@ public class ReleaseGateService {
      *
      * @param appVersionId version business id
      */
-    @Async(AsyncConfig.GATE_EXECUTOR)
-    public void runGateAsync(String appVersionId) {
-        try {
-            runGate(appVersionId);
-        } catch (Exception e) {
-            log.error("release gate pass failed, errorCode={}, appVersionId={}",
-                    ErrorCode.INTERNAL_ERROR, appVersionId, e);
-            failGate(appVersionId);
-        }
+    private void submitGate(String appVersionId) {
+        gateExecutor.execute(() -> {
+            try {
+                runGate(appVersionId);
+            } catch (Exception e) {
+                log.error("release gate pass failed, errorCode={}, appVersionId={}",
+                        ErrorCode.INTERNAL_ERROR, appVersionId, e);
+                failGate(appVersionId);
+            }
+        });
     }
 
     /**

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/config/AsyncConfig.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/config/AsyncConfig.java
@@ -45,8 +45,11 @@ public class AsyncConfig {
     /** Bean name of the pool the timeout guarded retrieval stages run on. */
     public static final String RETRIEVAL_EXECUTOR = "retrievalTaskExecutor";
 
-    /** Bean name referenced by the {@code @Async} annotation of the evaluation run submission. */
+    /** Bean name of the pool one evaluation run's execution is submitted to. */
     public static final String EVAL_EXECUTOR = "evalTaskExecutor";
+
+    /** Bean name of the pool the cases of the running evaluations are spread over. */
+    public static final String EVAL_CASE_EXECUTOR = "evalCaseTaskExecutor";
 
     /** Bean name of the pool one release gate's dual run supervision occupies. */
     public static final String GATE_EXECUTOR = "gateTaskExecutor";
@@ -85,13 +88,20 @@ public class AsyncConfig {
 
     /**
      * One run submission can create up to 6 runs and each is handed to this pool independently, so a
-     * small size is enough: the actual per-case concurrency of one run is its own bounded pool sized
-     * by {@code kb.eval.concurrency}, created and torn down inside the run's own execution.
+     * small size is enough: a thread here only supervises one run, the cases themselves fan out again
+     * over {@link #evalCaseTaskExecutor}.
      */
     private static final int EVAL_CORE_POOL_SIZE = 2;
     private static final int EVAL_MAX_POOL_SIZE = 6;
     private static final int EVAL_QUEUE_CAPACITY = 50;
     private static final String EVAL_THREAD_PREFIX = "kb-eval-";
+
+    /**
+     * A case thread waits for the retrieval stages, so it must not share the pool the runs supervising
+     * it occupy: a case queued behind its own run would wait for a run that cannot finish.
+     */
+    private static final int EVAL_CASE_QUEUE_CAPACITY = 500;
+    private static final String EVAL_CASE_THREAD_PREFIX = "kb-eval-case-";
 
     /**
      * A gate thread spends its life waiting for two evaluation runs, so it must never share the pool those
@@ -197,6 +207,36 @@ public class AsyncConfig {
         executor.setMaxPoolSize(EVAL_MAX_POOL_SIZE);
         executor.setQueueCapacity(EVAL_QUEUE_CAPACITY);
         executor.setThreadNamePrefix(EVAL_THREAD_PREFIX);
+        executor.setTaskDecorator(requestIdPropagatingDecorator());
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Creates the executor the cases of the running evaluations are spread over, sized from configuration.
+     *
+     * <p>Shared across the runs rather than created per run: the cases are what actually call the embedding,
+     * rerank and judge providers, and they reach them through the very retrieval pool the online search uses.
+     * A pool per run made the peak load the product of the two concurrencies - six runs of a submitted matrix
+     * fanning out at {@code kb.eval.concurrency} each - which an offline report has no business imposing on
+     * the served traffic. One pool makes the setting the ceiling it reads like.
+     *
+     * <p>The caller runs policy is the back pressure: a full queue makes the supervising run thread judge a
+     * case itself, which slows the producer down instead of failing a run whose data set is simply large. It
+     * cannot deadlock, because that thread is waiting on these very cases and never on itself.
+     *
+     * @param properties knowledge base configuration, source of the concurrency
+     * @return executor used by the evaluation case execution
+     */
+    @Bean(EVAL_CASE_EXECUTOR)
+    public Executor evalCaseTaskExecutor(KbProperties properties) {
+        int concurrency = Math.max(1, properties.getEval().getConcurrency());
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(concurrency);
+        executor.setMaxPoolSize(concurrency);
+        executor.setQueueCapacity(EVAL_CASE_QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(EVAL_CASE_THREAD_PREFIX);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.setTaskDecorator(requestIdPropagatingDecorator());
         executor.initialize();
         return executor;

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalRunService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalRunService.java
@@ -39,10 +39,9 @@ import io.kbrag.domain.service.BizIdGenerator;
 import io.kbrag.domain.service.EvalHitJudge;
 import io.kbrag.domain.service.EvalMetricsCalculator;
 import io.kbrag.domain.service.OverlapRatioCalculator;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -50,9 +49,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 
 /**
  * Evaluation run submission, execution and comparison, requirement section 4.6.
@@ -69,11 +68,16 @@ import java.util.concurrent.Future;
  * configured is never silently downgraded to a BM25 result labelled as something else; its run is
  * created {@code FAILED} with an explicit reason and never executes, requirement section 3.1.
  *
+ * <p><b>The executors are injected, not annotated.</b> A submission hands its runs over from
+ * {@link #createOne}, which is this very bean calling itself - the shape a proxied {@code @Async}
+ * silently runs inline, leaving the whole matrix on the submitting request thread and the pool idle.
+ * Handing the task to the executor directly is the same choice, and for the same reason, that
+ * {@code IndexCleanupService} made.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class EvalRunService {
 
     private static final int MIN_CONFIGS = 1;
@@ -95,6 +99,44 @@ public class EvalRunService {
     private final OverlapRatioCalculator overlapRatioCalculator;
     private final BizIdGenerator bizIdGenerator;
     private final KbProperties properties;
+    private final Executor evalExecutor;
+    private final Executor evalCaseExecutor;
+
+    public EvalRunService(EvalDatasetService evalDatasetService,
+                          EvalRunMapper evalRunMapper,
+                          EvalResultMapper evalResultMapper,
+                          EvalCaseMapper evalCaseMapper,
+                          RetrievalService retrievalService,
+                          EmbeddingProvider embeddingProvider,
+                          RerankProvider rerankProvider,
+                          ChatProvider chatProvider,
+                          EvalJudgeService evalJudgeService,
+                          CorpusFingerprintFactory corpusFingerprintFactory,
+                          EvalHitJudge evalHitJudge,
+                          EvalMetricsCalculator evalMetricsCalculator,
+                          OverlapRatioCalculator overlapRatioCalculator,
+                          BizIdGenerator bizIdGenerator,
+                          KbProperties properties,
+                          @Qualifier(AsyncConfig.EVAL_EXECUTOR) Executor evalExecutor,
+                          @Qualifier(AsyncConfig.EVAL_CASE_EXECUTOR) Executor evalCaseExecutor) {
+        this.evalDatasetService = evalDatasetService;
+        this.evalRunMapper = evalRunMapper;
+        this.evalResultMapper = evalResultMapper;
+        this.evalCaseMapper = evalCaseMapper;
+        this.retrievalService = retrievalService;
+        this.embeddingProvider = embeddingProvider;
+        this.rerankProvider = rerankProvider;
+        this.chatProvider = chatProvider;
+        this.evalJudgeService = evalJudgeService;
+        this.corpusFingerprintFactory = corpusFingerprintFactory;
+        this.evalHitJudge = evalHitJudge;
+        this.evalMetricsCalculator = evalMetricsCalculator;
+        this.overlapRatioCalculator = overlapRatioCalculator;
+        this.bizIdGenerator = bizIdGenerator;
+        this.properties = properties;
+        this.evalExecutor = evalExecutor;
+        this.evalCaseExecutor = evalCaseExecutor;
+    }
 
     /**
      * Creates one run per configuration of the matrix, kicking off execution for every one that is not
@@ -291,19 +333,29 @@ public class EvalRunService {
         }
         run.setStatus(RunStatus.PENDING);
         evalRunMapper.insert(run);
-        executeAsync(run.getRunId(), judgeEnabled);
+        submitExecution(run.getRunId(), judgeEnabled);
         return run;
     }
 
     /**
      * Queues one run's execution off the submitting request.
      *
+     * <p>The run row is already {@code PENDING} in the database when this returns, so a submission that
+     * never reaches its executor thread is visible as a run that stayed pending rather than as one that
+     * was never created - which is what the release gate's wait budget is there to time out on.
+     *
      * @param runId        run business id
      * @param judgeEnabled {@code true} runs the LLM-as-judge stage
      */
-    @Async(AsyncConfig.EVAL_EXECUTOR)
-    public void executeAsync(String runId, boolean judgeEnabled) {
-        execute(runId, judgeEnabled);
+    private void submitExecution(String runId, boolean judgeEnabled) {
+        evalExecutor.execute(() -> {
+            try {
+                execute(runId, judgeEnabled);
+            } catch (Exception e) {
+                log.error("evaluation run execution could not start, errorCode={}, runId={}",
+                        ErrorCode.INTERNAL_ERROR, runId, e);
+            }
+        });
     }
 
     /**
@@ -355,28 +407,40 @@ public class EvalRunService {
         }
     }
 
+    /**
+     * Judges every case of one run on the shared, container managed case pool.
+     *
+     * <p>A pool created here per run would be invisible to the deployment - unnamed threads in a dump, no
+     * request id carried into them, and a concurrency ceiling that multiplied by however many runs happened
+     * to be executing. Every case is submitted before any is collected, so they overlap: joining inside the
+     * submission loop would judge them one at a time.
+     *
+     * @param kbId         knowledge base business id
+     * @param cases        the run's effective cases
+     * @param config       retrieval configuration under test
+     * @param k            metrics {@code K}
+     * @param judgeEnabled {@code true} runs the LLM-as-judge stage
+     * @return one outcome per case, in the order the cases were given
+     */
     private List<CaseOutcome> judgeAll(String kbId, List<EvalCase> cases, EvalRetrievalConfig config, int k,
                                        boolean judgeEnabled) {
-        if (cases.isEmpty()) {
+        if (CollectionUtils.isEmpty(cases)) {
             return List.of();
         }
-        int concurrency = Math.max(1, properties.getEval().getConcurrency());
-        ExecutorService pool = Executors.newFixedThreadPool(Math.min(concurrency, cases.size()));
-        try {
-            List<Future<CaseOutcome>> futures = new ArrayList<>(cases.size());
-            for (EvalCase evalCase : cases) {
-                futures.add(pool.submit(() -> judgeOneCase(kbId, evalCase, config, k, judgeEnabled)));
-            }
-            List<CaseOutcome> outcomes = new ArrayList<>(cases.size());
-            for (Future<CaseOutcome> future : futures) {
-                outcomes.add(future.get());
-            }
-            return outcomes;
-        } catch (Exception e) {
-            throw new IllegalStateException("evaluation case execution failed", e);
-        } finally {
-            pool.shutdown();
+        List<CompletableFuture<CaseOutcome>> futures = new ArrayList<>(cases.size());
+        for (EvalCase evalCase : cases) {
+            futures.add(CompletableFuture.supplyAsync(
+                    () -> judgeOneCase(kbId, evalCase, config, k, judgeEnabled), evalCaseExecutor));
         }
+        List<CaseOutcome> outcomes = new ArrayList<>(cases.size());
+        try {
+            for (CompletableFuture<CaseOutcome> future : futures) {
+                outcomes.add(future.join());
+            }
+        } catch (CompletionException e) {
+            throw new IllegalStateException("evaluation case execution failed", e.getCause());
+        }
+        return outcomes;
     }
 
     private CaseOutcome judgeOneCase(String kbId, EvalCase evalCase, EvalRetrievalConfig config, int k,

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryAppKeyService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryAppKeyService.java
@@ -12,14 +12,14 @@ import io.kbrag.domain.enums.MemoryAppKeyStatus;
 import io.kbrag.domain.mapper.MemoryAppKeyMapper;
 import io.kbrag.domain.service.BizIdGenerator;
 import io.kbrag.domain.service.MemoryKeyFactory;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Memory key management and authentication, the M19 contract.
@@ -34,7 +34,6 @@ import java.util.List;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class MemoryAppKeyService {
 
     private final MemoryAppKeyMapper memoryAppKeyMapper;
@@ -42,6 +41,21 @@ public class MemoryAppKeyService {
     private final BizIdGenerator bizIdGenerator;
     private final ApiRateLimiter apiRateLimiter;
     private final KbProperties properties;
+    private final Executor auditExecutor;
+
+    public MemoryAppKeyService(MemoryAppKeyMapper memoryAppKeyMapper,
+                               MemoryKeyFactory memoryKeyFactory,
+                               BizIdGenerator bizIdGenerator,
+                               ApiRateLimiter apiRateLimiter,
+                               KbProperties properties,
+                               @Qualifier(AsyncConfig.AUDIT_EXECUTOR) Executor auditExecutor) {
+        this.memoryAppKeyMapper = memoryAppKeyMapper;
+        this.memoryKeyFactory = memoryKeyFactory;
+        this.bizIdGenerator = bizIdGenerator;
+        this.apiRateLimiter = apiRateLimiter;
+        this.properties = properties;
+        this.auditExecutor = auditExecutor;
+    }
 
     /**
      * Mints a key bound to one library.
@@ -203,18 +217,23 @@ public class MemoryAppKeyService {
      * Records the last use of a key off the request path, asynchronous and best effort - an
      * operational hint, not an audit fact.
      *
+     * <p>Handed to the executor directly rather than through {@code @Async}: its only caller is
+     * {@link #authenticate} on this same bean, where a proxied annotation is bypassed and the update
+     * would run inline on the request path it exists to stay off.
+     *
      * @param keyId key business id
      */
-    @Async(AsyncConfig.AUDIT_EXECUTOR)
-    public void touchAsync(String keyId) {
-        try {
-            memoryAppKeyMapper.update(null, new LambdaUpdateWrapper<MemoryAppKey>()
-                    .set(MemoryAppKey::getLastUsedAt, LocalDateTime.now())
-                    .eq(MemoryAppKey::getKeyId, keyId));
-        } catch (Exception e) {
-            log.error("memory key last used timestamp not updated, errorCode={}, keyId={}",
-                    ErrorCode.INTERNAL_ERROR, keyId, e);
-        }
+    private void touchAsync(String keyId) {
+        auditExecutor.execute(() -> {
+            try {
+                memoryAppKeyMapper.update(null, new LambdaUpdateWrapper<MemoryAppKey>()
+                        .set(MemoryAppKey::getLastUsedAt, LocalDateTime.now())
+                        .eq(MemoryAppKey::getKeyId, keyId));
+            } catch (Exception e) {
+                log.error("memory key last used timestamp not updated, errorCode={}, keyId={}",
+                        ErrorCode.INTERNAL_ERROR, keyId, e);
+            }
+        });
     }
 
     /**

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/openapi/ApiKeyService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/openapi/ApiKeyService.java
@@ -14,15 +14,15 @@ import io.kbrag.domain.enums.ApiKeyStatus;
 import io.kbrag.domain.mapper.ApiKeyMapper;
 import io.kbrag.domain.service.ApiKeyFactory;
 import io.kbrag.domain.service.BizIdGenerator;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * API key management and authentication, requirement section 4.8.
@@ -36,7 +36,6 @@ import java.util.List;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ApiKeyService {
 
     private final ApiKeyMapper apiKeyMapper;
@@ -44,6 +43,21 @@ public class ApiKeyService {
     private final AppService appService;
     private final BizIdGenerator bizIdGenerator;
     private final KbProperties properties;
+    private final Executor auditExecutor;
+
+    public ApiKeyService(ApiKeyMapper apiKeyMapper,
+                         ApiKeyFactory apiKeyFactory,
+                         AppService appService,
+                         BizIdGenerator bizIdGenerator,
+                         KbProperties properties,
+                         @Qualifier(AsyncConfig.AUDIT_EXECUTOR) Executor auditExecutor) {
+        this.apiKeyMapper = apiKeyMapper;
+        this.apiKeyFactory = apiKeyFactory;
+        this.appService = appService;
+        this.bizIdGenerator = bizIdGenerator;
+        this.properties = properties;
+        this.auditExecutor = auditExecutor;
+    }
 
     /**
      * Mints a key.
@@ -201,18 +215,23 @@ public class ApiKeyService {
      * and the value it maintains is an operational hint, not an audit fact - the audit table is where the
      * facts live.
      *
+     * <p>Handed to the executor directly rather than through {@code @Async}, because its only caller is
+     * {@link #authenticate} on this same bean: a proxied annotation is bypassed there, and the update would
+     * run inline on the very request path it exists to stay off - once per authenticated open API call.
+     *
      * @param keyId key business id
      */
-    @Async(AsyncConfig.AUDIT_EXECUTOR)
-    public void touchAsync(String keyId) {
-        try {
-            apiKeyMapper.update(null, new LambdaUpdateWrapper<ApiKey>()
-                    .set(ApiKey::getLastUsedAt, LocalDateTime.now())
-                    .eq(ApiKey::getKeyId, keyId));
-        } catch (Exception e) {
-            log.error("api key last used timestamp not updated, errorCode={}, keyId={}",
-                    ErrorCode.INTERNAL_ERROR, keyId, e);
-        }
+    private void touchAsync(String keyId) {
+        auditExecutor.execute(() -> {
+            try {
+                apiKeyMapper.update(null, new LambdaUpdateWrapper<ApiKey>()
+                        .set(ApiKey::getLastUsedAt, LocalDateTime.now())
+                        .eq(ApiKey::getKeyId, keyId));
+            } catch (Exception e) {
+                log.error("api key last used timestamp not updated, errorCode={}, keyId={}",
+                        ErrorCode.INTERNAL_ERROR, keyId, e);
+            }
+        });
     }
 
     /**

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/appcenter/ReleaseGateServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/appcenter/ReleaseGateServiceTest.java
@@ -32,8 +32,15 @@ import org.mockito.InOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -65,6 +72,8 @@ class ReleaseGateServiceTest {
     private static final String BASELINE_RUN = "evr_baseline";
     private static final String KB_ID = "kb_1";
     private static final String SNAPSHOT_INDEX = "kb_1_none_s1";
+    private static final String GATE_PROBE_THREAD = "gate-probe";
+    private static final int HAND_OFF_TIMEOUT_SECONDS = 5;
 
     /** Frozen snapshot every successful release in this class is expected to install. */
     private static final AppReleaseSnapshotService.ReleaseSnapshot RELEASE_SNAPSHOT =
@@ -92,9 +101,22 @@ class ReleaseGateServiceTest {
         properties = new KbProperties();
         properties.getGate().setMinCases(2);
         when(releaseSnapshotService.freeze(any(), any())).thenReturn(RELEASE_SNAPSHOT);
-        service = new ReleaseGateService(appVersionService, releaseSnapshotService, evalRunService,
+        service = newService(Runnable::run);
+    }
+
+    /**
+     * Builds the service over the executor the gate is submitted to.
+     *
+     * <p>Inline for the suite, so a {@code release} that starts a gate has finished it by the time the call
+     * returns and the verdict can simply be asserted; the hand-off itself is measured separately.
+     *
+     * @param gateExecutor pool one gate's dual run supervision is submitted to
+     * @return service under test
+     */
+    private ReleaseGateService newService(Executor gateExecutor) {
+        return new ReleaseGateService(appVersionService, releaseSnapshotService, evalRunService,
                 evalResultMapper, new GateMetricsRecomputer(), new ReleaseGateJudge(), embeddingProvider,
-                rerankProvider, properties);
+                rerankProvider, properties, gateExecutor);
     }
 
     @Test
@@ -279,6 +301,46 @@ class ReleaseGateServiceTest {
         assertEquals(0.5d, report.candidate().hitRate(), 1e-9d);
         assertEquals(0.5d, report.baseline().hitRate(), 1e-9d);
         assertEquals(List.of("c1", "c2"), report.caseIds());
+    }
+
+    /**
+     * A release that starts a gate must hand it over and return, leaving the console a {@code GATING}
+     * version to poll rather than a request blocked for the whole dual run.
+     *
+     * <p>Regression guard for the {@code @Async} self invocation this replaced: {@code release} called the
+     * annotated method on its own bean, which the proxy never intercepts, so both evaluation runs and the
+     * polling loop that waits for them ran on the releasing HTTP thread while the gate pool stood idle.
+     */
+    @Test
+    void shouldRunTheGateOnTheGateExecutorRatherThanTheReleasingThread() throws InterruptedException {
+        AppVersion version = versionOf(AppVersionStatus.TESTING, DATASET_ID);
+        stubDualRun(version, baselineVersion());
+        when(evalResultMapper.selectList(any()))
+                .thenReturn(List.of(result("c1", true, 1, 1), result("c2", true, 1, 1)))
+                .thenReturn(List.of(result("c1", true, 1, 1), result("c2", true, 1, 1)));
+
+        CountDownLatch gated = new CountDownLatch(1);
+        AtomicReference<String> gateThread = new AtomicReference<>();
+        when(evalRunService.submit(eq(DATASET_ID), anyInt(), anyList(), eq(false))).thenAnswer(invocation -> {
+            // The dual run is submitted from runGate and nowhere else, so this is the gate's own thread.
+            gateThread.set(Thread.currentThread().getName());
+            gated.countDown();
+            return List.of(runOf(CANDIDATE_RUN, RunStatus.SUCCESS), runOf(BASELINE_RUN, RunStatus.SUCCESS));
+        });
+
+        ExecutorService gatePool = Executors.newSingleThreadExecutor(task -> new Thread(task, GATE_PROBE_THREAD));
+        try {
+            ReleaseGateService asyncService = newService(gatePool);
+
+            asyncService.release(VERSION_ID, false, "admin");
+
+            assertTrue(gated.await(HAND_OFF_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "the gate never reached its executor");
+            assertEquals(GATE_PROBE_THREAD, gateThread.get());
+            assertNotEquals(Thread.currentThread().getName(), gateThread.get());
+        } finally {
+            gatePool.shutdownNow();
+        }
     }
 
     @Test

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/eval/EvalRunServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/eval/EvalRunServiceTest.java
@@ -33,9 +33,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -54,6 +61,9 @@ class EvalRunServiceTest {
 
     private static final String DATASET_ID = "evds_test";
     private static final String KB_ID = "kb_test";
+    private static final String RUN_PROBE_THREAD = "eval-run-probe";
+    private static final String CASE_PROBE_THREAD = "eval-case-probe";
+    private static final int HAND_OFF_TIMEOUT_SECONDS = 5;
 
     private EvalDatasetService evalDatasetService;
     private EvalRunMapper evalRunMapper;
@@ -84,11 +94,26 @@ class EvalRunServiceTest {
         bizIdGenerator = mock(BizIdGenerator.class);
         properties = new KbProperties();
 
-        service = new EvalRunService(evalDatasetService, evalRunMapper, evalResultMapper, evalCaseMapper,
+        service = newService(Runnable::run, Runnable::run);
+    }
+
+    /**
+     * Builds the service over the two executors a case is routed through.
+     *
+     * <p>The suite runs both inline so its assertions about what a run produces stay free of thread
+     * coordination; the two hand-off tests are where the executors are given real threads and the fact
+     * that the work actually leaves the caller is what is being measured.
+     *
+     * @param evalExecutor     pool one run's execution is submitted to
+     * @param evalCaseExecutor pool the cases of a run are spread over
+     * @return service under test
+     */
+    private EvalRunService newService(Executor evalExecutor, Executor evalCaseExecutor) {
+        return new EvalRunService(evalDatasetService, evalRunMapper, evalResultMapper, evalCaseMapper,
                 retrievalService, embeddingProvider, rerankProvider, chatProvider, evalJudgeService,
                 corpusFingerprintFactory, new EvalHitJudge(new OverlapRatioCalculator(new ChunkTextHasher())),
                 new EvalMetricsCalculator(), new OverlapRatioCalculator(new ChunkTextHasher()),
-                bizIdGenerator, properties);
+                bizIdGenerator, properties, evalExecutor, evalCaseExecutor);
     }
 
     @Test
@@ -126,13 +151,90 @@ class EvalRunServiceTest {
         List<EvalRun> runs = service.submit(DATASET_ID, 5, List.of(configOf(EvalMode.BM25_ONLY)), false);
 
         // createOne() returns the run object it built locally before insertion, which starts PENDING;
-        // execute() ran synchronously in this Spring free unit test (no @Async proxy) against the
-        // separately mocked, re-fetched row, so that row is where the final state actually landed.
+        // this suite's executors run inline, so execute() had already finished against the separately
+        // mocked, re-fetched row by the time submit() returned, and that row is where the final state
+        // actually landed.
         assertEquals(RunStatus.PENDING, runs.get(0).getStatus());
         ArgumentCaptor<EvalRun> runCaptor = ArgumentCaptor.forClass(EvalRun.class);
         verify(evalRunMapper, org.mockito.Mockito.atLeastOnce()).updateById(runCaptor.capture());
         EvalRun finalState = runCaptor.getAllValues().get(runCaptor.getAllValues().size() - 1);
         assertEquals(RunStatus.SUCCESS, finalState.getStatus());
+    }
+
+    /**
+     * A submission must hand the execution over and leave the request thread with nothing but the rows it
+     * created.
+     *
+     * <p>Regression guard for the {@code @Async} self invocation this replaced. The annotation sat on a
+     * method {@code createOne} called on its own bean, which the proxy never intercepts, so a submitted
+     * matrix - up to six runs, every case of each - executed on the submitting HTTP thread while the pool
+     * it named stood idle. Nothing about the produced rows differs between the two, which is exactly why
+     * the assertion has to be about the thread.
+     */
+    @Test
+    void shouldExecuteTheRunOnTheEvalExecutorRatherThanTheSubmittingThread() throws InterruptedException {
+        when(evalDatasetService.require(DATASET_ID)).thenReturn(dataset());
+        when(corpusFingerprintFactory.fingerprint(KB_ID)).thenReturn("fp_1");
+        when(embeddingProvider.isConfigured()).thenReturn(false);
+        when(bizIdGenerator.evalRunId()).thenReturn("evr_async");
+        when(evalCaseMapper.selectList(any())).thenReturn(List.of());
+
+        CountDownLatch executed = new CountDownLatch(1);
+        AtomicReference<String> executionThread = new AtomicReference<>();
+        when(evalRunMapper.selectOne(any())).thenAnswer(invocation -> {
+            // requireRun is the first thing execute() does, so this is the thread the run really ran on.
+            executionThread.set(Thread.currentThread().getName());
+            executed.countDown();
+            return storedRun("evr_async");
+        });
+
+        ExecutorService evalPool = Executors.newSingleThreadExecutor(task -> new Thread(task, RUN_PROBE_THREAD));
+        try {
+            EvalRunService asyncService = newService(evalPool, Runnable::run);
+
+            asyncService.submit(DATASET_ID, 5, List.of(configOf(EvalMode.BM25_ONLY)), false);
+
+            assertTrue(executed.await(HAND_OFF_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "the run never reached the eval executor");
+            assertEquals(RUN_PROBE_THREAD, executionThread.get());
+            assertNotEquals(Thread.currentThread().getName(), executionThread.get());
+        } finally {
+            evalPool.shutdownNow();
+        }
+    }
+
+    /**
+     * The cases must be judged on the container managed pool, not on one the run creates for itself.
+     *
+     * <p>Regression guard for the per run {@code Executors.newFixedThreadPool} this replaced: its threads
+     * were unnamed, carried no request id into the retrieval calls, and multiplied the configured
+     * concurrency by however many runs happened to be executing.
+     */
+    @Test
+    void shouldJudgeTheCasesOnTheCaseExecutorRatherThanAPoolCreatedPerRun() {
+        EvalRun run = pendingRun();
+        when(evalRunMapper.selectOne(any())).thenReturn(run);
+        when(evalCaseMapper.selectList(any())).thenReturn(List.of(spanCase()));
+        when(bizIdGenerator.evalResultId()).thenReturn("evre_1");
+
+        AtomicReference<String> caseThread = new AtomicReference<>();
+        when(retrievalService.search(anyString(), any(RetrievalCommand.class))).thenAnswer(invocation -> {
+            caseThread.set(Thread.currentThread().getName());
+            return new SearchOutcome(List.of(hitNode()), List.of(), null);
+        });
+
+        ExecutorService casePool = Executors.newSingleThreadExecutor(task -> new Thread(task, CASE_PROBE_THREAD));
+        try {
+            // The run executor is inline here, so the case pool is the only hand-off left to observe and
+            // join() has already made it deterministic by the time execute() returns.
+            EvalRunService asyncService = newService(Runnable::run, casePool);
+
+            asyncService.execute("evr_run", false);
+
+            assertEquals(CASE_PROBE_THREAD, caseThread.get());
+        } finally {
+            casePool.shutdownNow();
+        }
     }
 
     @Test
@@ -259,6 +361,22 @@ class EvalRunServiceTest {
         run.setRetrievalConfig(JsonUtil.toJson(configOf(EvalMode.HYBRID)));
         run.setStatus(RunStatus.SUCCESS);
         return run;
+    }
+
+    /**
+     * The row {@code execute} re-reads for a run that was just submitted, as a real database would return
+     * it: pending, with the top n already resolved from k.
+     *
+     * @param runId run business id
+     * @return stored run
+     */
+    private EvalRun storedRun(String runId) {
+        EvalRun stored = runWithState(runId, 1, "fp_1");
+        stored.setStatus(RunStatus.PENDING);
+        EvalRetrievalConfig config = configOf(EvalMode.BM25_ONLY);
+        config.setTopN(5);
+        stored.setRetrievalConfig(JsonUtil.toJson(config));
+        return stored;
     }
 
     private EvalCase spanCase() {

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/memory/MemoryAppKeyServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/memory/MemoryAppKeyServiceTest.java
@@ -48,7 +48,7 @@ class MemoryAppKeyServiceTest {
         apiRateLimiter = mock(ApiRateLimiter.class);
         KbProperties properties = new KbProperties();
         service = new MemoryAppKeyService(memoryAppKeyMapper, memoryKeyFactory,
-                mock(BizIdGenerator.class), apiRateLimiter, properties);
+                mock(BizIdGenerator.class), apiRateLimiter, properties, Runnable::run);
     }
 
     @Test

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/openapi/ApiKeyServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/openapi/ApiKeyServiceTest.java
@@ -53,7 +53,10 @@ class ApiKeyServiceTest {
         apiKeyFactory = new ApiKeyFactory();
         properties = new KbProperties();
         when(bizIdGenerator.apiKeyId()).thenReturn(KEY_ID);
-        service = new ApiKeyService(apiKeyMapper, apiKeyFactory, appService, bizIdGenerator, properties);
+        // The audit executor runs inline so the last-used write this suite observes has already happened
+        // when authenticate returns; that it leaves the request thread in production is asserted separately.
+        service = new ApiKeyService(apiKeyMapper, apiKeyFactory, appService, bizIdGenerator, properties,
+                Runnable::run);
     }
 
     @Test

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
@@ -1272,7 +1272,10 @@ public class KbProperties {
          */
         private long offlineTimeoutMs = 10000L;
 
-        /** Cases judged concurrently by one evaluation run. */
+        /**
+         * Cases judged concurrently across every running evaluation. A global ceiling and not a per run
+         * one, because the cases reach the model providers through the pool the online search shares.
+         */
         private int concurrency = 4;
 
         /** Aggregate coverage threshold a span must reach across the top K to count as a hit. */


### PR DESCRIPTION
## 问题

Spring `@Async` 基于 AOP 代理，只拦截**外部**调用。同一个 bean 内部 `this.method()` 绕过代理，注解静默失效 —— 不报错、不告警，方法直接在调用线程上同步执行。

全仓扫描 20 处 `@Async`，命中 5 处自调用（`IndexCleanupService` 是手写线程池，注释里已经写明规避了这个坑，不在此列）：

| 位置 | 实际后果 |
|---|---|
| `EvalRunService.createOne` → `executeAsync` | 整个评测矩阵（最多 6 配置 × N case）阻塞在 HTTP 提交线程上，`evalTaskExecutor` 全程空转 |
| `ReleaseGateService.release` → `runGateAsync` | 两次评测运行 + 轮询等待全部压在发布请求线程上 |
| `ApiKeyService.authenticate` → `touchAsync` | **每次 OpenAPI 认证**都在请求路径上同步写一次库 |
| `MemoryAppKeyService.authenticate` → `touchAsync` | 同上，Memory API 每次认证一次同步写 |

后两处是本次排查中额外发现的，不在最初的问题描述里。它们比评测路径高频得多，而且 `touchAsync` 的方法注释恰好写着"a write on every call would put a row update in front of every search" —— 描述的正是它自己造成的后果。

## 修复取舍

三条路可选，选了第三条：

- **self 注入 / ObjectProvider** —— 能走通代理，但自引用是反模式，且下一个人很容易照着写成 `this.` 又坏掉，缺陷会无声复发。
- **拆独立 bean** —— 新 bean 要调 `EvalRunService`，而 `EvalRunService` 要调新 bean 提交任务，构成循环依赖。项目是 Spring Boot 3.3.9，默认禁止循环引用，这条路直接不成立。
- **注入 `Executor` 显式提交** ← 采用。不依赖代理、无循环依赖、不新增 bean，且 `IndexCleanupService` 已经是这个写法并留了注释说明原因。等于沿用仓库既有决策，而不是另立一套。

## 顺带收敛的裸线程池

`EvalRunService.judgeAll` 每个 run 现场 `Executors.newFixedThreadPool`：线程无名（dump 里认不出）、无 `TaskDecorator`（request_id 透传断裂，日志追不到链路）、并发上限被运行中的 run 数量放大。

收敛到新增的 `evalCaseTaskExecutor`。**这带来一个语义变更**：`kb.eval.concurrency` 从"每个 run 的并发"变为"全局并发上限"，javadoc 已同步更新。这么改是因为 case 最终会打到 `retrievalTaskExecutor` —— 那是**在线搜索共用的池**（core 4 / max 16 / 队列 0）。原来 6 个 run 并行时 case 并发可达 24，足以占满该池导致线上搜索被拒绝降级。收敛后是确定的全局上限，同 `embedTaskExecutor` 的既有惯例。队列满时用 `CallerRunsPolicy` 背压，不会丢 case。

等待链保持四层独立、无环，不会死锁：

    HTTP 线程 → gateTaskExecutor（等 run）→ evalTaskExecutor（等 case）
              → evalCaseTaskExecutor（等检索）→ retrievalTaskExecutor（叶子）

`gateTaskExecutor` 与 `evalTaskExecutor` 的分离是刻意设计（防门禁自等待死锁），未合并。

## 测试

新增 3 个回归用例，断言**提交线程 ≠ 执行线程**，分别覆盖 run 移交、case 移交、门禁移交。

这类测试容易写成永远绿的假测试，所以做了破坏性验证：把三处代码退回自调用形态后重跑，3 个新用例全部变红、其余 26 个仍绿；还原后全绿。

全量 711 个测试通过。

注：现有 `EvalRunServiceTest` 里有条注释把"没有 @Async 代理所以同步执行"当成了测试前提，已一并更正。