### PR TITLE
docs(readme): 完善项目说明与快速启动流程

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kb-rag
 
 可自托管、开箱即用的企业知识库 / RAG（检索增强生成）系统：上传文档 → 自动解析切分 →
-双引擎混合检索（向量 + BM25）→ 标注与评测闭环 → 对外开放平台（REST + MCP），
+向量 + BM25 双路混合检索 → 标注与评测闭环 → 对外开放平台（REST + MCP），
 并内置面向 Agent 的记忆库（长期记忆抽取 / 画像 / 记忆检索）。
 
 **一句话架构**：Java 主服务（检索/管理编排）+ Python 解析服务（文档转 Markdown）+
@@ -10,6 +10,20 @@ MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过 dock
 
 > 本仓库由原先四个独立仓库（`kb-rag-server` / `kb-rag-parser` / `kb-rag-web` /
 > `kb-rag-deploy`）合并而成，各子项目的完整提交历史已一并保留。
+
+## 核心能力
+
+| 能力域 | 已实现能力 |
+| --- | --- |
+| 数据接入 | PDF / DOCX / TXT / Markdown / SQL / XLSX / CSV / HTML / 图片上传，聊天记录导入，网页静态或 JS 渲染抓取，登录站点凭据，外部数据源连接器 |
+| 索引与检索 | 文档版本化、可配置切分与父子分片、向量 + BM25 + 可选图路召回、RRF / 加权融合、Query 改写、重排、图片检索、多知识库路由 |
+| 质量与治理 | 分片标注、评测集与 LLM-as-judge、发布门禁、检索反馈与洞察、文档审核、有效期、回收站、索引补偿与重建 |
+| 应用与 Agent | 应用版本发布与快照回滚、知识库 REST API、MCP 工具、SSE 流式问答、Agent 长期记忆抽取 / 画像 / 检索 |
+| 企业与运维 | 多租户隔离、RBAC 与知识库数据范围、文档 ACL、LDAP / OIDC / SAML / CAS、限流与审计、Prometheus 指标、备份恢复 |
+
+当前 `main` 的实现基线覆盖 M1–M20；其中 M15 / M16 为权限与企业化能力，M17 / M18
+为网页抓取增强，M19 为记忆库，M20 为 MCP 协议层。详细边界以
+[`ARCHITECTURE.md`](kb-rag-deploy/docs/ARCHITECTURE.md) 和现有里程碑契约为准。
 
 ## 架构图
 
@@ -150,38 +164,98 @@ flowchart LR
 8GB 内存即可跑起来。不填 `DASHSCOPE_API_KEY` 即为**零 Key 模式**——不需要任何账号和
 Key，clone 下来就能看到「上传 → 检索」跑通（检索自动降级 BM25 单路，依赖模型的功能置灰并给出引导）。
 
-### 1. 拉起中间件
+### 0. 环境要求
+
+- Docker Engine / Docker Desktop，并支持 `docker compose`
+- JDK 17、Maven 3.6+
+- Python 3.11+
+- Node.js 22、npm
+- lite 模式约需 8GB 可用内存；full 模式建议 16GB 以上
+
+以下命令均从仓库根目录开始执行，应用层需要分别占用三个终端。
+
+### 1. 配置并拉起中间件
 
 ```bash
 cd kb-rag-deploy
-cp .env.example .env        # 编辑 .env：占位口令(CHANGE_ME_*)必须替换，DASHSCOPE_API_KEY 可选
+cp .env.example .env
+# 编辑 .env：所有 CHANGE_ME_* 占位口令必须替换；DASHSCOPE_API_KEY 可留空
 ./scripts/preflight.sh lite # 校验 docker / 内存 / 端口占用 / 是否还在用占位口令
 docker compose -f docker-compose.lite.yml up -d
+docker compose -f docker-compose.lite.yml ps
 ```
 
-### 2. 启动应用层
+`mysql`、`elasticsearch`、`minio` 均显示 `healthy` 后，再启动应用层。
+
+### 2. 启动解析服务（终端 A）
 
 ```bash
-# kb-rag-server（:20000，JDK 17 + Maven）
-cd kb-rag-server && mvn -B -ntp -DskipTests package && java -jar kb-api/target/kb-rag-server.jar
+cd kb-rag-parser
+python3.11 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+set -a; source ../kb-rag-deploy/.env; set +a
+.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 20001
 ```
+
+### 3. 构建并启动 Java 主服务（终端 B）
 
 ```bash
-# kb-rag-parser（:20001，Python 3.11）
-cd kb-rag-parser && python3.11 -m venv .venv && .venv/bin/pip install -r requirements.txt && .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 20001
+cd kb-rag-server
+mvn -B -ntp -DskipTests package
+set -a; source ../kb-rag-deploy/.env; set +a
+java -jar kb-api/target/kb-rag-server.jar
 ```
+
+> `source ../kb-rag-deploy/.env` 不能省略：中间件与应用必须使用同一组 MySQL / MinIO
+> 凭据。上面的写法适用于 bash / zsh；其他 Shell 请使用等价的环境变量加载方式。
+
+### 4. 启动管理台（终端 C）
 
 ```bash
-# kb-rag-web（dev :20002，Node）
-cd kb-rag-web && npm install && npm run dev
+cd kb-rag-web
+npm install
+npm run dev
 ```
 
-首次启动 kb-rag-server 时会在日志中打印随机生成的 `admin` 初始密码，登录管理台
-`http://localhost:20002` 后会强制修改密码。
+### 5. 验证
 
-配置 `DASHSCOPE_API_KEY` 后重启应用层即可获得向量检索、Query 改写、重排、VLM 图片理解等全部能力；
-完整的部署模式、资源要求矩阵与 full 模式（独立 Qdrant / Redis）升级路径，见
+```bash
+curl -fsS http://127.0.0.1:20001/health
+curl -fsS http://127.0.0.1:20000/actuator/health
+```
+
+两个接口分别返回 `{"status":"UP"}` 和整体状态 `UP` 后，打开
+`http://localhost:20002`。首次启动 kb-rag-server 时会在日志中打印随机生成的 `admin`
+初始密码，可搜索日志关键字 `bootstrap administrator created`；该密码只打印一次，首次登录后
+系统会强制修改密码，请在首次启动时立即保存。若密码丢失，只能由另一名具备 `user:manage`
+权限的管理员在用户管理中重置；当前没有未登录密码恢复入口，重启服务也不会重新生成密码。
+
+完成登录后，按下面的最短路径验证零 Key 闭环：
+
+1. 在「知识库」中新建知识库并上传一份包含可检索文本的文档。
+2. 等待文档状态变为「已就绪」。
+3. 进入「检索调试」，选择该知识库并查询文档中明确出现的关键词。
+4. 结果应返回相关分片，同时降级提示包含 `vector_route_unavailable`，表示当前按预期使用 BM25 单路召回。
+
+`DASHSCOPE_API_KEY` 是嵌入、重排、对话和视觉 Provider 的默认共享凭据。配置后重新加载 `.env`
+并重启 Java 主服务，即可使用向量检索、重排、VLM 图片理解，以及由具体操作触发的对话、评测、
+路由和记忆抽取能力；这些业务能力仍受应用版本配置、评测任务或记忆规则约束，不会在后台自动执行。
+Query 改写还需显式设置 `RETRIEVAL_REWRITE_ENABLED=true`，因为它会给每次检索增加一次模型调用，默认关闭。
+零 Key 模式下已入库文档的嵌入状态为 `SKIPPED`；补 Key 后需要在知识库详情对这些文档执行
+逐篇或批量重建，旧文档才会生成向量，不能只重启服务。
+每次修改 `.env` 后都要在启动该进程的终端重新执行 `set -a; source ../kb-rag-deploy/.env; set +a`，
+否则 Shell 仍保留旧值。
+
+完整的部署模式、资源要求矩阵与 full 模式（独立 Qdrant）升级路径，见
 [`kb-rag-deploy/README.md`](kb-rag-deploy/README.md)。
+full 编排中还预留了可选 Redis 容器，但当前 Java 主服务仍使用进程内限流，单实例运行不需要 Redis。
+
+停止本地环境时，先在三个应用终端按 `Ctrl+C`，再执行：
+
+```bash
+cd ../kb-rag-deploy # 当前终端位于任一 kb-rag-* 子目录时
+docker compose -f docker-compose.lite.yml down
+```
 
 ## 文档导航
 
@@ -190,7 +264,9 @@ cd kb-rag-web && npm install && npm run dev
 | [`kb-rag-deploy/README.md`](kb-rag-deploy/README.md) | 部署总入口：部署模式、环境变量、ik 分词、备份恢复、各里程碑功能说明 |
 | [`kb-rag-deploy/docs/ARCHITECTURE.md`](kb-rag-deploy/docs/ARCHITECTURE.md) | 系统整体架构 |
 | [`kb-rag-deploy/docs/FLOWS.md`](kb-rag-deploy/docs/FLOWS.md) | 全量核心流程图（状态机、双写补偿、索引重建、评测、备份恢复等） |
-| `kb-rag-deploy/docs/M1~M14-CONTRACTS.md` | 各里程碑接口契约（OpenAPI 契约见 `kb-rag-deploy/docs/openapi/`） |
+| `kb-rag-deploy/docs/M1-CONTRACTS.md` ～ `M17-CONTRACTS.md`、`M19-CONTRACTS.md`、`M20-CONTRACTS.md` | 已落库的里程碑实现契约；M18 的站点凭据实现与后续隔离修复见架构文档 |
+| [`kb-rag-deploy/docs/openapi/kb-server.yaml`](kb-rag-deploy/docs/openapi/kb-server.yaml) | Java 主服务 OpenAPI 契约 |
+| [`kb-rag-deploy/docs/openapi/kb-parser.yaml`](kb-rag-deploy/docs/openapi/kb-parser.yaml) | Python 解析服务 OpenAPI 契约 |
 | [`docs/MCP接入指南.md`](docs/MCP接入指南.md) | MCP 客户端（Claude Desktop / Cursor 等）接入配置与工具目录 |
 | [`docs/记忆库接入指南.md`](docs/记忆库接入指南.md) | 记忆库 REST + MCP 接入、Memory Key 管理 |
 | [`docs/知识库需求文档.md`](docs/知识库需求文档.md) | 需求全集与设计取舍 |
@@ -202,6 +278,13 @@ cd kb-rag-web && npm install && npm run dev
 `.env` 已在 [`.gitignore`](.gitignore) 中忽略，任何真实密钥、口令均不入库；提交前请以
 `.env.example` 为模板，确保仅提交占位值。安全漏洞请通过各子目录的 `SECURITY.md` 渠道私下上报，不要开公开 issue。
 
-## License
+## 许可与第三方依赖
 
-四个子项目均以 [Apache License 2.0](kb-rag-server/LICENSE) 许可发布。
+四个子项目的项目代码均以 Apache License 2.0 许可发布：
+[`server`](kb-rag-server/LICENSE)、[`parser`](kb-rag-parser/LICENSE)、
+[`web`](kb-rag-web/LICENSE)、[`deploy`](kb-rag-deploy/LICENSE)。
+
+需要特别注意：`kb-rag-parser` 当前直接依赖 PyMuPDF，而该依赖采用 AGPL-3.0 / 商业许可
+双重授权。分发或以网络服务形式部署前，请先阅读
+[`kb-rag-parser/README.md`](kb-rag-parser/README.md#许可注意) 与
+[`kb-rag-parser/NOTICE`](kb-rag-parser/NOTICE)，并根据实际使用方式完成许可证合规评估。


### PR DESCRIPTION
## 变更内容

- 新增项目能力矩阵，补齐 M1-M20、企业化、记忆库和 MCP 能力说明
- 重写 lite / 零 Key 快速启动流程，补充环境要求、环境变量加载、启动顺序和健康检查
- 增加上传到检索的最短验证闭环，并说明补 Key 后旧文档需要重建向量
- 明确模型能力开关、管理员初始密码、Redis 当前边界和本地环境停止方式
- 更新里程碑、OpenAPI、MCP 文档导航及 PyMuPDF 许可证风险说明

## 验证

- git diff --check 通过
- README 中 20 个本地链接全部存在
- 按新用户视角复核启动、验证、补 Key 和停止流程，无阻塞步骤

## 影响范围

仅修改根 README，不改变运行时代码、配置或接口行为。
