### PR TITLE
docs(readme): 将总 README 移至仓库根目录并完善内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ flowchart LR
     TK --> RS["复用 REST 孪生服务，返回结构同源<br/>业务失败 → isError:true 工具结果<br/>协议违规 → JSON-RPC error"]
 ```
 
-接入配置与工具目录见 [`MCP接入指南.md`](MCP接入指南.md)、[`记忆库接入指南.md`](记忆库接入指南.md)。
+接入配置与工具目录见 [`docs/MCP接入指南.md`](docs/MCP接入指南.md)、[`docs/记忆库接入指南.md`](docs/记忆库接入指南.md)。
 
 更完整的架构说明与全量流程图（文档/版本状态机、双写补偿、索引重建、评测运行、图路、备份恢复等），见
-[`../kb-rag-deploy/docs/ARCHITECTURE.md`](../kb-rag-deploy/docs/ARCHITECTURE.md) 与
-[`../kb-rag-deploy/docs/FLOWS.md`](../kb-rag-deploy/docs/FLOWS.md)。
+[`kb-rag-deploy/docs/ARCHITECTURE.md`](kb-rag-deploy/docs/ARCHITECTURE.md) 与
+[`kb-rag-deploy/docs/FLOWS.md`](kb-rag-deploy/docs/FLOWS.md)。
 
 ## 目录结构
 
@@ -146,20 +146,62 @@ flowchart LR
 
 ## 快速启动
 
+推荐**轻量模式（lite）**：MySQL + Elasticsearch（同时承担 BM25 与向量检索）+ MinIO，
+8GB 内存即可跑起来。不填 `DASHSCOPE_API_KEY` 即为**零 Key 模式**——不需要任何账号和
+Key，clone 下来就能看到「上传 → 检索」跑通（检索自动降级 BM25 单路，依赖模型的功能置灰并给出引导）。
+
+### 1. 拉起中间件
+
 ```bash
-cd kb-rag-deploy && cp .env.example .env
+cd kb-rag-deploy
+cp .env.example .env        # 编辑 .env：占位口令(CHANGE_ME_*)必须替换，DASHSCOPE_API_KEY 可选
+./scripts/preflight.sh lite # 校验 docker / 内存 / 端口占用 / 是否还在用占位口令
+docker compose -f docker-compose.lite.yml up -d
 ```
 
-编辑 `.env` 填入数据库口令、MinIO 密钥与（可选的）`DASHSCOPE_API_KEY`，然后拉起中间件：
+### 2. 启动应用层
 
 ```bash
-docker compose -f kb-rag-deploy/docker-compose.lite.yml up -d
+# kb-rag-server（:20000，JDK 17 + Maven）
+cd kb-rag-server && mvn -B -ntp -DskipTests package && java -jar kb-api/target/kb-rag-server.jar
 ```
 
-完整的部署模式、资源要求矩阵、各里程碑接口契约与架构流程图，见
-[`../kb-rag-deploy/README.md`](../kb-rag-deploy/README.md) 与 `../kb-rag-deploy/docs`。
+```bash
+# kb-rag-parser（:20001，Python 3.11）
+cd kb-rag-parser && python3.11 -m venv .venv && .venv/bin/pip install -r requirements.txt && .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 20001
+```
+
+```bash
+# kb-rag-web（dev :20002，Node）
+cd kb-rag-web && npm install && npm run dev
+```
+
+首次启动 kb-rag-server 时会在日志中打印随机生成的 `admin` 初始密码，登录管理台
+`http://localhost:20002` 后会强制修改密码。
+
+配置 `DASHSCOPE_API_KEY` 后重启应用层即可获得向量检索、Query 改写、重排、VLM 图片理解等全部能力；
+完整的部署模式、资源要求矩阵与 full 模式（独立 Qdrant / Redis）升级路径，见
+[`kb-rag-deploy/README.md`](kb-rag-deploy/README.md)。
+
+## 文档导航
+
+| 文档 | 内容 |
+| --- | --- |
+| [`kb-rag-deploy/README.md`](kb-rag-deploy/README.md) | 部署总入口：部署模式、环境变量、ik 分词、备份恢复、各里程碑功能说明 |
+| [`kb-rag-deploy/docs/ARCHITECTURE.md`](kb-rag-deploy/docs/ARCHITECTURE.md) | 系统整体架构 |
+| [`kb-rag-deploy/docs/FLOWS.md`](kb-rag-deploy/docs/FLOWS.md) | 全量核心流程图（状态机、双写补偿、索引重建、评测、备份恢复等） |
+| `kb-rag-deploy/docs/M1~M14-CONTRACTS.md` | 各里程碑接口契约（OpenAPI 契约见 `kb-rag-deploy/docs/openapi/`） |
+| [`docs/MCP接入指南.md`](docs/MCP接入指南.md) | MCP 客户端（Claude Desktop / Cursor 等）接入配置与工具目录 |
+| [`docs/记忆库接入指南.md`](docs/记忆库接入指南.md) | 记忆库 REST + MCP 接入、Memory Key 管理 |
+| [`docs/知识库需求文档.md`](docs/知识库需求文档.md) | 需求全集与设计取舍 |
+| [`docs/自测步骤.md`](docs/自测步骤.md) | 端到端自测清单 |
+| 各子目录 `README.md` / `CONTRIBUTING.md` / `SECURITY.md` | 子项目自身的架构细节、开发规范与安全上报渠道 |
 
 ## 安全说明
 
-`.env` 已在 `../.gitignore` 中忽略，任何真实密钥、口令均不入库；提交前请以
-`.env.example` 为模板，确保仅提交占位值。
+`.env` 已在 [`.gitignore`](.gitignore) 中忽略，任何真实密钥、口令均不入库；提交前请以
+`.env.example` 为模板，确保仅提交占位值。安全漏洞请通过各子目录的 `SECURITY.md` 渠道私下上报，不要开公开 issue。
+
+## License
+
+四个子项目均以 [Apache License 2.0](kb-rag-server/LICENSE) 许可发布。

--- a/kb-rag-deploy/docs/M1-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M1-CONTRACTS.md
@@ -122,7 +122,7 @@ public interface FulltextStore { /* upsert/delete/searchBm25(alias, text, filter
 
 - `docker-compose.yml`（full：mysql8/es8.11+ik 说明/qdrant(单容器自带存储)/minio/redis 可选/含 healthcheck+固定镜像 tag）
 - `docker-compose.lite.yml`（mysql/es/minio，8GB 档）
-- `.env.example`、`scripts/backup.sh` 骨架、`../../docs/README.md`（快速启动：lite 优先、零 Key 路径与 DashScope 路径两条明路）、`docs/`（本契约、OpenAPI 骨架 openapi/kb-server.yaml 与 parser.yaml——按 §5/§6 写 M1 端点）
+- `.env.example`、`scripts/backup.sh` 骨架、`../../README.md`（快速启动：lite 优先、零 Key 路径与 DashScope 路径两条明路）、`docs/`（本契约、OpenAPI 骨架 openapi/kb-server.yaml 与 parser.yaml——按 §5/§6 写 M1 端点）
 - ES 中文分词：M1 允许 standard 分词器起步，README 注明 ik 安装步骤（M2 落地词典）
 
 ## 9. M1 验收（照抄需求 §10，实现完成后主会话逐条验）

--- a/kb-rag-web/.github/PULL_REQUEST_TEMPLATE.md
+++ b/kb-rag-web/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 - [ ] 代码原创，未复制 LLMentor / know-engine 的任何代码片段
 - [ ] `npm run lint` 通过
 - [ ] `npm run build` 通过（tsc 类型检查 + 生产构建）
-- [ ] 涉及路由/菜单变更时已同步更新 `../../docs/README.md` 的路由表
+- [ ] 涉及路由/菜单变更时已同步更新 `kb-rag-web/README.md` 的路由表
 - [ ] 未提交任何真实密钥/凭据
 - [ ] 已更新 `CHANGELOG.md`
 


### PR DESCRIPTION
## 背景

仓库根目录没有 README（GitHub 首页空白），而 `docs/README.md` 的相对链接（目录表 `kb-rag-server/`、`../kb-rag-deploy/...` 等）明显是按根目录位置写作的，放在 `docs/` 下全部失效。

## 改动

- `git mv docs/README.md README.md`，保留历史；修正 MCP/记忆库指南与 deploy 文档的相对链接
- 快速启动重写：修正原先 `cd kb-rag-deploy` 后又用 `kb-rag-deploy/docker-compose.lite.yml` 的工作目录不一致；补齐 preflight 预检、server/parser/web 三个应用层的启动命令、admin 初始密码提示与零 Key 模式引导
- 新增「文档导航」表（deploy 总入口 / 架构与流程图 / 契约 / 各接入指南）与 License 说明
- 同步修正两处指向 `docs/README.md` 的旧引用（M1-CONTRACTS、web PR 模板——后者路由表实际在 `kb-rag-web/README.md`）

## 验证

- README 内全部相对链接已逐一校验指向真实文件
- `grep -rn "docs/README"` 确认无残留旧引用