### PR TITLE
fix(memory): 补齐 M19 记忆库的多租户隔离

### DIFF
--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **记忆库多租户隔离（M19 后修复，`docs/M19-CONTRACTS.md` §1.4）**：M19 的六张记忆库表漏了 M16 的租户层——`memory:read`/`memory:write` 只回答「这个账号能不能碰记忆库」、回答不了「能碰哪些」，多租户部署下任何租户持 `memory:read` 的账号能列出全部署的记忆库，持 `memory:write` 能改删其他租户的库、规则、记忆与 Memory Key。Flyway `V21__memory_library_tenant.sql` 给 `t_kb_memory_library` 补 `tenant_id`（存量行由列 DEFAULT 划入内置默认租户，**升级零迁移、单租户部署行为不变**）并入行级围栏；五张从属表不加列、经 `library_id` 归属租户；管理端带 `libraryId` 的 21 个入口一律先解析库（`MemoryLibraryGuard`），否则按 `rule_id`/`node_id`/`key_id` 直接寻址的入口不经过带租户列的那张表、围栏形同虚设；余下 2 个（库列表、建库）无 `libraryId`，由围栏本体直接覆盖。**开放端（`Bearer kb-mk-*`）行为零变化**：那条过滤器链上没有控制台主体，围栏整条跳过，隔离仍由 Key 绑库 + `user_id` 两层查询谓词完成。**唯一行为变更**：记忆库同名校验从全局唯一收缩为租户内唯一。`ARCHITECTURE.md` 升 v1.6、`FLOWS.md` 升 v1.5。
+
 ### Added
 
 - **MCP 协议层（M20，`docs/M20-CONTRACTS.md`）**：知识库应用与记忆库各暴露一个 MCP Streamable HTTP 端点（`POST /api/v1/knowledge/mcp`、`POST /api/v1/memory/mcp`，JSON-RPC 2.0 单请求单 JSON 响应，协议版本 2025-03-26 兼容 2024-11-05），任何 MCP 兼容客户端（Claude Desktop / Cursor / Cline 等）配一个 URL 加一把既有 Key（kb-sk-* / kb-mk-*）即可直接调用。鉴权/限流/审计与 REST 开放端点同一条过滤器链；工具集 knowledge_search / knowledge_chat（仅非流式）与 memory 六工具，参数与返回结构同 REST 孪生端点。**无新增容器、依赖、环境变量与配置键**，纯新增、存量端点与行为零变化。控制台新增「MCP 调试」一级菜单；调用方文档见主仓 `docs/MCP接入指南.md`。

--- a/kb-rag-deploy/docs/ARCHITECTURE.md
+++ b/kb-rag-deploy/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # kb-rag 架构文档
 
-> 版本：v1.5（基线 = 一期 M1-M7 + 二期 M8/M9 + 核心能力增强 M10-M13 + 竞品能力对齐 M14 + 企业化 M15/M16 + 网页抓取增强 M17/M18 + 记忆库 M19 + MCP 协议层 M20，2026-08-03；v1.4 基线为 M19，v1.3 基线为 M14，v1.2 基线为 M13，v1.1 基线为 M9，v1.0 基线为 M8）
-> 日期：2026-08-03
+> 版本：v1.6（基线 = 一期 M1-M7 + 二期 M8/M9 + 核心能力增强 M10-M13 + 竞品能力对齐 M14 + 企业化 M15/M16 + 网页抓取增强 M17/M18 + 记忆库 M19 + MCP 协议层 M20 + 记忆库租户隔离修复 V21，2026-08-11；v1.5 基线为 M20，v1.4 基线为 M19，v1.3 基线为 M14，v1.2 基线为 M13，v1.1 基线为 M9，v1.0 基线为 M8）
+> 日期：2026-08-11
 > 作者：RichardFyoung / Claude
 >
 > **文档定位**：本文描述系统的实际实现架构（以代码为准），与以下文档互补——
@@ -235,6 +235,7 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | V18（M17） | `t_kb_web_source` 增 `render_js`（JS 渲染抓取开关，默认 0 静态抓取） |
 | V19（M18） | `t_kb_web_credential`（站点级认证凭据，host 全局唯一；BASIC/HEADER 两类，secret 刻意明文存储、读接口永不回传） |
 | V20（M19） | 记忆库 6 张表：`t_kb_memory_library` / `t_kb_memory_fragment_rule`（instruction_type/auto_update/expire_days/extract_version/builtin）/ `t_kb_memory_profile_rule`（fields 整体存 JSON 数组）/ `t_kb_memory_node`（idx_library_user）/ `t_kb_memory_profile`（uk_rule_user 唯一键 upsert）/ `t_kb_memory_app_key`（明文 `kb-mk-*`，只存 SHA-256 摘要 + 展示前缀）；权限种子 `memory:read`/`memory:write` |
+| V21（M19 后修复） | `t_kb_memory_library` 增 `tenant_id`（存量行靠列 DEFAULT 划入默认租户）+ `idx_tenant` —— V20 建表时漏了 M16 的租户层，多租户部署下任何租户持 `memory:read` 即可列出全部署记忆库、`memory:write` 可改删他人的库与 Memory Key。记忆库是 memory 域的根聚合表，五张从属表（片段/画像规则、节点、画像、Key）经 `library_id` 归属租户，故只加这一列；配套把它加进 `KbTenantLineHandler.FENCED_TABLES`，并由 `MemoryLibraryGuard` 让每个管理端入口先解析库（见 §7.2） |
 
 引擎侧可过滤字段全集（Qdrant 标量 / ES filter，建索引时显式声明）：`kb_id`、`doc_id`、`document_version_id`、`enabled`、`parent_id`、`chunk_type`、`tag_ids`、`session_id`、`sender`、`msg_time`、`chunk_seq`；其余 metadata 只存 MySQL。新增可过滤维度视为 schema 变更，走索引重建迁移。
 
@@ -350,6 +351,7 @@ Vite 8 + React 18 + TypeScript 6 + Ant Design 5 + react-router-dom 6 + axios；l
 ### 7.2 安全
 
 - **三条独立鉴权链**：管理台 Bearer Token（`AuthInterceptor`，Token 哈希落库 `t_kb_auth_token`、防爆破锁定、首登随机密码强制改密；M15 起叠加 `PermissionInterceptor` 功能权限 + 知识库数据范围两层授权）、对外 API Key（`ApiKeyAuthFilter` 独立过滤器链、哈希存储、app_scope 授权范围、令牌桶限流）、记忆库 Memory Key（M19，`MemoryKeyAuthFilter`：`Bearer kb-mk-*` 只作用于 `/api/v1/memory/**`，一把 Key 绑定一个记忆库、库内再按 user_id 隔离，隔离是查询谓词、越权一律 404；限流复用 `ApiRateLimiter`）——三面凭据形态、失败面、限流口径互不干扰。
+- **记忆库的第三层隔离是租户**（V21 修复）：Key 绑定库（应用级）与 `user_id`（实体级）只覆盖开放端，管理端的 `memory:read`/`memory:write` 只回答"这个账号能不能碰记忆库"，回答不了"能碰哪些"。补法与知识库同构：`t_kb_memory_library` 加 `tenant_id` 并进围栏，五张从属表不加列、经 `library_id` 归属；关键是 `MemoryLibraryGuard` —— 管理端带 `libraryId` 的 21 个入口**一律先解析库**（包括按 rule_id / node_id / key_id 直接寻址的那些），否则从属语句压根不经过带 `tenant_id` 的那张表，围栏形同虚设；余下 2 个（库列表、建库）无 libraryId，由围栏本体覆盖（SELECT 拼条件 / INSERT 注入）。开放端不受影响：那条链上没有控制台主体，`ignoreTable` 整条跳过，这是必须保留的既有语义（一拼租户条件，Key 会把自己的库过滤掉）。
 - **MCP 是第二种 transport，不是第二种身份**（M20）：`/api/v1/knowledge/mcp` 与 `/api/v1/memory/mcp` 刻意落在上述后两条过滤器链的 URL 前缀之下，凭证仍是既有 `kb-sk-*` / `kb-mk-*`，鉴权、授权范围、限流、审计与 REST 完全同一条管线，零过滤器改动、无新增凭据面；协议层错误（JSON-RPC error / `isError`）全部在 HTTP 200 的 body 里，401/429 信封同 REST（见 §3.9）。
 - **Prompt 注入四防线**：①生成/judge prompt 固定分隔符包裹资料原文；②LLM 切分输出强校验（非法降级按长度切）；③路由白名单交集裁决；④改写结果仅作检索词。
 - 解析侧基线：magic number 校验、zip-slip/炸弹、XXE（defusedxml）、SSRF（解析期零出站）；前端零 `dangerouslySetInnerHTML`；聊天导入默认脱敏（手机号/身份证/银行卡 16-19 位）；审计 query 无条件脱敏；MinIO 私有桶 + 限时预签名 URL。

--- a/kb-rag-deploy/docs/FLOWS.md
+++ b/kb-rag-deploy/docs/FLOWS.md
@@ -1,7 +1,7 @@
 # kb-rag 流程图文档
 
-> 版本：v1.4（基线与 `ARCHITECTURE.md` 相同 = M1-M20 及其后修复的状态；v1.3 基线为 M19，v1.2 基线为 M13）
-> 日期：2026-08-03
+> 版本：v1.5（基线与 `ARCHITECTURE.md` 相同 = M1-M20 及其后修复的状态，含记忆库租户隔离修复 V21；v1.4 基线为 M20，v1.3 基线为 M19，v1.2 基线为 M13）
+> 日期：2026-08-11
 > 作者：RichardFyoung / Claude
 >
 > 图使用 Mermaid 绘制（GitHub / 主流 IDE 原生渲染）。每张图标注对应的核心类与契约出处，与代码不一致时以代码为准并须在同一 PR 内修订本文档（项目铁律②）。
@@ -400,6 +400,9 @@ flowchart LR
 ## 14. 记忆库：写入抽取与检索（M19）
 
 对应：`MemoryKeyAuthFilter` / `MemoryApiService` / `MemoryExtractionService` / `EsMemoryStore`（契约 M19 §3/§5/§6）。
+
+> 下面两张图画的都是**开放端**（`Bearer kb-mk-*`）。那条链上没有控制台主体，租户围栏整条跳过，隔离由 Key 绑定的唯一记忆库 + `user_id` 两层查询谓词完成 —— 这是刻意的，拼租户条件反而会把 Key 自己的库过滤掉。
+> **管理端**（`/api/v1/memory-libraries`，控制台主体在线程上）多一层租户围栏：`t_kb_memory_library` 带 `tenant_id` 进 `FENCED_TABLES`，带 `libraryId` 的 21 个入口一律先经 `MemoryLibraryGuard` 解析库再碰从属表 —— 从属表不带租户列，跳过这一步等于没有围栏；库列表与建库两个入口无 `libraryId`，由围栏本体直接覆盖（契约 M19 §1.4，Flyway V21）。
 
 ### 14.1 AddMemory 写入与抽取时序
 

--- a/kb-rag-deploy/docs/M16-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M16-CONTRACTS.md
@@ -50,8 +50,9 @@
 
 ### 1.3 行级隔离的执行点（TenantLineInnerInterceptor）
 
-- MyBatis-Plus `TenantLineInnerInterceptor` 注册在分页插件**之前**（官方要求，租户条件必须进 count 语句）；`TenantLineHandler.getTenantId()` 取 `UserContextHolder` 的租户，无控制台主体（开放 API、后台任务线程）时**返回 null 并跳过拼接** —— 后台任务按业务 id 精确定位行，API Key 已被应用版本限定范围，再拼租户条件需要的上下文根本不在线程里。
+- MyBatis-Plus `TenantLineInnerInterceptor` 注册在分页插件**之前**（官方要求，租户条件必须进 count 语句）；`TenantLineHandler.getTenantId()` 取 `UserContextHolder` 的租户，无控制台主体（开放 API、后台任务线程）时**整条跳过拼接** —— 后台任务按业务 id 精确定位行，API Key 已被应用版本限定范围，再拼租户条件需要的上下文根本不在线程里。跳过发生在 `ignoreTable()`（无主体一律返回 true），不是靠 `getTenantId()` 返回 null：后者永远返回一个合法值（无主体时回落默认租户），只为兜住"某条路径绕过 ignoreTable 还来问租户"的情况。
 - **忽略清单**（`ignoreTable`）：除 §1.2 六张根聚合表外全部忽略。从属表靠父表裁剪；`t_kb_tenant`、`t_kb_permission`、`t_kb_auth_token`、两张登录/操作审计表、META 表、flyway 表天然全局。
+  > 后续里程碑新增的根聚合表要一并入列，这是本节的持续义务而不是一次性清单：M19 的 `t_kb_memory_library` 漏了这一步，多租户下记忆库全员可见可改，由 Flyway V21 补齐（见 M19 契约 §1.4）。判据是"该表是不是某个域的根、有没有从属表经它归属租户"——是，就加列 + 入围栏 + 让该域每个入口先解析根。
 - 平台超管跨租户：**默认租户的 SUPER_ADMIN** 是唯一能看到租户管理页的人；其余一切读写都被钉死在自己租户内，包括默认租户超管的日常操作 —— 跨租户视角只存在于 `TenantController`，不存在"切换租户"的全局态，全局态是每一个越权 bug 的温床。
 - **唯一的栅栏例外**：持 `tenant:manage` 者对 `t_kb_admin_user`、`t_kb_role` 两表不拼租户条件 —— 否则运营商无法为新租户建首个账号、授其角色、移户，建出来的租户永远没人能登录。其余四张根表即使运营商也钉死本租户：库、Key、数据集、应用的日常操作不需要跨租户视角。配套约束：角色授予校验角色与用户同租户（绑定表自身无 tenant 列，栅栏拦不住这类泄漏）；username 全局唯一校验走 `@InterceptorIgnore(tenantLine)` 的跨租户查询；移户（`PUT /users/{userId}/tenant`，`tenant:manage`）清空旧角色绑定并吊销会话。
 

--- a/kb-rag-deploy/docs/M19-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M19-CONTRACTS.md
@@ -7,14 +7,15 @@
 
 - **本期做**：①记忆库/记忆片段规则/画像规则/记忆节点/用户画像/Memory Key 六实体的管理 API 与控制台页面；②开放 API 六端点（Add/Search/List/Update/Delete/GetUserProfile），语义与百炼 AddMemory 等一一对应；③LLM 抽取（片段 + 画像）、auto_update 记忆演化（PRO 版抽取对旧记忆窗口内合并去重）、过期策略（按规则天数，查询期过滤）；④检索：向量 + BM25 混合，可选意图识别 / 查询改写 / 重排三开关；⑤Memory Key 独立鉴权过滤器链（签发/禁用/轮换/删除，QPS 令牌桶）。
 - **本期不做**：短期记忆（原始对话轮次按 session 存取——调用方自维护会话上下文，属有意边界）；过期节点物理清扫任务（查询期过滤已保证不可见，列表页管理视角刻意可见）；记忆节点的引擎双写补偿任务（MySQL 是事实源，ES 副本随写随建，失败面见 §2.2）；多实例分布式限流（沿用 M4c 进程内令牌桶的单实例口径）。
-- **隔离红线（本期核心不变式）**：两层隔离**都是查询谓词而不是约定**——①一把 Memory Key 只绑定一个记忆库（应用级隔离），请求无需也无法指定 library_id；②库内按 `user_id`（记忆实体）隔离。每条语句都带 `library_id` 过滤、实体级语句再加 `user_id`；交集之外的节点对调用方等于不存在，所以越权一律 **404 而不是 403**。
-- **兼容红线**：纯新增——V20 六张新表 + 两个权限码、新 Controller/过滤器/端口，存量端点与行为零变化；`WebMvcConfig.PUBLIC_PATHS` 增 `/api/v1/memory/**`（该面鉴权由 MemoryKeyAuthFilter 承担，不走管理台拦截器）；无新增环境变量与配置键（嵌入/重排/对话模型全部复用既有 Provider 配置，零 Key 降级语义见 §3.4）。
+- **隔离红线（本期核心不变式）**：三层隔离**都是查询谓词而不是约定**——①**租户**（M16 行级围栏，见 §1.4，V21 补课）；②一把 Memory Key 只绑定一个记忆库（应用级隔离），请求无需也无法指定 library_id；③库内按 `user_id`（记忆实体）隔离。每条语句都带 `library_id` 过滤、实体级语句再加 `user_id`；交集之外的节点对调用方等于不存在，所以越权一律 **404 而不是 403**。
+  三层各管一段，不可互相替代：租户层管"哪个组织的库"（只对管理端成立），Key 绑定管"哪个应用的库"，`user_id` 管"哪个终端用户的记忆"。
+- **兼容红线**：纯新增——V20 六张新表 + 两个权限码、新 Controller/过滤器/端口，存量端点与行为零变化；V21 补租户列同样零迁移（存量库由列 DEFAULT 落入默认租户，单租户部署行为不变）；`WebMvcConfig.PUBLIC_PATHS` 增 `/api/v1/memory/**`（该面鉴权由 MemoryKeyAuthFilter 承担，不走管理台拦截器）；无新增环境变量与配置键（嵌入/重排/对话模型全部复用既有 Provider 配置，零 Key 降级语义见 §3.4）。
 
 ## 1. 数据模型（Flyway V20，6 张新表 + 权限种子）
 
 | 表 | 要点 |
 |---|---|
-| `t_kb_memory_library` | 记忆库（`ml*`）；同名校验在服务层（逻辑删除下唯一索引会挡住重建） |
+| `t_kb_memory_library` | 记忆库（`ml*`）；`tenant_id`（V21 补，见 §1.4）；同名校验在服务层（逻辑删除下唯一索引会挡住重建），随租户列落地后同名判定收缩为**租户内**唯一 —— 两个租户各建一个「客服记忆库」是正常业务，全局唯一会让后建的那个租户建不出来 |
 | `t_kb_memory_fragment_rule` | 记忆片段规则（`mfr*`）；`instruction_type`（DEFAULT 内置指令 / CUSTOM 自定义，CUSTOM 时 `instruction` 必填）、`auto_update`（1 时抽取合并更新旧记忆而非只追加）、`expire_days`（7/30/180，NULL 永不过期——存天数不存枚举串，写入时算 `expire_at`，语义在一列闭合）、`extract_version`（PRO 带旧记忆合并去重 / LITE 单次直抽）、`builtin`（建库预置「默认项目」规则，可编辑不可删除）；每库上限 50 条由服务层守 |
 | `t_kb_memory_profile_rule` | 画像规则（`mpr*`）；`fields` 整体存 JSON 数组 `[{name,description,initial_value}]`（上限 50 个）——字段只随规则整体编辑读取，没有按字段查询的入口，不拆子表 |
 | `t_kb_memory_node` | 记忆节点（`mn*`）；`source`（EXTRACTED / CUSTOM）、`meta_data`（调用方 JSON 原样存取）、`expire_at`（过期不再被检索）；唯一高频查询路径是（库，实体）翻页，索引 `idx_library_user` |
@@ -22,6 +23,20 @@
 | `t_kb_memory_app_key` | Memory Key（行 ID `mak*`，明文 `kb-mk-*`）；与 `t_kb_api_key` 同一决策：只存 SHA-256 摘要 + 展示前缀，明文仅签发响应回传一次；`qps_limit` 令牌桶上限、`status` 禁用即刻生效、`last_used_at` 异步更新 |
 
 权限种子：`memory:read`（看库/规则/记忆/调试检索）与 `memory:write`（建删库、改规则、管 Key）插入 `t_kb_permission`（module=MEMORY），并授予 `role_superadmin000` 与 `role_kbadmin00000`（沿 V16 授权口径）。
+
+### 1.4 租户隔离（Flyway V21，M19 后修复）
+
+**缺陷**：V20 建六张表时漏了 M16 的租户层。权限码只回答"这个账号能不能碰记忆库"，回答不了"能碰哪些"，于是多租户部署下任何租户持 `memory:read` 的账号能列出全部署的记忆库，持 `memory:write` 能改删其他租户的库、规则、记忆与 Memory Key。开放端不受影响（Key 绑库天然隔离），受影响的是管理端 23 个端点。
+
+**补法与 M16 §1.1 取舍①同构**：
+
+1. **只有 `t_kb_memory_library` 加 `tenant_id`**（VARCHAR(64) NOT NULL DEFAULT `'tnt_default0000000'` + `idx_tenant`，存量行由列 DEFAULT 划入默认租户、升级零迁移）。它是 memory 域的根聚合表，五张从属表（片段规则 / 画像规则 / 节点 / 画像 / Key）经 `library_id` 归属租户 —— 六张表全加列不叫隔离叫散弹枪，从属查询永远先过根表的租户行过滤。
+2. **`KbTenantLineHandler.FENCED_TABLES` 增 `t_kb_memory_library`**，根表由 MyBatis-Plus 行级围栏自动拼租户条件（列表、详情、同名校验、建库 INSERT 的 tenant_id 注入全部随之生效，与 `t_kb_knowledge_base` 完全同构）。
+3. **`MemoryLibraryGuard`：管理端带 `libraryId` 的 21 个入口先解析库**。这一条才是关键，单加列 + 进围栏是不够的：从属表不带 `tenant_id`，按 `rule_id` / `node_id` / `key_id` 直接寻址的入口（改删片段规则、改删画像规则、删节点、Key 的启停/轮换/删除）压根不查根表，围栏对它们形同虚设。守卫是一个独立 bean 而不是 `MemoryAdminService` 的方法 —— `MemoryAppKeyService` 需要同一个检查且是前者的依赖，反向边就是循环；同 `KbScopeGuard` 的形状与理由。检查放服务层不放 Controller：Controller 里的守卫只能护住有人记得加的那几条路径。
+   剩下 2 个入口（库列表 `GET /`、建库 `POST /`）没有 `libraryId`，由围栏本体直接覆盖 —— 列表靠 SELECT 拼租户条件，建库靠 `TenantLineInnerInterceptor` 往 INSERT 补 `tenant_id`（服务层从不 `setTenantId`，与 `KnowledgeBaseService` 同构）。**这两条是全域唯一没有第二道防线的路径**：给 `MemoryLibraryMapper` 写一条绕开围栏的自定义 SQL、或挂 `@InterceptorIgnore`，它们的隔离就直接没了。
+4. **开放端语义原样保留**：`MemoryKeyAuthFilter` 那条链上没有控制台主体，`ignoreTable` 整条跳过。这不是顺带的，是必须的 —— 那条线程上拼租户条件会把 Key 自己的库过滤掉，接口直接全灭。`MemoryAppKeyService.authenticate` 因此刻意不过守卫。
+
+**受影响的语义**：记忆库同名校验从全局唯一收缩为租户内唯一（见 §1 表格）。其余行为零变化。
 
 ## 2. 端口与实现（六边形）
 
@@ -63,6 +78,7 @@
 
 ### 3.5 管理 API（`MemoryLibraryController` → `MemoryAdminService`/`MemoryProfileService`/`MemoryAppKeyService`，23 端点）
 - 基路径 `/api/v1/memory-libraries`，全部 `@RequiresPermission(MEMORY_READ/WRITE)`，写操作 `@AuditedOperation(module=MEMORY)`。
+- **带 `libraryId` 的 21 个入口一律先经 `MemoryLibraryGuard.requireLibrary(libraryId)`**（§1.4），路径上的 `libraryId` 是唯一的归属事实源；库不在本租户 → 404，调用在触到任何从属语句之前就结束。另 2 个（库列表、建库）无 `libraryId`，由行级围栏直接覆盖。
 - 库 CRUD（5）：建库自动预置内置「默认项目」片段规则；删库级联清 Key/规则/节点/画像 + `deleteByLibrary` 清 ES（刻意非事务，与 add 同理）。
 - 片段规则（4）/ 画像规则（4）：每库各限 50 条；builtin 规则可编辑不可删除；删片段规则级联删其节点与 ES 副本；画像行物理删除（软删行会占住规则×实体唯一键）。
 - 记忆数据（4）：`GET /{id}/entities`（实体分页）、`GET /{id}/nodes`（节点分页，含过期）、`DELETE /{id}/nodes/{nodeId}`、`GET /{id}/profiles`。
@@ -90,7 +106,8 @@
 
 - `MemoryAdminServiceTest` / `MemoryApiServiceTest`（kb-app）：库/规则 CRUD 上限与级联、add 双入口与 auto_update 演化、search 意图 veto/降级/hydrate 跳过已删行、越权 404。
 - domain 纯函数测试：`MemoryExtractionParser`（UPDATE 目标窗口校验、非法输出跳过）、`MemoryKeyFactory`（前缀/摘要/展示形态）、`MemoryPromptAssembler`。
-- 全量 `mvn -B -ntp verify` 1118 测试通过；web `npm run lint` 新增代码零告警。
+- 租户隔离（V21 随修补入，§1.4）：`MemoryAdminServiceTest` 两例覆盖库不在本租户时读写入口全数 404 且**从属表一条语句都不发**（`selectOne` 全部 `never()`）；`MemoryAppKeyServiceTest` 两例覆盖 Key 五个管理入口同样被拒、且 `authenticate` 不经守卫（开放端语义不被改坏）；`KbTenantLineHandlerTest` 钉住 `t_kb_memory_library` 进围栏、五张从属表不进、无控制台主体时整条跳过。
+- 全量 `mvn -B -ntp verify` 1134 测试通过；web `npm run lint` 新增代码零告警。
 
 ## 8. 验收
 
@@ -100,3 +117,4 @@
 4. 零 Key 部署：add 直写（custom_content）成功、search 走 BM25 单路仍有结果；配 Key 后新写入带向量、混合检索生效。
 5. Key 禁用后调用 → 401 `API_KEY_DISABLED`；轮换后旧密钥立即 401；把 `qps_limit` 设 1 连打 → 429 `RATE_LIMITED`。
 6. 无 `memory:read` 的角色登录 → 菜单不可见、直贴 `/memory` 原地 403；`memory:write` 缺失时列表页只读。
+7. 租户隔离（§1.4）：建租户 B 的管理员账号（持 `memory:read`+`memory:write`）→ 登录后记忆库列表看不到租户 A 的库；拿租户 A 的 `libraryId` 直贴详情页 404；带上 A 的 `ruleId`/`nodeId`/`memoryKeyId` 直调改删接口同样 404。升级既有单租户部署：全部存量库落入默认租户，控制台行为与升级前无差。开放端回归：A 的 Memory Key 调 add/search 照常成功（那条链不拼租户条件）。

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 尚未打过 tag，以下条目全部属于首个发布版本的内容，按里程碑倒序排列。
 
+### 安全修复（M19 后修复：记忆库多租户隔离）
+
+- `[schema]` Flyway `V21__memory_library_tenant.sql`：`t_kb_memory_library` 增 `tenant_id`（NOT NULL DEFAULT `'tnt_default0000000'`，存量行由列 DEFAULT 划入默认租户、升级零迁移）+ `idx_tenant`。**修复的缺陷**：V20 建六张记忆库表时漏了 M16 的租户层，`memory:read`/`memory:write` 只回答「这个账号能不能碰记忆库」、回答不了「能碰哪些」，于是多租户部署下任何租户持 `memory:read` 的账号能列出全部署的记忆库，持 `memory:write` 能改删其他租户的库、规则、记忆节点与 Memory Key
+- 只有根聚合表加列：五张从属表（片段规则 / 画像规则 / 节点 / 画像 / Key）经 `library_id` 归属租户，与 M16 §1.1 取舍①同构——六张表全加列不叫隔离叫散弹枪，从属查询永远先过根表的租户行过滤，再多一列只是第二个可以不一致的事实源
+- `KbTenantLineHandler.FENCED_TABLES` 增 `t_kb_memory_library`：库列表、详情、同名校验、建库 INSERT 的 `tenant_id` 注入随 MyBatis-Plus 行级围栏自动生效（与 `t_kb_knowledge_base` 完全同构）
+- 新增 `MemoryLibraryGuard`，管理端**带 `libraryId` 的 21 个入口一律先解析库**。这一条是修复的关键：从属表不带 `tenant_id`，按 `rule_id` / `node_id` / `key_id` 直接寻址的入口（改删片段规则、改删画像规则、删记忆节点、Memory Key 的启停/轮换/删除）压根不查根表，只加列 + 进围栏对它们形同虚设。守卫做成独立 bean 而非 `MemoryAdminService` 的方法——`MemoryAppKeyService` 需要同一个检查且是前者的依赖，反向边就是循环；检查放服务层不放 Controller，Controller 里的守卫只护得住有人记得加的那几条路径
+- 余下 2 个入口（库列表 `GET /`、建库 `POST /`）没有 `libraryId`，由围栏本体覆盖：列表靠 SELECT 拼租户条件，建库靠 `TenantLineInnerInterceptor` 往 INSERT 补 `tenant_id`（服务层从不 `setTenantId`，与 `KnowledgeBaseService` 同构，依赖 MyBatis-Plus 默认 `NOT_NULL` 字段策略）。**这两条是记忆库域唯一没有第二道防线的路径**，任何绕开围栏的写法（自定义 mapper SQL、`@InterceptorIgnore`）会直接抹掉它们的隔离
+- **开放端行为零变化**：`MemoryKeyAuthFilter` 那条链上没有控制台主体，租户围栏整条跳过（既有语义，刻意保留——在那条线程上拼租户条件会把 Key 自己绑定的库过滤掉）；`MemoryAppKeyService.authenticate` 相应不过守卫
+- **行为变更一处**：记忆库同名校验从全局唯一收缩为租户内唯一（两个租户各建一个「客服记忆库」是正常业务）
+- 单测：`MemoryAdminServiceTest` / `MemoryAppKeyServiceTest` 各 2 例覆盖跨租户读写入口全数 404 且从属表一条语句都不发，`KbTenantLineHandlerTest` 钉住围栏名单与「无主体整条跳过」的开放端语义
+
 ### 新增（M20）
 
 - MCP 协议层（`docs/M20-CONTRACTS.md`）：知识库应用与记忆库各暴露一个 MCP Streamable HTTP 端点（`POST /api/v1/knowledge/mcp`、`POST /api/v1/memory/mcp`），任何 MCP 兼容客户端配一个 URL 加一把既有 Key 即可直接调用。手写无状态 JSON-RPC 2.0 引擎（`McpServerEngine`，支持 initialize / ping / tools/list / tools/call / notifications/*，协议版本 2025-03-26 兼容 2024-11-05，不支持批量数组），**零新增依赖**。工具集：knowledge_search / knowledge_chat（仅非流式，stream=true 报 INVALID_PARAM 指路 REST SSE）与 memory_add / memory_search / memory_list / memory_update / memory_delete / memory_get_profile，参数与返回结构同 REST 孪生端点（复用 DTO，`McpArgumentBinder` 补 jakarta Validator 显式校验）。

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/MemoryLibraryController.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/controller/MemoryLibraryController.java
@@ -48,6 +48,11 @@ import java.util.List;
  * comes from the URL path and every service call filters on it, so a rule or key of another
  * library answers 404.
  *
+ * <p>The permission codes answer "may this account touch memory libraries at all"; <em>which</em>
+ * libraries it may touch is the tenant fence on {@code t_kb_memory_library}, enforced service side
+ * through {@code MemoryLibraryGuard}. No ownership check is written here on purpose - one placed in
+ * a controller only guards the paths somebody remembered to guard.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
@@ -377,7 +382,6 @@ public class MemoryLibraryController {
     @GetMapping("/{libraryId}/keys")
     @RequiresPermission(PermissionCodes.MEMORY_READ)
     public Result<List<MemoryAppKeyResponse>> listKeys(@PathVariable String libraryId) {
-        memoryAdminService.requireLibrary(libraryId);
         return Result.success(memoryAppKeyService.listByLibrary(libraryId).stream()
                 .map(MemoryAppKeyResponse::from).toList());
     }
@@ -395,7 +399,6 @@ public class MemoryLibraryController {
             targetId = "#result.data.key.keyId")
     public Result<MemoryAppKeyIssuedResponse> issueKey(@PathVariable String libraryId,
                                                        @Valid @RequestBody MemoryAppKeyCreateRequest request) {
-        memoryAdminService.requireLibrary(libraryId);
         return Result.success(MemoryAppKeyIssuedResponse.from(
                 memoryAppKeyService.issue(libraryId, request.name(), request.qpsLimit())));
     }

--- a/kb-rag-server/kb-api/src/main/resources/db/migration/V21__memory_library_tenant.sql
+++ b/kb-rag-server/kb-api/src/main/resources/db/migration/V21__memory_library_tenant.sql
@@ -1,0 +1,21 @@
+-- M19 补课：记忆库接入 M16 的多租户行级隔离。V20 建六张表时漏了这一层，后果是多租户部署下
+-- 任何租户持 memory:read 的账号能列出全部署的记忆库、持 memory:write 能改删别人的库与 Memory Key。
+--
+-- 三条取舍，与 V17 同一套推理，写在这里免得后人重新推一遍：
+--   ① 只有 t_kb_memory_library 加 tenant_id。它是记忆库聚合的根，片段规则 / 画像规则 / 记忆节点 /
+--      用户画像 / Memory Key 五张从属表全部经 library_id 归属租户 —— 给六张表全加列不叫隔离叫散弹枪，
+--      从属查询永远先过根表的租户行过滤，再多一列只是第二个可以不一致的事实源。
+--   ② 存量行由列 DEFAULT 划入默认租户，升级零迁移，同 V17 的六张根聚合表。
+--   ③ 开放 API（MemoryKeyAuthFilter 那条链）不受影响：Memory Key 绑定唯一记忆库，隔离由 Key 的
+--      绑定关系天然完成；那条链上没有控制台主体，栅栏本就整条跳过（KbTenantLineHandler#ignoreTable）。
+--
+-- 列 DEFAULT 只服务存量行。新建记忆库时服务层从不写这一列（MemoryAdminService#createLibrary），
+-- tenant_id 由 MybatisPlusConfig 的 TenantLineInnerInterceptor 往 INSERT 注入 —— 与 V17 的六张根
+-- 聚合表同一机制。前提是 MyBatis-Plus 保持默认的 NOT_NULL 字段策略（application.yml 未覆盖
+-- insert-strategy）：改成 ignored/always 会让实体的 null tenant_id 显式进 SQL，拦截器判定"调用方
+-- 已给出租户列"而放行，建库随即撞 NOT NULL 报错。是 fast-fail，但改那个配置前先看这段。
+SET NAMES utf8mb4;
+
+ALTER TABLE t_kb_memory_library
+    ADD COLUMN tenant_id VARCHAR(64) NOT NULL DEFAULT 'tnt_default0000000' COMMENT '所属租户业务标识' AFTER library_id,
+    ADD KEY idx_tenant (tenant_id);

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryAdminService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryAdminService.java
@@ -40,6 +40,18 @@ import java.util.Set;
  * every statement filters on the library id taken from the URL path, and a row that does not
  * belong to that library answers 404, never 403.
  *
+ * <p><b>Every entry taking a library id resolves it through {@link MemoryLibraryGuard} first</b>,
+ * including the ones that address a rule or a node directly. Those could locate their row from the
+ * library id in the path alone, but only the library table carries a {@code tenant_id}: skipping the
+ * lookup would leave the subordinate statement outside the tenant fence, which is exactly how a
+ * caller of another tenant used to edit rules and keys it named by id.
+ *
+ * <p>The two entries without a library id - {@link #pageLibraries} and {@link #createLibrary} - are
+ * covered by the fence directly rather than by the guard: it trims the listing to the caller's tenant
+ * and stamps the tenant onto the insert. They are the only memory statements with no second line of
+ * defence, so anything that would take them off the fence (a hand written mapper query, an
+ * {@code @InterceptorIgnore}) removes their isolation outright.
+ *
  * <p>Cascading deletions are deliberately not one transaction. They fan out over MySQL and
  * Elasticsearch, and holding a connection across the ES round trip is the same pool hazard the add
  * path avoids around LLM calls. Instead the parent row is removed <em>last</em>, so a cascade that
@@ -67,6 +79,7 @@ public class MemoryAdminService {
     /** Lifetime of the seeded default rule. */
     private static final int BUILTIN_EXPIRE_DAYS = 180;
 
+    private final MemoryLibraryGuard memoryLibraryGuard;
     private final MemoryLibraryMapper memoryLibraryMapper;
     private final MemoryFragmentRuleMapper memoryFragmentRuleMapper;
     private final MemoryProfileRuleMapper memoryProfileRuleMapper;
@@ -184,18 +197,14 @@ public class MemoryAdminService {
     }
 
     /**
-     * Loads a library or answers 404.
+     * Loads a library visible to the caller, or answers 404. Every entry taking a library id starts
+     * here, see the class comment.
      *
      * @param libraryId library business id
      * @return live library row
      */
-    public MemoryLibrary requireLibrary(String libraryId) {
-        MemoryLibrary library = memoryLibraryMapper.selectOne(new LambdaQueryWrapper<MemoryLibrary>()
-                .eq(MemoryLibrary::getLibraryId, libraryId));
-        if (library == null) {
-            throw BizException.notFound("记忆库不存在");
-        }
-        return library;
+    private MemoryLibrary requireLibrary(String libraryId) {
+        return memoryLibraryGuard.requireLibrary(libraryId);
     }
 
     // ------------------------------------------------------------------ fragment rules
@@ -416,6 +425,7 @@ public class MemoryAdminService {
      * @param nodeId    node business id
      */
     public void deleteNode(String libraryId, String nodeId) {
+        requireLibrary(libraryId);
         MemoryNode node = memoryNodeMapper.selectOne(new LambdaQueryWrapper<MemoryNode>()
                 .eq(MemoryNode::getLibraryId, libraryId)
                 .eq(MemoryNode::getNodeId, nodeId));
@@ -486,6 +496,9 @@ public class MemoryAdminService {
     }
 
     private MemoryFragmentRule requireFragmentRule(String libraryId, String ruleId) {
+        // Resolving the library first is the tenant check, see the class comment; the rule table
+        // itself carries no tenant_id and would answer a caller of any tenant.
+        requireLibrary(libraryId);
         MemoryFragmentRule rule = memoryFragmentRuleMapper.selectOne(
                 new LambdaQueryWrapper<MemoryFragmentRule>()
                         .eq(MemoryFragmentRule::getLibraryId, libraryId)
@@ -497,6 +510,7 @@ public class MemoryAdminService {
     }
 
     private MemoryProfileRule requireProfileRule(String libraryId, String ruleId) {
+        requireLibrary(libraryId);
         MemoryProfileRule rule = memoryProfileRuleMapper.selectOne(
                 new LambdaQueryWrapper<MemoryProfileRule>()
                         .eq(MemoryProfileRule::getLibraryId, libraryId)

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryAppKeyService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryAppKeyService.java
@@ -30,6 +30,13 @@ import java.util.List;
  * authentication resolves the library and hands it to the principal instead of carrying a scope
  * list.
  *
+ * <p><b>The console entries resolve their library through {@link MemoryLibraryGuard} first</b>: the
+ * key table carries no {@code tenant_id}, so a statement filtering on {@code library_id} and
+ * {@code key_id} alone sits outside the tenant fence and would let a caller of another tenant
+ * disable, rotate or delete a key it named by id. {@link #authenticate(String)} is deliberately not
+ * guarded - it runs on the open API thread, where there is no console caller and the key's own
+ * binding is the isolation.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
@@ -37,6 +44,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemoryAppKeyService {
 
+    private final MemoryLibraryGuard memoryLibraryGuard;
     private final MemoryAppKeyMapper memoryAppKeyMapper;
     private final MemoryKeyFactory memoryKeyFactory;
     private final BizIdGenerator bizIdGenerator;
@@ -46,13 +54,14 @@ public class MemoryAppKeyService {
     /**
      * Mints a key bound to one library.
      *
-     * @param libraryId library the key will authorise, existence checked by the caller
+     * @param libraryId library the key will authorise
      * @param name      purpose note, e.g. the consuming agent's name
      * @param qpsLimit  token bucket rate, {@code null} or non positive takes the deployment default
      * @return stored row plus the plaintext, shown once and never stored
      */
     @Transactional(rollbackFor = Exception.class)
     public IssuedKey issue(String libraryId, String name, Integer qpsLimit) {
+        memoryLibraryGuard.requireLibrary(libraryId);
         MemoryKeyFactory.GeneratedKey generated = memoryKeyFactory.generate();
         MemoryAppKey key = new MemoryAppKey();
         key.setKeyId(bizIdGenerator.memoryAppKeyId());
@@ -76,6 +85,7 @@ public class MemoryAppKeyService {
      * @return keys, digests included - callers must never serialise the rows directly
      */
     public List<MemoryAppKey> listByLibrary(String libraryId) {
+        memoryLibraryGuard.requireLibrary(libraryId);
         return memoryAppKeyMapper.selectList(new LambdaQueryWrapper<MemoryAppKey>()
                 .eq(MemoryAppKey::getLibraryId, libraryId)
                 .orderByDesc(MemoryAppKey::getId));
@@ -89,6 +99,7 @@ public class MemoryAppKeyService {
      * @return key row
      */
     public MemoryAppKey require(String libraryId, String keyId) {
+        memoryLibraryGuard.requireLibrary(libraryId);
         MemoryAppKey key = memoryAppKeyMapper.selectOne(new LambdaQueryWrapper<MemoryAppKey>()
                 .eq(MemoryAppKey::getLibraryId, libraryId)
                 .eq(MemoryAppKey::getKeyId, keyId)
@@ -157,6 +168,9 @@ public class MemoryAppKeyService {
 
     /**
      * Soft deletes every key of one library, the cleanup of a library deletion.
+     *
+     * <p>The library check rides along in {@link #listByLibrary(String)} rather than being written
+     * again here; establishing ownership once covers the whole loop.
      *
      * @param libraryId library business id
      */

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryLibraryGuard.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/memory/MemoryLibraryGuard.java
@@ -1,0 +1,61 @@
+package io.kbrag.app.memory;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.domain.entity.MemoryLibrary;
+import io.kbrag.domain.mapper.MemoryLibraryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * The single point at which a console call resolves the memory library it names.
+ *
+ * <p><b>This is what makes the tenant fence reach the subordinate tables.</b> Only
+ * {@code t_kb_memory_library} carries a {@code tenant_id}, so the MyBatis fence can only trim
+ * statements against that one table; rules, nodes, profiles and keys are addressed by
+ * {@code library_id} alone and a statement over them would happily cross a tenant boundary. Routing
+ * every console entry through this lookup first turns the fence on the root into isolation for all
+ * six tables: a library of another tenant is filtered away here, and the call ends before it ever
+ * reaches a subordinate statement.
+ *
+ * <p>A bean rather than a method on {@link MemoryAdminService} because {@link MemoryAppKeyService}
+ * needs the same check and is a dependency of the admin service - the reverse edge would be a cycle.
+ * Same shape as {@code KbScopeGuard} on the knowledge side, and the same reason: an ownership check
+ * has to sit next to the data, since one placed in a controller only guards the paths somebody
+ * remembered to guard.
+ *
+ * <p>A miss answers 404, never 403, which is the M19 isolation stance: outside the caller's
+ * intersection the row does not exist as far as the caller can observe.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+@RequiredArgsConstructor
+public class MemoryLibraryGuard {
+
+    private final MemoryLibraryMapper memoryLibraryMapper;
+
+    /**
+     * Loads a library visible to the current caller, or fails.
+     *
+     * <p>The tenant clause is added by the MyBatis fence, not written here: on a console thread the
+     * statement is trimmed to the caller's tenant and a foreign library simply does not come back.
+     * On a thread without a console principal - the open API behind the memory key filter, the
+     * background tasks - the fence is skipped and this stays a plain existence check, which is the
+     * pre-existing semantics that must not change: a memory key is already bound to exactly one
+     * library, so its isolation needs no tenant clause.
+     *
+     * @param libraryId library business id
+     * @return live library row
+     * @throws BizException not found when the library does not exist or belongs to another tenant
+     */
+    public MemoryLibrary requireLibrary(String libraryId) {
+        MemoryLibrary library = memoryLibraryMapper.selectOne(new LambdaQueryWrapper<MemoryLibrary>()
+                .eq(MemoryLibrary::getLibraryId, libraryId)
+                .last("limit 1"));
+        if (library == null) {
+            throw BizException.notFound("记忆库不存在");
+        }
+        return library;
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/memory/MemoryAdminServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/memory/MemoryAdminServiceTest.java
@@ -1,6 +1,7 @@
 package io.kbrag.app.memory;
 
 import io.kbrag.app.support.MybatisLambdaCache;
+import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.domain.entity.MemoryFragmentRule;
 import io.kbrag.domain.entity.MemoryLibrary;
@@ -18,6 +19,7 @@ import io.kbrag.domain.port.MemoryStore;
 import io.kbrag.domain.service.BizIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -38,7 +40,9 @@ import static org.mockito.Mockito.when;
 /**
  * Covers the console-side invariants of the memory library: the built in rule seeded at creation
  * and shielded from deletion, the 50-rule and 50-field Bailian ceilings, the per-type instruction
- * gate, and the leaf-first cascade that keeps a failed deletion retryable.
+ * gate, the leaf-first cascade that keeps a failed deletion retryable, and the tenant boundary -
+ * every entry resolves its library first, so a library the fence filters away ends the call before
+ * any subordinate statement runs.
  *
  * @author owlzhangfq@gmail.com
  */
@@ -73,7 +77,10 @@ class MemoryAdminServiceTest {
         when(bizIdGenerator.memoryLibraryId()).thenReturn(LIBRARY_ID);
         when(bizIdGenerator.memoryFragmentRuleId()).thenReturn(RULE_ID);
         when(bizIdGenerator.memoryProfileRuleId()).thenReturn("mpr_1");
-        service = new MemoryAdminService(memoryLibraryMapper, memoryFragmentRuleMapper,
+        // The real guard over the mocked mapper, so a library the tenant fence filters away is
+        // simply a null row here - which is exactly what the fence does on a console thread.
+        service = new MemoryAdminService(new MemoryLibraryGuard(memoryLibraryMapper),
+                memoryLibraryMapper, memoryFragmentRuleMapper,
                 memoryProfileRuleMapper, memoryNodeMapper, memoryProfileMapper,
                 memoryAppKeyService, mock(MemoryProfileService.class), mock(MemoryApiService.class),
                 memoryStore, bizIdGenerator);
@@ -129,6 +136,7 @@ class MemoryAdminServiceTest {
     void shouldRefuseToDeleteTheBuiltinFragmentRule() {
         MemoryFragmentRule builtin = fragmentRuleRow();
         builtin.setBuiltin(1);
+        when(memoryLibraryMapper.selectOne(any())).thenReturn(libraryRow());
         when(memoryFragmentRuleMapper.selectOne(any())).thenReturn(builtin);
 
         assertThrows(BizException.class, () -> service.deleteFragmentRule(LIBRARY_ID, RULE_ID));
@@ -138,6 +146,7 @@ class MemoryAdminServiceTest {
 
     @Test
     void shouldCascadeTheRuleMemoriesWhenDeletingACustomRule() {
+        when(memoryLibraryMapper.selectOne(any())).thenReturn(libraryRow());
         when(memoryFragmentRuleMapper.selectOne(any())).thenReturn(fragmentRuleRow());
 
         service.deleteFragmentRule(LIBRARY_ID, RULE_ID);
@@ -193,10 +202,58 @@ class MemoryAdminServiceTest {
 
     @Test
     void shouldAnswerNotFoundForANodeOutsideTheLibrary() {
+        when(memoryLibraryMapper.selectOne(any())).thenReturn(libraryRow());
         when(memoryNodeMapper.selectOne(any())).thenReturn(null);
 
         assertThrows(BizException.class, () -> service.deleteNode(LIBRARY_ID, "mnode_missing"));
         verify(memoryStore, never()).delete(anyString());
+    }
+
+    @Test
+    void shouldRefuseEveryRuleAndNodeEntryOfALibraryOutsideTheTenant() {
+        // The tenant fence trims the library statement to the caller's tenant, so a library of
+        // another tenant comes back null. These five entries address a rule or a node directly and
+        // used to reach their subordinate statement without ever touching the library table - which
+        // is precisely how a foreign tenant could edit rules and delete memories it named by id.
+        when(memoryLibraryMapper.selectOne(any())).thenReturn(null);
+
+        // 404 rather than 403 is the contract: answering "forbidden" would confirm to another
+        // tenant that the library exists.
+        assertNotFound(() -> service.updateFragmentRule(LIBRARY_ID, RULE_ID, defaultRuleCommand("改名")));
+        assertNotFound(() -> service.deleteFragmentRule(LIBRARY_ID, RULE_ID));
+        assertNotFound(() -> service.updateProfileRule(LIBRARY_ID, "mpr_1",
+                new MemoryAdminService.ProfileRuleCommand("画像", null,
+                        List.of(new MemoryProfileField("称呼", null, null)))));
+        assertNotFound(() -> service.deleteProfileRule(LIBRARY_ID, "mpr_1"));
+        assertNotFound(() -> service.deleteNode(LIBRARY_ID, "mnode_1"));
+
+        // Nothing was read from or written to the subordinate tables: the call ends at the library.
+        verify(memoryFragmentRuleMapper, never()).selectOne(any());
+        verify(memoryProfileRuleMapper, never()).selectOne(any());
+        verify(memoryNodeMapper, never()).selectOne(any());
+        verify(memoryProfileMapper, never()).hardDeleteByRuleId(anyString());
+        verify(memoryStore, never()).delete(anyString());
+        verify(memoryStore, never()).deleteByRule(anyString(), anyString());
+    }
+
+    @Test
+    void shouldRefuseEveryReadEntryOfALibraryOutsideTheTenant() {
+        when(memoryLibraryMapper.selectOne(any())).thenReturn(null);
+
+        assertNotFound(() -> service.libraryDetail(LIBRARY_ID));
+        assertNotFound(() -> service.listFragmentRules(LIBRARY_ID));
+        assertNotFound(() -> service.listProfileRules(LIBRARY_ID));
+        assertNotFound(() -> service.pageEntities(LIBRARY_ID, null, 1, 20));
+        assertNotFound(() -> service.pageNodes(LIBRARY_ID, "u1", null, 1, 20));
+        assertNotFound(() -> service.profiles(LIBRARY_ID, "u1", null));
+        assertNotFound(() -> service.deleteLibrary(LIBRARY_ID));
+
+        verify(memoryLibraryMapper, never()).deleteById(any(Long.class));
+    }
+
+    private void assertNotFound(Executable call) {
+        BizException e = assertThrows(BizException.class, call);
+        assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
     }
 
     private void stubZeroedStatistics() {

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/memory/MemoryAppKeyServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/memory/MemoryAppKeyServiceTest.java
@@ -12,6 +12,7 @@ import io.kbrag.domain.service.BizIdGenerator;
 import io.kbrag.domain.service.MemoryKeyFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -24,8 +25,9 @@ import static org.mockito.Mockito.when;
 
 /**
  * Covers the memory key trust boundary: authentication tells "mistyped" apart from "withdrawn",
- * the principal carries the one bound library, and rotation swaps the digest while dropping the
- * stale rate limit bucket.
+ * the principal carries the one bound library, rotation swaps the digest while dropping the stale
+ * rate limit bucket, and the console entries refuse a library outside the caller's tenant while
+ * authentication stays free of that lookup.
  *
  * @author owlzhangfq@gmail.com
  */
@@ -35,6 +37,7 @@ class MemoryAppKeyServiceTest {
     private static final String KEY_ID = "mkey_1";
     private static final String PLAINTEXT = "kb-mk-0123456789abcdef0123456789abcdef0123456789abcdef";
 
+    private MemoryLibraryGuard memoryLibraryGuard;
     private MemoryAppKeyMapper memoryAppKeyMapper;
     private MemoryKeyFactory memoryKeyFactory;
     private ApiRateLimiter apiRateLimiter;
@@ -43,11 +46,12 @@ class MemoryAppKeyServiceTest {
     @BeforeEach
     void setUp() {
         MybatisLambdaCache.register(MemoryAppKey.class);
+        memoryLibraryGuard = mock(MemoryLibraryGuard.class);
         memoryAppKeyMapper = mock(MemoryAppKeyMapper.class);
         memoryKeyFactory = mock(MemoryKeyFactory.class);
         apiRateLimiter = mock(ApiRateLimiter.class);
         KbProperties properties = new KbProperties();
-        service = new MemoryAppKeyService(memoryAppKeyMapper, memoryKeyFactory,
+        service = new MemoryAppKeyService(memoryLibraryGuard, memoryAppKeyMapper, memoryKeyFactory,
                 mock(BizIdGenerator.class), apiRateLimiter, properties);
     }
 
@@ -116,6 +120,49 @@ class MemoryAppKeyServiceTest {
         assertThrows(BizException.class, () -> service.updateStatus(LIBRARY_ID, KEY_ID,
                 MemoryAppKeyStatus.DISABLED));
         verify(apiRateLimiter, never()).forget(anyString());
+    }
+
+    @Test
+    void shouldRefuseEveryConsoleEntryOfALibraryOutsideTheTenant() {
+        // The key table carries no tenant_id, so a statement on (library_id, key_id) alone sits
+        // outside the fence: without the library lookup a foreign tenant could disable, rotate or
+        // delete a key by knowing the two ids from an audit line or a screenshot.
+        when(memoryLibraryGuard.requireLibrary(LIBRARY_ID))
+                .thenThrow(BizException.notFound("记忆库不存在"));
+
+        // 404 rather than 403, same reasoning as the library entries: a 403 would confirm the
+        // library exists to a tenant that may not see it.
+        assertNotFound(() -> service.issue(LIBRARY_ID, "agent", 10));
+        assertNotFound(() -> service.listByLibrary(LIBRARY_ID));
+        assertNotFound(() -> service.updateStatus(LIBRARY_ID, KEY_ID, MemoryAppKeyStatus.DISABLED));
+        assertNotFound(() -> service.rotate(LIBRARY_ID, KEY_ID));
+        assertNotFound(() -> service.delete(LIBRARY_ID, KEY_ID));
+        assertNotFound(() -> service.deleteByLibrary(LIBRARY_ID));
+
+        verify(memoryAppKeyMapper, never()).selectOne(any());
+        verify(memoryAppKeyMapper, never()).insert(any(MemoryAppKey.class));
+        verify(memoryAppKeyMapper, never()).updateById(any(MemoryAppKey.class));
+        verify(memoryAppKeyMapper, never()).deleteById(any(Long.class));
+        verify(apiRateLimiter, never()).forget(anyString());
+    }
+
+    @Test
+    void shouldAuthenticateWithoutResolvingTheLibrary() {
+        // The open API thread has no console caller, so the fence is skipped there anyway; the
+        // isolation of that surface is the key's own binding to one library. Adding a library
+        // lookup here would cost a query per call and protect nothing.
+        when(memoryKeyFactory.looksLikeKey(PLAINTEXT)).thenReturn(true);
+        when(memoryKeyFactory.hash(PLAINTEXT)).thenReturn("digest");
+        when(memoryAppKeyMapper.selectOne(any())).thenReturn(keyRow());
+
+        service.authenticate(PLAINTEXT);
+
+        verify(memoryLibraryGuard, never()).requireLibrary(anyString());
+    }
+
+    private void assertNotFound(Executable call) {
+        BizException e = assertThrows(BizException.class, call);
+        assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
     }
 
     private MemoryAppKey keyRow() {

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbTenantLineHandler.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbTenantLineHandler.java
@@ -14,7 +14,7 @@ import java.util.Set;
 /**
  * Fences every root aggregate query to the tenant of the console caller, the M16 contract section 1.3.
  *
- * <p>Only the six root aggregate tables are fenced; every subordinate table reaches its tenant through
+ * <p>Only the root aggregate tables are fenced; every subordinate table reaches its tenant through
  * its root and is skipped here. Requests without a console principal - the open API, the background
  * task threads, the startup runners - are skipped entirely: they locate rows by exact business id, and
  * the tenant a clause would need is simply not on those threads.
@@ -22,18 +22,24 @@ import java.util.Set;
  * <p>One deliberate exception: a caller holding {@code tenant:manage} - the platform operator of the
  * default tenant - sees users and roles across tenants. That is what lets the user management screen
  * create the first account of a fresh tenant and move accounts between tenants; without it the operator
- * could create a tenant nobody can ever log in to. The other four root tables stay fenced even for the
- * operator: daily work on bases, keys, datasets and apps is pinned to the own tenant.
+ * could create a tenant nobody can ever log in to. The remaining root tables stay fenced even for the
+ * operator: daily work on bases, keys, datasets, apps and memory libraries is pinned to the own tenant.
  *
  * @author owlzhangfq@gmail.com
  */
 @Component
 public class KbTenantLineHandler implements TenantLineHandler {
 
-    /** Root aggregate tables carrying a tenant_id column, everything else is reached through them. */
+    /**
+     * Root aggregate tables carrying a tenant_id column, everything else is reached through them.
+     *
+     * <p>{@code t_kb_memory_library} joined in V21: it is the root of the memory domain, and the five
+     * subordinate memory tables - fragment rules, profile rules, nodes, profiles, keys - reach their
+     * tenant through their library, so fencing this one table isolates all six.
+     */
     private static final Set<String> FENCED_TABLES = Set.of(
             "t_kb_admin_user", "t_kb_role", "t_kb_knowledge_base",
-            "t_kb_api_key", "t_kb_eval_dataset", "t_kb_app");
+            "t_kb_api_key", "t_kb_eval_dataset", "t_kb_app", "t_kb_memory_library");
 
     /** Tables the platform operator may query across tenants, see the class comment. */
     private static final Set<String> OPERATOR_UNFENCED_TABLES = Set.of("t_kb_admin_user", "t_kb_role");

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/MemoryLibrary.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/entity/MemoryLibrary.java
@@ -13,6 +13,10 @@ import lombok.ToString;
  * between applications is the library boundary, isolation inside a library is the {@code user_id}
  * of each node - both are query predicates, never conventions.
  *
+ * <p>Above those two sits the tenant, and this is the only memory table carrying it: the root
+ * aggregate of the memory domain. Rules, nodes, profiles and keys reach their tenant through their
+ * library, which is why fencing this one table isolates all six.
+ *
  * @author owlzhangfq@gmail.com
  */
 @Getter
@@ -26,6 +30,10 @@ public class MemoryLibrary extends BaseEntity {
     /** Business identifier exposed through the API. */
     @TableField("library_id")
     private String libraryId;
+
+    /** Owning tenant business id, defaulted to the built in tenant by the V21 migration. */
+    @TableField("tenant_id")
+    private String tenantId;
 
     /** Display name; uniqueness among live rows is guarded by the service layer. */
     @TableField("name")

--- a/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/config/KbTenantLineHandlerTest.java
+++ b/kb-rag-server/kb-domain/src/test/java/io/kbrag/domain/config/KbTenantLineHandlerTest.java
@@ -28,6 +28,7 @@ class KbTenantLineHandlerTest {
     private static final String USERS_TABLE = "t_kb_admin_user";
     private static final String ROLES_TABLE = "t_kb_role";
     private static final String BASES_TABLE = "t_kb_knowledge_base";
+    private static final String MEMORY_LIBRARIES_TABLE = "t_kb_memory_library";
 
     private final KbTenantLineHandler handler = new KbTenantLineHandler();
 
@@ -39,9 +40,12 @@ class KbTenantLineHandlerTest {
     @Test
     void shouldSkipEveryTableWhenThereIsNoConsolePrincipal() {
         // The open API, the background tasks and the startup runners locate rows by exact business
-        // id; the tenant a clause would need is simply not on those threads.
+        // id; the tenant a clause would need is simply not on those threads. For the memory open
+        // API this is load bearing rather than incidental: a memory key is bound to exactly one
+        // library, and a tenant clause on that thread would filter its own library away.
         assertTrue(handler.ignoreTable(BASES_TABLE));
         assertTrue(handler.ignoreTable(USERS_TABLE));
+        assertTrue(handler.ignoreTable(MEMORY_LIBRARIES_TABLE));
     }
 
     @Test
@@ -52,6 +56,13 @@ class KbTenantLineHandlerTest {
         // tenant_id column on every table for no additional isolation.
         assertTrue(handler.ignoreTable("t_kb_document"));
         assertTrue(handler.ignoreTable("t_kb_chunk"));
+        // The five subordinate memory tables reach their tenant through their library, which the
+        // console entries resolve first - see MemoryLibraryGuard.
+        assertTrue(handler.ignoreTable("t_kb_memory_fragment_rule"));
+        assertTrue(handler.ignoreTable("t_kb_memory_profile_rule"));
+        assertTrue(handler.ignoreTable("t_kb_memory_node"));
+        assertTrue(handler.ignoreTable("t_kb_memory_profile"));
+        assertTrue(handler.ignoreTable("t_kb_memory_app_key"));
     }
 
     @Test
@@ -61,6 +72,7 @@ class KbTenantLineHandlerTest {
         assertFalse(handler.ignoreTable(BASES_TABLE));
         assertFalse(handler.ignoreTable(USERS_TABLE));
         assertFalse(handler.ignoreTable(ROLES_TABLE));
+        assertFalse(handler.ignoreTable(MEMORY_LIBRARIES_TABLE));
         assertEquals(TENANT_ID, ((StringValue) handler.getTenantId()).getValue());
     }
 
@@ -73,6 +85,7 @@ class KbTenantLineHandlerTest {
         assertTrue(handler.ignoreTable(USERS_TABLE));
         assertTrue(handler.ignoreTable(ROLES_TABLE));
         assertFalse(handler.ignoreTable(BASES_TABLE));
+        assertFalse(handler.ignoreTable(MEMORY_LIBRARIES_TABLE));
     }
 
     @Test


### PR DESCRIPTION
## 缺陷

M19 建 6 张记忆库表（Flyway V20）时漏了 M16 的租户层。`memory:read` / `memory:write` 只回答「这个账号能不能碰记忆库」，回答不了「能碰哪些」：

- 多租户部署下**任何租户**持 `memory:read` 的账号能列出全部署的记忆库；
- 持 `memory:write` 能改删其他租户的库、片段/画像规则、记忆节点与 Memory Key（后者意味着可以直接吊销别家线上智能体的凭据）。

`MemoryAdminService` 全程没有任何租户/数据范围校验，`t_kb_memory_library` 也不在 `KbTenantLineHandler.FENCED_TABLES` 里。

## 修法（照 M16 §1.1 取舍①）

**1. 只有根聚合表加列。** Flyway `V21__memory_library_tenant.sql` 给 `t_kb_memory_library` 加 `tenant_id`（`NOT NULL DEFAULT 'tnt_default0000000'` + `idx_tenant`，存量行由列 DEFAULT 划入默认租户、**升级零迁移**），并加进 `FENCED_TABLES`。五张从属表（片段规则 / 画像规则 / 节点 / 画像 / Key）不加列，经 `library_id` 归属租户——六张全加列不叫隔离叫散弹枪，从属查询永远先过根表的租户行过滤，再多一列只是第二个可以不一致的事实源。

**2. 新增 `MemoryLibraryGuard`，管理端带 `libraryId` 的 21 个入口一律先解析库。** 这一条才是修复的关键，单加列 + 进围栏是不够的：从属表不带 `tenant_id`，按 `rule_id` / `node_id` / `key_id` 直接寻址的入口（改删两类规则、删记忆节点、Key 的启停/轮换/删除）压根不查根表，围栏对它们形同虚设。

守卫做成独立 bean 而不是 `MemoryAdminService` 的方法：`MemoryAppKeyService` 需要同一个检查、且是前者的依赖，反向边就是循环。形状与理由同知识库侧的 `KbScopeGuard`。检查放服务层不放 Controller——Controller 里的守卫只护得住有人记得加的那几条路径。

余下 2 个入口（库列表 `GET /`、建库 `POST /`）没有 `libraryId`，由围栏本体覆盖：列表靠 SELECT 拼租户条件，建库靠 `TenantLineInnerInterceptor` 往 INSERT 注入 `tenant_id`（服务层从不 `setTenantId`，与 `KnowledgeBaseService` 同构）。这两条是记忆库域**唯一没有第二道防线**的路径，已在代码注释与 V21 脚本头写明。

**3. 开放端行为零变化。** `MemoryKeyAuthFilter` 那条链上没有控制台主体，围栏靠 `ignoreTable` 整条跳过——这是必须保留的既有语义，在那条线程上拼租户条件反而会把 Key 自己绑定的库过滤掉，接口直接全灭。`MemoryAppKeyService.authenticate` 相应刻意不过守卫。MCP 层（M20）落在同一前缀下、同样不受影响。

## 行为变更

**一处**：记忆库同名校验从全局唯一收缩为**租户内唯一**——两个租户各建一个「客服记忆库」是正常业务，全局唯一会让后建的那个租户建不出来。`t_kb_memory_library` 本来就没有 name 唯一索引，不会撞 DB 约束。

单租户部署（升级路径）行为完全不变：存量库全部落入内置默认租户。

## 测试

全量 `mvn -B -ntp verify` **1134 通过**（新增 4 例）：

- `MemoryAdminServiceTest` 2 例：库不在本租户时读写入口全数 404，且**从属表一条语句都不发**（`selectOne` 全部 `never()`）——这几行 verify 才是承重墙，去掉守卫后 `assertThrows` 仍会因 mapper 返回 null 而通过，但 verify 会红。
- `MemoryAppKeyServiceTest` 2 例：Key 五个管理入口同样被拒；`authenticate` 用 `verify(guard, never())` 钉住不经守卫。
- 越权一律断言 `ErrorCode.NOT_FOUND` 而非只断言 `BizException`：403 会向另一租户确认「这个库存在」，正是契约要避免的。
- `KbTenantLineHandlerTest` 扩断言：`t_kb_memory_library` 进围栏、五张从属表不进、无控制台主体时整条跳过。

## 文档（按项目铁律同 PR 修订）

- `M19-CONTRACTS.md`：新增 §1.4 租户隔离（缺陷、四条补法、行为变更），§0 隔离红线从两层改三层，§3.5 与 §7 单测、§8 验收各补一条。
- `M16-CONTRACTS.md` §1.3：补「新增根聚合表要一并入围栏」的持续义务（M19 正是漏了这一步），并纠正 `getTenantId()` 返回 null 的陈述——实际跳过发生在 `ignoreTable()`。
- `ARCHITECTURE.md` 升 v1.6（Flyway 表增 V21 行、§7.2 安全补记忆库第三层隔离）、`FLOWS.md` 升 v1.5（§14 标明两张图画的是开放端、管理端另有围栏）、server 与 deploy 两仓 CHANGELOG。

## 顺带核查：`t_kb_web_credential`（M18）——建议**不同批修**

`host` 全局唯一无 `tenant_id`，站点凭据确实跨租户共享，是真实缺陷。但不宜塞进本 PR：

抓取侧 `WebCredentialService.resolveFor(host)` 由 `WebSourceService.syncEnabledSources()` 这条 `@Scheduled` 链路调用，**线程上没有 principal**。若照本 PR 的方子只加列 + 进围栏，后台线程会跳过围栏，`resolveFor` 变成按 host 命中**任意租户**的凭据——把 A 租户的密码发给 B 租户的抓取请求，比现状更危险的静默错误。

正确修法需要 `resolveFor` 改签名带上租户（租户从 `WebSource.kbId` → `KnowledgeBase.tenantId` 反查）、`uk_host` 收缩为 `uk_tenant_host`，并回归 M12/M17/M18 三段抓取链路（含 JS 渲染那条）。是另一个改动面，单开 PR 更安全也更好审。