### PR TITLE
fix(security): isolate Actuator management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ npm run dev
 
 ```bash
 curl -fsS http://127.0.0.1:20001/health
-curl -fsS http://127.0.0.1:20000/actuator/health
+curl -fsS http://127.0.0.1:20003/actuator/health
 ```
 
 两个接口分别返回 `{"status":"UP"}` 和整体状态 `UP` 后，打开
@@ -229,6 +229,10 @@ curl -fsS http://127.0.0.1:20000/actuator/health
 初始密码，可搜索日志关键字 `bootstrap administrator created`；该密码只打印一次，首次登录后
 系统会强制修改密码，请在首次启动时立即保存。若密码丢失，只能由另一名具备 `user:manage`
 权限的管理员在用户管理中重置；当前没有未登录密码恢复入口，重启服务也不会重新生成密码。
+
+`20003` 是默认只绑定 `127.0.0.1` 的独立管理端口，不与 `20000` 业务端口共同暴露。
+远程 Prometheus 抓取方式与生产安全要求见
+[`kb-rag-deploy/docs/ACTUATOR-SECURITY.md`](kb-rag-deploy/docs/ACTUATOR-SECURITY.md)。
 
 完成登录后，按下面的最短路径验证零 Key 闭环：
 

--- a/docs/知识库需求文档.md
+++ b/docs/知识库需求文档.md
@@ -1,7 +1,7 @@
 # 企业级 RAG 知识库系统 · 需求文档
 
-> 版本：v1.20
-> 日期：2026-08-11
+> 版本：v1.21
+> 日期：2026-08-14
 > 作者：RichardFyoung / Claude
 > 状态：一期（M1–M7）、二期（M8–M13）与三期已交付批次（M14 能力对齐、M15 权限体系、M16 企业化）均已开发完成并与代码实测对齐
 > 维护说明：本文件为 monorepo `docs/` 下的需求文档；对外发布事实源为 `kb-rag-deploy/docs/知识库需求文档.md`——自 v1.18 起两份内容逐字一致，任一处修订须同步另一份（"实现偏离须在同一 PR 内修订仓库内文档"铁律）
@@ -27,6 +27,7 @@
 > - v1.18（三期 M15/M16 完成后的文档回补，并将 M14 契约先行稿转正）：①**M14 转正**——§4.13 六特性已合并主干（Flyway V15），条款去除"契约先行稿/开发中"标记；②**权限体系与单点登录**（M15，新增 §4.14）——RBAC 五内置角色 + 18 权限码（Flyway V16 五表）、`@RequiresPermission` 控制台端点全量拦截、角色级知识库数据范围（KbScopeGuard）、LDAP 域账号单点登录（登录入口不区分账号来源）、用户/角色管理界面；升级零锁死：存量账号自动授予 SUPER_ADMIN（收敛为运维职责，见 §4.15 启动提醒）；③**企业化批次**（M16，新增 §4.15）——完整多租户隔离（Flyway V17：根聚合表加 tenant_id、存量行 DEFAULT 划入默认租户零迁移、非默认租户物理索引带租户段）、文档级数据权限（visibility + t_kb_doc_acl，管理面与检索面统一裁剪）、LDAP 组同步反授角色（granted_by=MANUAL/LDAP_SYNC 语义）、SSO 三协议（OIDC / SAML 2.0 / CAS 3.0，回调以 URL fragment 交付令牌）、开放 API 终端用户反馈（`POST /api/v1/knowledge/feedback`，channel/end_user_id）、操作审计"谁"维度（t_kb_operation_audit，默认保留 180 天）；④**删库物理索引清理转正**（M4 遗留销账）——删除知识库由"引擎数据仅靠对账兜底"收口为事务提交后异步清理 ES/Qdrant 物理索引与 registry 行；⑤销账与决策更新：§13.2 权限与用户体系整节销账、D5/D17 补已演进注、§13.4 待办 2/3 销项、§4.10/§4.11 "不记谁"注补 M15/M16 已覆盖。详见 `kb-rag-deploy/docs/M15-CONTRACTS.md` / `M16-CONTRACTS.md`
 > - v1.19（M14 切分策略装配缺陷修复的文档回补）：三处"文档写了、代码没那么跑"的偏差按铁律在同 PR 内改文档。①**M14 三策略此前是死代码**——`SplitStrategy` 枚举只登记了 fixed_length/llm_semantic 两项，而配置写入以该枚举为唯一白名单，导致 separator/heading/page 三个已交付的策略在控制台保存时被拒（报 `unknown split strategy: page`），实现类与前端表单全部闲置；枚举补齐五项后策略方可选用（§4.3/§4.13）；②**`page` 策略改吃清洗后的正文**（§4.3 第 3 项 / §4.13 F3）——初版契约"从 parsed.json 取分页文本"会绕过页眉页脚/水印/正则替换/脱敏四步清洗与图片占位符替换，按页切分的库因此把未脱敏 PII 直接写进索引、分片 `image_urls` 恒空；改为 parser 逐页返回 `pages[].markdown` 切片、server 逐页清洗后拼回并记录页区间，按区间切分，与其他策略消费同一份正文；③**父子分片与切分策略并非正交**（§4.3 父子分片条）——v1.4 写的"任一策略均可开启、先用所选策略切父片"从未实现，两级切分实为定长策略与自身组合，配 llm_semantic 时静默跑定长而指纹记 llm_semantic；口径收窄为"开启父子分片时仅允许按长度切分"，与 M4b-CONTRACTS.md §4 统一。详见 `kb-rag-deploy/docs/M14-CONTRACTS.md` §4（v1.1 修订条）
 > - v1.20（工程基线与 M17-M20 现状回补）：① GitHub Actions 收敛到 monorepo 根目录唯一入口，Java / Python / Web / 部署契约四组门禁并行执行；Web 建立 Vitest 单测基线；配置校验阻止 `.env.example` 重复键、开发机绝对路径和需求文档副本漂移。② 修正配置事实：`GRAPH_EXTRACT_MAX_TOKENS` 默认 3072、Demo 目录使用仓库相对路径、full 模式预检门槛 16GB。③ §13 销账 M17 JS 渲染、M18 登录站点凭据与 M20 MCP，保留站点级爬取、API 型连接器及 MCP 最新规范兼容等真实未完成项；数据库现状更新至 Flyway V22。
+> - v1.21（Actuator 安全默认值加固）：管理端点从 `20000` 业务监听器迁至独立的 `20003` 管理监听器，默认只绑定 `127.0.0.1`；健康响应由始终暴露组件详情收敛为只返回聚合状态。新增 `MANAGEMENT_SERVER_PORT` / `MANAGEMENT_SERVER_ADDRESS` 部署变量、配置契约单测与远程 Prometheus 安全部署指南；需要远程抓取时必须显式开放地址并由防火墙或带认证的反向代理限制来源。
 
 ---
 
@@ -390,7 +391,7 @@
     | `kb.openapi.rejected` | Counter | error_code（有界枚举） | API Key 鉴权 401/429 的既有唯一出口 |
     | `kb.websource.sync` | Counter | status（同步四态） | 网页来源同步结果的既有唯一落点 |
 
-    埋点原则：只在既有横切汇聚点搭车、不进 RetrievalService 内部（评测/门禁复用检索管线，不得污染在线指标）；指标失败绝不影响业务路径；**拒绝 per-KB/per-key 无界基数标签**（Prometheus 反模式——按库统计用 §4.10 洞察报表、按 key 统计用审计统计）；上传量不单独设指标（kb.task.completed 已覆盖）；Grafana 面板与告警规则资产未随代码分发（见 §13.1）；管理端口面当前无鉴权，生产由部署侧网络隔离（控制台业务端点已由 M15 权限拦截覆盖，§4.14；/actuator 端口面仍依赖网络隔离，见 §13.1）
+    埋点原则：只在既有横切汇聚点搭车、不进 RetrievalService 内部（评测/门禁复用检索管线，不得污染在线指标）；指标失败绝不影响业务路径；**拒绝 per-KB/per-key 无界基数标签**（Prometheus 反模式——按库统计用 §4.10 洞察报表、按 key 统计用审计统计）；上传量不单独设指标（kb.task.completed 已覆盖）；Grafana 面板与告警规则资产未随代码分发（见 §13.1）；Actuator 默认运行在独立回环管理监听器 `127.0.0.1:20003`，健康响应只给聚合状态，不与 `20000` 业务端口共同暴露。远程抓取需显式修改监听地址并由防火墙或带认证的反向代理限制来源
   - 日志规范：仅 info/error 两级、英文、error 带错误码；**request_id 全链路透传**（X-Request-Id 经 kb-server → kb-parser → 模型 Provider 调用日志，三端按 request_id 串联排障）
 - **代码规范**：Java 侧 lombok、CollectionUtils 判空、JsonUtil、无魔法值；fast-fail 只在 Controller 一处；充血模型优先；**注释与公共 API 文档用英文**（D15）；**每个类/模块的类级文档注释标注 `@author owlzhangfq@gmail.com`（Python 用 `Author:` 行）**
 - **工程规范**：四仓库统一分支模型（main/dev + feature 分支）、Conventional Commits、接口先行（OpenAPI 契约），Python/Java 服务间以 HTTP + JSON 契约解耦
@@ -580,7 +581,8 @@
 
 - **原决策（历史）**：M10-M13 阶段优先知识库核心内容能力，RBAC / 多用户 / 权限裁剪延后，凡"需要身份"的能力统一归入权限体系一次补齐，避免零散引入半吊子身份概念。该决策已按计划兑现。
 - **补齐情况**：多用户与角色权限（RBAC）——M15（§4.14）；审核人 / 操作者身份记录与操作审计"谁"维度——M16 操作审计（§4.15）；开放 API 终端用户反馈——M16（`POST /api/v1/knowledge/feedback`）；多租户隔离、文档级数据权限、LDAP 组同步与 SSO——M16（§4.15）。
-- **剩余项**：`/actuator/health`、`/actuator/prometheus` 管理端口面鉴权仍未排期，生产环境继续由部署侧网络隔离兜底。
+- **加固情况**：`/actuator/health`、`/actuator/prometheus` 已迁至独立管理端口，默认只绑定回环地址；health 不再返回组件详情，业务端口不再承载 `/actuator`。
+- **剩余边界**：管理监听器不内置应用层身份认证。远程 Prometheus 抓取必须显式开放地址，并在防火墙、服务网格或带认证的反向代理处限制来源；不得直接发布到公网。
 
 ### 13.3 MCP 对接（M20 已恢复）
 

--- a/docs/自测步骤.md
+++ b/docs/自测步骤.md
@@ -35,7 +35,7 @@ cd /AI/kb-rag/kb-rag-web && npm run dev
 
 启动就绪判定：
 ```bash
-curl -s http://127.0.0.1:20000/actuator/health | head -c 60   # 期望 {"status":"UP"...
+curl -s http://127.0.0.1:20003/actuator/health | head -c 60   # 期望 {"status":"UP"...
 ```
 浏览器打开 **http://localhost:20002** → 登录。
 

--- a/kb-rag-deploy/.env.example
+++ b/kb-rag-deploy/.env.example
@@ -8,6 +8,12 @@
 # 【第一部分】应用侧契约变量（docs/M1-CONTRACTS.md §1，kb-rag-server / kb-rag-parser 消费）
 # ---------------------------------------------------------------------
 
+# kb-rag-server 业务端口与独立管理端口。Actuator 默认仅监听本机回环地址；如需由远程
+# Prometheus 抓取，必须在防火墙或带认证的反向代理之后显式修改 MANAGEMENT_SERVER_ADDRESS。
+SERVER_PORT=20000
+MANAGEMENT_SERVER_PORT=20003
+MANAGEMENT_SERVER_ADDRESS=127.0.0.1
+
 # MySQL：kb-rag-server 通过 MYSQL_HOST/PORT 连接下方 docker-compose 拉起的 MySQL 容器
 MYSQL_HOST=127.0.0.1
 # 宿主机映射端口，避开本机默认 3306；容器内 MySQL 仍监听 3306

--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Added
 
+- 新增 `docs/ACTUATOR-SECURITY.md`，说明独立管理端口的安全默认值与远程 Prometheus 抓取边界。
 - 新增 `scripts/validate_config.py` 与单元测试，统一拦截 `.env.example` 重复键、开发机绝对路径和
   两份需求文档漂移；校验已接入 monorepo 根级 CI。
 
 ### Changed
 
+- `.env.example` 新增 `MANAGEMENT_SERVER_PORT=20003` 与
+  `MANAGEMENT_SERVER_ADDRESS=127.0.0.1`；OpenAPI 健康检查条目改为独立管理端口，需求文档升至
+  v1.21。远程开放管理地址时必须同时配置防火墙、服务网格或带认证的反向代理。
 - 四个历史子仓库工作流收敛为根目录单一 CI 入口，Java、Python、Web 与部署契约并行验证。
 
 ### Fixed

--- a/kb-rag-deploy/README.md
+++ b/kb-rag-deploy/README.md
@@ -418,10 +418,12 @@ docker compose -f docker-compose.lite.yml --profile graph up -d
   注意 `DELETE /documents/{docId}` 语义已改为移入回收站（见 CHANGELOG 醒目提示）
 - **M12 URL 导入与增量同步**：网页登记即抓、定时增量同步（四态结果、hash 去重）、
   SSRF 防线；新增 `WEB_IMPORT_*` 六个变量；注意 `UPLOAD_ALLOWED_EXTENSIONS` 默认值已含 `html`
-- **M13 Prometheus 业务指标**：`/actuator/prometheus` 可抓取 `kb_search_seconds` /
+- **M13 Prometheus 业务指标**：默认从独立回环管理端口
+  `127.0.0.1:20003/actuator/prometheus` 抓取 `kb_search_seconds` /
   `kb_task_completed_total` / `kb_task_backlog` / `kb_openapi_rejected_total` /
-  `kb_websource_sync_total` 及 JVM/HTTP 基础指标；无新环境变量，该端点与 health 同口径
-  暂无鉴权，生产由部署侧网络隔离
+  `kb_websource_sync_total` 及 JVM/HTTP 基础指标；管理端口与 `20000` 业务端口分离，健康响应
+  不暴露组件详情。远程抓取必须显式修改管理地址并配置网络访问控制，见
+  [`docs/ACTUATOR-SECURITY.md`](docs/ACTUATOR-SECURITY.md)
 
 ## 竞品能力对齐（M14）
 

--- a/kb-rag-deploy/docs/ACTUATOR-SECURITY.md
+++ b/kb-rag-deploy/docs/ACTUATOR-SECURITY.md
@@ -1,0 +1,46 @@
+# Actuator 安全部署指南
+
+kb-rag-server 将 Actuator 作为独立的运维平面处理，不把健康信息和 Prometheus 指标与
+`20000` 业务 API 共同暴露。
+
+## 安全默认值
+
+| 配置 | 默认值 | 作用 |
+|---|---:|---|
+| `SERVER_PORT` | `20000` | 管理台与开放 API 业务端口 |
+| `MANAGEMENT_SERVER_PORT` | `20003` | Actuator 独立端口 |
+| `MANAGEMENT_SERVER_ADDRESS` | `127.0.0.1` | 只允许本机访问管理端口 |
+
+管理端点只暴露 `health`、`info`、`prometheus`。`health` 默认只返回聚合状态，不返回
+MySQL、Elasticsearch、MinIO、Qdrant 或 Neo4j 的组件名称、地址与失败详情；具体原因从应用
+日志排查。
+
+本机验证：
+
+```bash
+curl -fsS http://127.0.0.1:20003/actuator/health
+curl -fsS http://127.0.0.1:20003/actuator/prometheus | head
+```
+
+访问 `http://127.0.0.1:20000/actuator/health` 应得到 404，证明管理平面没有挂在业务端口。
+
+## 远程 Prometheus 抓取
+
+优先让 Prometheus 与 kb-rag-server 位于同一主机，或者通过 SSH 隧道、服务网格等受控通道
+访问回环端口。确实需要监听非回环地址时，可以显式配置：
+
+```bash
+MANAGEMENT_SERVER_ADDRESS=0.0.0.0
+MANAGEMENT_SERVER_PORT=20003
+```
+
+这两个配置只负责监听，不提供应用层身份认证。修改为非回环地址前必须同时满足：
+
+1. 云安全组或主机防火墙只允许 Prometheus 固定来源地址访问 `20003`。
+2. 不把 `20003` 发布到公网；跨不可信网络时，在前置反向代理启用 TLS 与身份认证。
+3. 反向代理只转发 `/actuator/prometheus` 和必要的健康路径，不开放其他路径。
+4. `MANAGEMENT_SERVER_PORT` 不得与 `SERVER_PORT` 相同，否则会失去独立监听器提供的隔离边界。
+
+项目不复用控制台 Bearer Token 保护 Actuator：监控采集器不是控制台用户，把两类凭据混在
+同一认证链中会扩大控制台 Token 的分发范围。需要远程采集时，认证与来源限制应收敛在专用的
+运维网络或反向代理边界。

--- a/kb-rag-deploy/docs/ARCHITECTURE.md
+++ b/kb-rag-deploy/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # kb-rag 架构文档
 
 
-> 版本：v2.2（基线 = 一期 M1-M7 + 二期 M8/M9 + 核心能力增强 M10-M13 + 竞品能力对齐 M14 + 企业化 M15/M16 + 网页抓取增强 M17/M18 + 记忆库 M19 + MCP 协议层 M20 + 记忆库租户隔离修复 V21 + 站点凭据租户隔离修复 V22 + 网页源租户解析修复 + 异步池形状与状态机修复 + 应用版本租户解析修复 + 按资源自身 id 寻址入口的租户解析修复 + 按 kbId 寻址的列表与批量入口租户解析修复 + 角色行租户归属可辨识性修复，2026-08-12；v2.1 基线为按 kbId 寻址的列表与批量入口租户解析修复，v2.0 基线为按资源自身 id 寻址入口的租户解析修复，v1.9 基线为异步池与应用版本租户解析修复，v1.8 基线为网页源租户解析修复，v1.7 基线为 V22，v1.6 基线为 V21，v1.5 基线为 M20，v1.4 基线为 M19，v1.3 基线为 M14，v1.2 基线为 M13，v1.1 基线为 M9，v1.0 基线为 M8）
-> 日期：2026-08-12
+> 版本：v2.3（基线 = v2.2 + Actuator 独立回环管理监听器与健康详情收敛，2026-08-14；v2.2 基线为角色行租户归属可辨识性修复，v2.1 基线为按 kbId 寻址的列表与批量入口租户解析修复，v2.0 基线为按资源自身 id 寻址入口的租户解析修复，v1.9 基线为异步池与应用版本租户解析修复，v1.8 基线为网页源租户解析修复，v1.7 基线为 V22，v1.6 基线为 V21，v1.5 基线为 M20，v1.4 基线为 M19，v1.3 基线为 M14，v1.2 基线为 M13，v1.1 基线为 M9，v1.0 基线为 M8）
+> 日期：2026-08-14
 > 作者：RichardFyoung / Claude
 >
 > **文档定位**：本文描述系统的实际实现架构（以代码为准），与以下文档互补——
@@ -378,8 +378,8 @@ Vite 8 + React 18 + TypeScript 6 + Ant Design 5 + react-router-dom 6 + axios；l
 ### 7.3 可观测
 
 - `request_id` 全链路：`RequestIdFilter` 入口生成 → MDC → 响应头 → `X-Request-Id` 透传 parser 与 Provider 调用日志 → `TaskDecorator` 带入异步线程。
-- 健康：Actuator 组合探针（ES 必选；Qdrant/Neo4j 仅配置时注册；MinIO；parser `/health`）。
-- 指标（M13）：`/actuator/prometheus` 可直接抓取（micrometer-registry-prometheus，与 health 同口径暂不鉴权）；`KbMetrics` 门面承载四类业务指标——`kb_search_seconds`（Timer，source/zero_hit/degraded 标签）、`kb_task_completed_total`、`kb_openapi_rejected_total`、`kb_websource_sync_total`；`TaskBacklogMetrics` 提供 `kb_task_backlog`（pending/running 两支 gauge，DB 异常回 NaN 不失败抓取）；埋点全部骑在既有横切点上，记录失败绝不影响业务路径。
+- 健康：Actuator 组合探针（ES 必选；Qdrant/Neo4j 仅配置时注册；MinIO；parser `/health`）。Actuator 默认运行在独立回环监听器 `127.0.0.1:20003`，与业务端口分离；health 只返回聚合状态，不暴露组件名称和错误详情。
+- 指标（M13）：`/actuator/prometheus` 从独立管理端口抓取（micrometer-registry-prometheus）；`KbMetrics` 门面承载四类业务指标——`kb_search_seconds`（Timer，source/zero_hit/degraded 标签）、`kb_task_completed_total`、`kb_openapi_rejected_total`、`kb_websource_sync_total`；`TaskBacklogMetrics` 提供 `kb_task_backlog`（pending/running 两支 gauge，DB 异常回 NaN 不失败抓取）；埋点全部骑在既有横切点上，记录失败绝不影响业务路径。远程抓取需要显式开放管理地址，并由防火墙或带认证的反向代理限制来源。
 - 告警：`AlertEvaluator` 三类触发 + 静默期，Webhook 未配置降级界面红点；日志仅 info/error、英文、错误码占位符。
 
 ### 7.4 一致性手法汇总

--- a/kb-rag-deploy/docs/M13-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M13-CONTRACTS.md
@@ -8,7 +8,7 @@
 - **本期做**：①激活既有 actuator 的 `/actuator/prometheus` 端点（`management.endpoints.web.exposure.include` 早已含 prometheus，缺的只是 `micrometer-registry-prometheus` 依赖）；②新增业务指标门面 `KbMetrics`（kb-app），在既有横切汇聚点埋计数器/计时器；③任务积压 gauge。JVM/HTTP 等基础指标由 actuator 自动配置免费提供，不重造。
 - **本期不做**：Grafana 面板与告警规则文件（部署侧资产，属运维文档范畴）；指标持久化（Prometheus 拉走即可）；per-KB / per-key 维度标签（kb_id、key_id 是无界基数，Prometheus 反模式——需要按库统计时用 M10 洞察报表，按 key 统计时用 M4c 审计统计，各有专门端点）；`@Timed` AOP（项目横切惯例是显式调用，不引 AOP）。
 - **埋点原则（与 M10 洞察同一哲学）**：只在**既有的横切汇聚点**搭车，不进 `RetrievalService` 内部——评测运行与发布卡点复用检索管线，不能污染在线指标。指标失败绝不影响业务路径（micrometer 计数本身无 IO，不会失败；gauge 的 DB 查询包 try/catch）。
-- **兼容红线**：纯新增，无表变更、无端点行为变化、无新环境变量；`/actuator/prometheus` 与 health 同属管理端口面，当前无鉴权（与 health 一致，生产由部署侧网络隔离，权限属后期统一补充范畴）。
+- **M13 交付时的兼容红线**：纯新增，无表变更、无端点行为变化、无新环境变量；当时 `/actuator/prometheus` 与 health 同端口且无鉴权。v1.21 已将二者迁至默认只绑定 `127.0.0.1:20003` 的独立管理监听器，并隐藏 health 组件详情，现行部署边界见 `ACTUATOR-SECURITY.md`。
 
 ## 1. 依赖（版本一律由 Spring Boot BOM 管理）
 
@@ -57,7 +57,7 @@
 
 ## 6. 验收
 
-1. 启动 kb-rag-server → `curl :20000/actuator/prometheus` 可见 `kb_search_seconds_*`、`kb_task_backlog` 等指标及 JVM/HTTP 基础指标
+1. 启动 kb-rag-server → `curl 127.0.0.1:20003/actuator/prometheus` 可见 `kb_search_seconds_*`、`kb_task_backlog` 等指标及 JVM/HTTP 基础指标（M13 初版端口为 20000，v1.21 后为独立管理端口）
 2. 管理台执行一次检索 → `kb_search_seconds_count{source="console"}` 递增；零命中查询 → `zero_hit="true"` 系列递增
 3. 上传一篇文档索引完成 → `kb_task_completed_total{type="index",status="success"}` 递增
 4. 用错误 API Key 调开放接口 → `kb_openapi_rejected_total{error_code="INVALID_API_KEY"}` 递增

--- a/kb-rag-deploy/docs/openapi/kb-server.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-server.yaml
@@ -2652,7 +2652,10 @@ paths:
     get:
       tags:
       - system
-      summary: 健康检查（含 MySQL/ES/MinIO/Qdrant 探活）
+      summary: 独立管理端口健康检查
+      description: 默认仅监听 127.0.0.1:20003，返回聚合状态但不暴露组件名称与错误详情。
+      servers:
+      - url: http://127.0.0.1:20003
       security: []
       responses:
         '200':
@@ -4998,9 +5001,11 @@ components:
       scheme: bearer
       description: '自定义 Header：Authorization: Bearer <token>。服务端 token 表/内存缓存维护，
 
-        有效期 24h；除 /api/v1/auth/login、/api/v1/auth/sso-available、/api/v1/auth/sso/**（含
+        有效期 24h；业务监听器上除 /api/v1/auth/login、/api/v1/auth/sso-available、
 
-        oidc/saml/cas 的 login 与回调）与 /actuator/** 外全部拦截。
+        /api/v1/auth/sso/**（含 oidc/saml/cas 的 login 与回调）外全部拦截。Actuator 运行在独立管理监听器，
+
+        不属于该认证链。
 
         M15 起认证之后还有一道功能权限拦截：命中 @RequiresPermission 且主体不持有其中任一权限码时返回 403 FORBIDDEN。
 

--- a/kb-rag-deploy/docs/知识库需求文档.md
+++ b/kb-rag-deploy/docs/知识库需求文档.md
@@ -1,7 +1,7 @@
 # 企业级 RAG 知识库系统 · 需求文档
 
-> 版本：v1.20
-> 日期：2026-08-11
+> 版本：v1.21
+> 日期：2026-08-14
 > 作者：RichardFyoung / Claude
 > 状态：一期（M1–M7）、二期（M8–M13）与三期已交付批次（M14 能力对齐、M15 权限体系、M16 企业化）均已开发完成并与代码实测对齐
 > 维护说明：本文件为 monorepo `docs/` 下的需求文档；对外发布事实源为 `kb-rag-deploy/docs/知识库需求文档.md`——自 v1.18 起两份内容逐字一致，任一处修订须同步另一份（"实现偏离须在同一 PR 内修订仓库内文档"铁律）
@@ -27,6 +27,7 @@
 > - v1.18（三期 M15/M16 完成后的文档回补，并将 M14 契约先行稿转正）：①**M14 转正**——§4.13 六特性已合并主干（Flyway V15），条款去除"契约先行稿/开发中"标记；②**权限体系与单点登录**（M15，新增 §4.14）——RBAC 五内置角色 + 18 权限码（Flyway V16 五表）、`@RequiresPermission` 控制台端点全量拦截、角色级知识库数据范围（KbScopeGuard）、LDAP 域账号单点登录（登录入口不区分账号来源）、用户/角色管理界面；升级零锁死：存量账号自动授予 SUPER_ADMIN（收敛为运维职责，见 §4.15 启动提醒）；③**企业化批次**（M16，新增 §4.15）——完整多租户隔离（Flyway V17：根聚合表加 tenant_id、存量行 DEFAULT 划入默认租户零迁移、非默认租户物理索引带租户段）、文档级数据权限（visibility + t_kb_doc_acl，管理面与检索面统一裁剪）、LDAP 组同步反授角色（granted_by=MANUAL/LDAP_SYNC 语义）、SSO 三协议（OIDC / SAML 2.0 / CAS 3.0，回调以 URL fragment 交付令牌）、开放 API 终端用户反馈（`POST /api/v1/knowledge/feedback`，channel/end_user_id）、操作审计"谁"维度（t_kb_operation_audit，默认保留 180 天）；④**删库物理索引清理转正**（M4 遗留销账）——删除知识库由"引擎数据仅靠对账兜底"收口为事务提交后异步清理 ES/Qdrant 物理索引与 registry 行；⑤销账与决策更新：§13.2 权限与用户体系整节销账、D5/D17 补已演进注、§13.4 待办 2/3 销项、§4.10/§4.11 "不记谁"注补 M15/M16 已覆盖。详见 `kb-rag-deploy/docs/M15-CONTRACTS.md` / `M16-CONTRACTS.md`
 > - v1.19（M14 切分策略装配缺陷修复的文档回补）：三处"文档写了、代码没那么跑"的偏差按铁律在同 PR 内改文档。①**M14 三策略此前是死代码**——`SplitStrategy` 枚举只登记了 fixed_length/llm_semantic 两项，而配置写入以该枚举为唯一白名单，导致 separator/heading/page 三个已交付的策略在控制台保存时被拒（报 `unknown split strategy: page`），实现类与前端表单全部闲置；枚举补齐五项后策略方可选用（§4.3/§4.13）；②**`page` 策略改吃清洗后的正文**（§4.3 第 3 项 / §4.13 F3）——初版契约"从 parsed.json 取分页文本"会绕过页眉页脚/水印/正则替换/脱敏四步清洗与图片占位符替换，按页切分的库因此把未脱敏 PII 直接写进索引、分片 `image_urls` 恒空；改为 parser 逐页返回 `pages[].markdown` 切片、server 逐页清洗后拼回并记录页区间，按区间切分，与其他策略消费同一份正文；③**父子分片与切分策略并非正交**（§4.3 父子分片条）——v1.4 写的"任一策略均可开启、先用所选策略切父片"从未实现，两级切分实为定长策略与自身组合，配 llm_semantic 时静默跑定长而指纹记 llm_semantic；口径收窄为"开启父子分片时仅允许按长度切分"，与 M4b-CONTRACTS.md §4 统一。详见 `kb-rag-deploy/docs/M14-CONTRACTS.md` §4（v1.1 修订条）
 > - v1.20（工程基线与 M17-M20 现状回补）：① GitHub Actions 收敛到 monorepo 根目录唯一入口，Java / Python / Web / 部署契约四组门禁并行执行；Web 建立 Vitest 单测基线；配置校验阻止 `.env.example` 重复键、开发机绝对路径和需求文档副本漂移。② 修正配置事实：`GRAPH_EXTRACT_MAX_TOKENS` 默认 3072、Demo 目录使用仓库相对路径、full 模式预检门槛 16GB。③ §13 销账 M17 JS 渲染、M18 登录站点凭据与 M20 MCP，保留站点级爬取、API 型连接器及 MCP 最新规范兼容等真实未完成项；数据库现状更新至 Flyway V22。
+> - v1.21（Actuator 安全默认值加固）：管理端点从 `20000` 业务监听器迁至独立的 `20003` 管理监听器，默认只绑定 `127.0.0.1`；健康响应由始终暴露组件详情收敛为只返回聚合状态。新增 `MANAGEMENT_SERVER_PORT` / `MANAGEMENT_SERVER_ADDRESS` 部署变量、配置契约单测与远程 Prometheus 安全部署指南；需要远程抓取时必须显式开放地址并由防火墙或带认证的反向代理限制来源。
 
 ---
 
@@ -390,7 +391,7 @@
     | `kb.openapi.rejected` | Counter | error_code（有界枚举） | API Key 鉴权 401/429 的既有唯一出口 |
     | `kb.websource.sync` | Counter | status（同步四态） | 网页来源同步结果的既有唯一落点 |
 
-    埋点原则：只在既有横切汇聚点搭车、不进 RetrievalService 内部（评测/门禁复用检索管线，不得污染在线指标）；指标失败绝不影响业务路径；**拒绝 per-KB/per-key 无界基数标签**（Prometheus 反模式——按库统计用 §4.10 洞察报表、按 key 统计用审计统计）；上传量不单独设指标（kb.task.completed 已覆盖）；Grafana 面板与告警规则资产未随代码分发（见 §13.1）；管理端口面当前无鉴权，生产由部署侧网络隔离（控制台业务端点已由 M15 权限拦截覆盖，§4.14；/actuator 端口面仍依赖网络隔离，见 §13.1）
+    埋点原则：只在既有横切汇聚点搭车、不进 RetrievalService 内部（评测/门禁复用检索管线，不得污染在线指标）；指标失败绝不影响业务路径；**拒绝 per-KB/per-key 无界基数标签**（Prometheus 反模式——按库统计用 §4.10 洞察报表、按 key 统计用审计统计）；上传量不单独设指标（kb.task.completed 已覆盖）；Grafana 面板与告警规则资产未随代码分发（见 §13.1）；Actuator 默认运行在独立回环管理监听器 `127.0.0.1:20003`，健康响应只给聚合状态，不与 `20000` 业务端口共同暴露。远程抓取需显式修改监听地址并由防火墙或带认证的反向代理限制来源
   - 日志规范：仅 info/error 两级、英文、error 带错误码；**request_id 全链路透传**（X-Request-Id 经 kb-server → kb-parser → 模型 Provider 调用日志，三端按 request_id 串联排障）
 - **代码规范**：Java 侧 lombok、CollectionUtils 判空、JsonUtil、无魔法值；fast-fail 只在 Controller 一处；充血模型优先；**注释与公共 API 文档用英文**（D15）；**每个类/模块的类级文档注释标注 `@author owlzhangfq@gmail.com`（Python 用 `Author:` 行）**
 - **工程规范**：四仓库统一分支模型（main/dev + feature 分支）、Conventional Commits、接口先行（OpenAPI 契约），Python/Java 服务间以 HTTP + JSON 契约解耦
@@ -580,7 +581,8 @@
 
 - **原决策（历史）**：M10-M13 阶段优先知识库核心内容能力，RBAC / 多用户 / 权限裁剪延后，凡"需要身份"的能力统一归入权限体系一次补齐，避免零散引入半吊子身份概念。该决策已按计划兑现。
 - **补齐情况**：多用户与角色权限（RBAC）——M15（§4.14）；审核人 / 操作者身份记录与操作审计"谁"维度——M16 操作审计（§4.15）；开放 API 终端用户反馈——M16（`POST /api/v1/knowledge/feedback`）；多租户隔离、文档级数据权限、LDAP 组同步与 SSO——M16（§4.15）。
-- **剩余项**：`/actuator/health`、`/actuator/prometheus` 管理端口面鉴权仍未排期，生产环境继续由部署侧网络隔离兜底。
+- **加固情况**：`/actuator/health`、`/actuator/prometheus` 已迁至独立管理端口，默认只绑定回环地址；health 不再返回组件详情，业务端口不再承载 `/actuator`。
+- **剩余边界**：管理监听器不内置应用层身份认证。远程 Prometheus 抓取必须显式开放地址，并在防火墙、服务网格或带认证的反向代理处限制来源；不得直接发布到公网。
 
 ### 13.3 MCP 对接（M20 已恢复）
 

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 尚未打过 tag，以下条目全部属于首个发布版本的内容，按里程碑倒序排列。
 
+### 安全加固（Actuator 管理平面）
+
+- `/actuator/health`、`/actuator/info` 与 `/actuator/prometheus` 从 `20000` 业务监听器迁至
+  独立管理监听器，默认地址为 `127.0.0.1:20003`，避免管理信息随业务 API 对外暴露。
+- `management.endpoint.health.show-details` 从 `always` 收敛为 `never`，探针只得到聚合状态，
+  组件拓扑与错误详情改由应用日志承载。
+- 新增 `MANAGEMENT_SERVER_PORT` / `MANAGEMENT_SERVER_ADDRESS` 配置契约单测；远程抓取必须
+  显式开放监听地址并在防火墙或带认证的反向代理处限制来源。
+
 ### 工程修复（monorepo 配置基线）
 
 - `kb.demo.data-dir` 的默认值由个人开发机绝对路径改为 monorepo 相对路径
@@ -217,7 +226,7 @@
 ### 新增（M13）
 
 - Prometheus 业务指标：`kb-api/pom.xml` 补齐 `micrometer-registry-prometheus` 依赖，激活既有 actuator 的 `/actuator/prometheus` 端点（JVM/HTTP 基础指标随自动配置免费提供）。业务指标经 `KbMetrics` 门面单点注册：`kb_search_seconds`（Timer，标签 source=console/open_api、zero_hit、degraded；chat-preview 管理流量不计入）、`kb_task_completed_total`（Counter，type × success/failed）、`kb_openapi_rejected_total`（Counter，按 error_code）、`kb_websource_sync_total`（Counter，按 M12 同步四态）、`kb_task_backlog`（`TaskBacklogMetrics` gauge，pending/running 两支，抓取时实查 DB，DB 异常返回 NaN 不使抓取失败）
-- 纯新增：无表变更、无新环境变量、无既有端点行为变化；该端点与 health 同口径暂不鉴权，生产由部署侧网络隔离
+- M13 交付时为纯新增：无表变更、无新环境变量、无既有端点行为变化；当时该端点与 health 同端口且依赖网络隔离。后续 Actuator 安全加固条目已将其迁至独立回环管理监听器
 
 ### 新增（M12）
 

--- a/kb-rag-server/README.md
+++ b/kb-rag-server/README.md
@@ -123,6 +123,8 @@ Query 改写 → 多库路由 → 双路/三路召回（子片粒度）→ 库�
 
 ```bash
 SERVER_PORT=20000                            # 应用端口，parser 为 20001
+MANAGEMENT_SERVER_PORT=20003                 # Actuator 独立管理端口
+MANAGEMENT_SERVER_ADDRESS=127.0.0.1          # 默认仅允许本机访问
 MYSQL_HOST=127.0.0.1  MYSQL_PORT=13306  MYSQL_DB=kb_rag  MYSQL_USER=kbrag  MYSQL_PASSWORD=
 ES_URI=http://127.0.0.1:9200
 QDRANT_URI=                                  # 轻量模式留空
@@ -191,11 +193,21 @@ CI 配置见仓库根目录 `../.github/workflows/ci.yml`（Temurin 17）。
 | 管理台 | `/api/v1/**` | `Authorization: Bearer <token>`（登录签发，默认 24h，落 `t_kb_auth_token` 只存 SHA-256 摘要） | `WebMvcConfig` 拦截器 |
 | 对外开放 | `/api/v1/knowledge/**` | `Authorization: Bearer kb-sk-***`（API Key，库里只存 SHA-256 摘要与展示前缀） | `ApiKeyAuthFilter` servlet 过滤器 |
 
-免鉴权的只有 `/api/v1/auth/login`、`/internal/dict/ik/**` 与 `/actuator/**`。
+业务监听器上，登录与 SSO 入口按流程免控制台 Token；`/internal/dict/ik/**` 是供 Elasticsearch
+轮询的显式例外。Actuator 不属于这条鉴权链，它运行在独立管理监听器上。
 
 统一响应体：成功 `{"code":"OK","message":"success","data":...,"request_id":"..."}`，失败 `{"code":"...","message":"...","request_id":"..."}`。`request_id` 在入口过滤器生成（可由 `X-Request-Id` 请求头指定），写入日志 MDC，透传给 parser 服务，并随异步线程池的 `TaskDecorator` 传到 worker 线程。
 
-`/actuator` 的暴露白名单为 `health,info,prometheus`；健康探针含 MySQL、Elasticsearch、MinIO，配置了 Qdrant / Neo4j 时各自增加一项。M13 起依赖里已包含 micrometer 的 Prometheus registry，`/actuator/prometheus` 可直接抓取：业务指标为 `kb_search_seconds`（Timer，source / zero_hit / degraded 标签）、`kb_task_completed_total`、`kb_openapi_rejected_total`、`kb_websource_sync_total` 三个 Counter 与 `kb_task_backlog`（pending / running 两支 gauge，数据库不可用时回 NaN 不失败）。该端点与 health 同口径暂不鉴权。
+`/actuator` 的暴露白名单为 `health,info,prometheus`，默认监听
+`127.0.0.1:20003`（`MANAGEMENT_SERVER_ADDRESS` / `MANAGEMENT_SERVER_PORT` 可改），不再随
+`20000` 业务端口对外暴露。健康探针含 MySQL、Elasticsearch、MinIO，配置了 Qdrant / Neo4j
+时各自增加一项；响应只返回聚合状态，不返回组件名称和错误详情。M13 起依赖里已包含
+micrometer 的 Prometheus registry，`/actuator/prometheus` 可直接抓取：业务指标为
+`kb_search_seconds`（Timer，source / zero_hit / degraded 标签）、`kb_task_completed_total`、
+`kb_openapi_rejected_total`、`kb_websource_sync_total` 三个 Counter 与 `kb_task_backlog`
+（pending / running 两支 gauge，数据库不可用时回 NaN 不失败）。需要远程抓取时必须在防火墙
+或带认证的反向代理后显式开放管理地址，详见
+`kb-rag-deploy/docs/ACTUATOR-SECURITY.md`。
 
 ## 文档导航
 
@@ -208,6 +220,7 @@ CI 配置见仓库根目录 `../.github/workflows/ci.yml`（Temurin 17）。
 | `M1~M13-CONTRACTS.md` | 各里程碑的开发契约与「实现期修订」——实现与契约的偏离都记在这里 |
 | `openapi/kb-server.yaml` | 本服务的 API 契约 |
 | `openapi/kb-parser.yaml` | parser 服务的 API 契约 |
+| [`ACTUATOR-SECURITY.md`](../kb-rag-deploy/docs/ACTUATOR-SECURITY.md) | Actuator 独立管理端口与远程 Prometheus 安全部署指南 |
 | `backup-restore.md` | 备份与恢复演练步骤、RPO/RTO |
 | `知识库需求文档.md` | 需求唯一事实源 |
 

--- a/kb-rag-server/SECURITY.md
+++ b/kb-rag-server/SECURITY.md
@@ -52,9 +52,12 @@ kb-rag-server 是自托管（self-hosted）开源知识库 / RAG 系统的主服
 - 管理台面（`/api/v1/**`，Bearer token）与对外开放面（`/api/v1/knowledge/**`，API Key）走
   **两条完全独立的鉴权链路**：前者是 MVC 拦截器，后者是 servlet 过滤器，刻意不共用入口
 - API Key 带 `app_scope` 授权范围（越权 403）与按 Key 的令牌桶限流（超限 429 + `Retry-After`）
-- 免鉴权路径只有三条：`/api/v1/auth/login`、`/actuator/**`、`/internal/dict/ik/**`。第三条是
-  给 Elasticsearch 的 ik 插件轮询词典用的（插件从 ES 进程内发起纯 HTTP 请求，无法携带 Bearer
-  Token），它只回运维手动录入的领域词，不含任何文档内容或配置
+- 业务监听器上的免控制台 Token 入口仅限登录 / SSO 流程与 `/internal/dict/ik/**`。后者供
+  Elasticsearch 的 ik 插件轮询词典（插件从 ES 进程内发起纯 HTTP 请求，无法携带 Bearer
+  Token），只返回运维手动录入的领域词，不含任何文档内容或配置
+- Actuator 运行在默认只绑定 `127.0.0.1:20003` 的独立管理监听器，业务端口不承载
+  `/actuator/**`；health 只返回聚合状态。远程开放管理地址前必须配置网络来源限制或带认证的
+  反向代理
 
 **输入与外部调用**
 

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/config/WebMvcConfig.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/config/WebMvcConfig.java
@@ -37,7 +37,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
             "/api/v1/auth/oidc/**",
             "/api/v1/auth/saml/**",
             "/api/v1/auth/cas/**",
-            "/actuator/**",
             // The open API has its own authentication chain (ApiKeyAuthFilter): an API key is not a console
             // session, and letting the console interceptor see these paths would reject every external call
             // for missing a token it is not supposed to have.

--- a/kb-rag-server/kb-api/src/main/java/io/kbrag/api/filter/AuthInterceptor.java
+++ b/kb-rag-server/kb-api/src/main/java/io/kbrag/api/filter/AuthInterceptor.java
@@ -16,9 +16,11 @@ import java.util.Optional;
 /**
  * Verifies the bearer token of every management call and binds the caller for the rest of the request.
  *
- * <p>The login endpoint and the actuator are excluded by the MVC registration; everything else needs a
- * valid token. Using a custom header instead of a cookie removes cross site request forgery from the
- * threat model entirely.
+ * <p>The login and single sign-on entry points are excluded by the MVC registration; everything else
+ * under the management API needs a valid token. Actuator runs on its own loopback-only management
+ * listener and is therefore outside this interceptor's {@code /api/**} and {@code /internal/**} scope.
+ * Using a custom header instead of a cookie removes cross site request forgery from the threat model
+ * entirely.
  *
  * <p>The permissions of the caller are resolved once here rather than wherever they happen to be needed,
  * so a single request cannot see a grant change take effect halfway through it.

--- a/kb-rag-server/kb-api/src/main/resources/application.yml
+++ b/kb-rag-server/kb-api/src/main/resources/application.yml
@@ -48,13 +48,20 @@ mybatis-plus:
       logic-not-delete-value: 0
 
 management:
+  server:
+    # Actuator is an operations surface, not a business API. Keep it on a separate loopback-only
+    # listener by default so health details and metrics are not published with the console API.
+    port: ${MANAGEMENT_SERVER_PORT:20003}
+    address: ${MANAGEMENT_SERVER_ADDRESS:127.0.0.1}
   endpoints:
     web:
       exposure:
         include: health,info,prometheus
   endpoint:
     health:
-      show-details: always
+      # Component names and failure details reveal deployment topology. The aggregate status is
+      # sufficient for probes; operators should use logs to diagnose a DOWN response.
+      show-details: never
   health:
     defaults:
       enabled: true

--- a/kb-rag-server/kb-api/src/test/java/io/kbrag/api/config/ActuatorConfigurationTest.java
+++ b/kb-rag-server/kb-api/src/test/java/io/kbrag/api/config/ActuatorConfigurationTest.java
@@ -1,0 +1,60 @@
+package io.kbrag.api.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Pins the secure-by-default management listener contract without starting external dependencies.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class ActuatorConfigurationTest {
+
+    private static final String APPLICATION_CONFIG = "application.yml";
+
+    @Test
+    void shouldKeepActuatorOnAnIndependentLoopbackListener() throws IOException {
+        StandardEnvironment environment = loadEnvironment(Map.of());
+
+        assertEquals("20003", environment.getProperty("management.server.port"));
+        assertEquals("127.0.0.1", environment.getProperty("management.server.address"));
+        assertEquals("never", environment.getProperty("management.endpoint.health.show-details"));
+        assertEquals("health,info,prometheus",
+                environment.getProperty("management.endpoints.web.exposure.include"));
+        assertNotEquals(environment.getProperty("server.port"),
+                environment.getProperty("management.server.port"));
+    }
+
+    @Test
+    void shouldAllowDeploymentToMoveTheIsolatedManagementListener() throws IOException {
+        StandardEnvironment environment = loadEnvironment(Map.of(
+                "MANAGEMENT_SERVER_PORT", "19090",
+                "MANAGEMENT_SERVER_ADDRESS", "10.0.0.8"));
+
+        assertEquals("19090", environment.getProperty("management.server.port"));
+        assertEquals("10.0.0.8", environment.getProperty("management.server.address"));
+        assertEquals("never", environment.getProperty("management.endpoint.health.show-details"));
+    }
+
+    private StandardEnvironment loadEnvironment(Map<String, Object> overrides) throws IOException {
+        StandardEnvironment environment = new StandardEnvironment();
+        MutablePropertySources sources = environment.getPropertySources();
+        sources.addFirst(new MapPropertySource("testOverrides", overrides));
+        List<PropertySource<?>> yamlSources = new YamlPropertySourceLoader()
+                .load(APPLICATION_CONFIG, new ClassPathResource(APPLICATION_CONFIG));
+        yamlSources.forEach(sources::addLast);
+        return environment;
+    }
+}


### PR DESCRIPTION
## 变更说明

- 将 Actuator 从 20000 业务监听器迁移到独立的 20003 管理监听器
- 默认仅绑定 127.0.0.1，避免健康信息和 Prometheus 指标随业务 API 对外暴露
- 健康检查默认只返回聚合状态，不暴露组件名称与错误详情
- 删除无效的 Actuator MVC 公共路径声明，补齐配置契约测试
- 同步 README、安全策略、架构、OpenAPI、需求文档、CHANGELOG 与远程 Prometheus 运维指南

## 安全边界

管理监听器不内置应用层认证。远程抓取必须显式开放地址，并由防火墙、服务网格或带认证的反向代理限制来源，不得直接发布到公网。

## 验证

- 完整 Java Maven verify 通过
- Actuator 配置契约测试 2 例通过
- 部署单元测试 4 例通过
- 配置事实源校验通过
- 四组 Docker Compose 配置解析通过
- OpenAPI YAML、Shell 语法、Git diff 与需求文档双副本一致性校验通过