### PR TITLE
fix: 补齐 sql/htm 扩展名的契约、白名单与死代码欠账

### DIFF
--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -37,6 +37,19 @@
 
 ### Fixed
 
+- **`.htm` 上传被白名单挡下（M12 后修复）**：M12 在 kb-rag-parser 注册的是 `html` 与 `htm` 两个
+  扩展名，`UPLOAD_ALLOWED_EXTENSIONS` 默认值当期却只追加了 `html`。上传路径唯一的校验闸门
+  `UploadValidator` 因此把 `.htm` 判为 `unsupported file extension`——解析侧支持、入口不放行，
+  **运维视角看到的是「同一个网页存成 .htm 就传不进去」**；同一份白名单还管着 M14 外部数据源同步的
+  对象过滤，对象存储桶里的 `.htm` 对象一直被静默跳过（不报错、不计失败，只是不入库）。默认值补
+  `htm`。另修一处只影响测试的漂移：`KbProperties` 的兜底默认值里连 `html` 都没有，真实部署总由
+  yml 覆盖故**生产无影响**，但单测吃的是兜底值、`.html` 在测试中一直是被拒的，已补齐为与 yml
+  逐项一致。**无 Flyway、无新增环境变量与配置键，升级零操作**；`kb-server.yaml` 的上传端点补了
+  白名单口径说明（**纯描述订正，schema 与版本号不变**，仍为 `0.26.0-m24`）。
+  **唯一对外行为变更**：`.htm` 由 400 变为可上传。**运维提醒**：已在 `.env` 里显式写死过
+  `UPLOAD_ALLOWED_EXTENSIONS` 的部署不会自动获得 `htm`，需要手动把它补进那一行（与 M12 追加
+  `html`、`f8f925c` 追加 `sql` 时同一口径）。
+
 - **解析服务契约漏记 `sql` 扩展名（`f8f925c` 后修复）**：`sql` 自 2026-07-29 那次 pdf 乱码页修复起
   就已是 kb-rag-parser 的正式支持格式（与 `txt`/`md` 共用纯文本解析器，`app/parsers/registry.py`
   已注册、pytest 有专门用例），kb-rag-server 的 `UPLOAD_ALLOWED_EXTENSIONS` 默认值同期也已放行；

--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -37,6 +37,18 @@
 
 ### Fixed
 
+- **解析服务契约漏记 `sql` 扩展名（`f8f925c` 后修复）**：`sql` 自 2026-07-29 那次 pdf 乱码页修复起
+  就已是 kb-rag-parser 的正式支持格式（与 `txt`/`md` 共用纯文本解析器，`app/parsers/registry.py`
+  已注册、pytest 有专门用例），kb-rag-server 的 `UPLOAD_ALLOWED_EXTENSIONS` 默认值同期也已放行；
+  唯独三处对外文档的扩展名清单没跟着改——`docs/openapi/kb-parser.yaml` 的 `SupportedFileExt` 枚举、
+  `docs/ARCHITECTURE.md` §4.2 的端点表、`kb-rag-parser/README.md` 的 `file_ext` 说明与支持格式表。
+  **后果**：照契约对接解析服务的人会以为 `file_ext=sql` 会被 400 拒绝，从而绕开一个早已可用的格式；
+  排障时反过来也会把「这套部署能传 .sql」误判成实现越界。本次按实现补齐这三处清单。
+  **无 Flyway 脚本、无新增环境变量与配置键、无代码改动，升级零操作**；`kb-parser.yaml` 属
+  **纯描述订正，schema 与版本号不变**（仍为 `0.14.0-m14`），服务端本就接受 `sql`，对外行为零变更。
+  **运维提醒（沿用 `f8f925c` 的口径）**：已在 `.env` 里显式写死过 `UPLOAD_ALLOWED_EXTENSIONS` 的
+  部署不会自动获得 `sql`，需要手动把它补进那一行。
+
 - 修正 `GRAPH_EXTRACT_MAX_TOKENS` 在 `.env.example` 中重复且默认值冲突的问题，统一为服务端实际
   默认值 3072；Demo 目录改为仓库相对路径；full 模式内存说明统一为当前预检执行的 16GB。
 

--- a/kb-rag-deploy/README.md
+++ b/kb-rag-deploy/README.md
@@ -118,7 +118,7 @@ lite → full 的索引迁移路径（切 `VECTOR_ENGINE=qdrant` 后从 MySQL �
 | 仓库 | 职责 | 技术栈 |
 | --- | --- | --- |
 | [kb-rag-server](../kb-rag-server) | Java 主服务：知识库/文档/索引管线编排、混合检索、管理台 API | JDK 17、Spring Boot 3.3.x、MyBatis-Plus、Flyway |
-| [kb-rag-parser](../kb-rag-parser) | Python 文档解析服务：pdf/docx/txt/md/xlsx/csv → Markdown | Python 3.11、FastAPI |
+| [kb-rag-parser](../kb-rag-parser) | Python 文档解析服务：pdf/docx/txt/md/sql/xlsx/csv/html/htm → Markdown | Python 3.11、FastAPI |
 | [kb-rag-web](../kb-rag-web) | 前端管理台：登录、知识库管理、检索调试 | React 18、TypeScript、Vite、Ant Design 5 |
 | **kb-rag-deploy**（本仓库） | docker-compose、环境变量模板、OpenAPI 接口契约、部署文档 | docker-compose |
 

--- a/kb-rag-deploy/docs/ARCHITECTURE.md
+++ b/kb-rag-deploy/docs/ARCHITECTURE.md
@@ -293,7 +293,7 @@ Python 3.11+ / FastAPI + Uvicorn / pydantic 2。解析实现：**PyMuPDF**（pdf
 | 端点 | 用途 |
 |---|---|
 | `GET /health` | 存活探针 |
-| `POST /api/v1/parse` | multipart `file` + `file_ext`（pdf/docx/txt/md/xlsx/csv/html/htm，html 为 M12 增量）→ markdown + 按页文本与该页 markdown 切片（`scanned`/`ocr_source` 标记，`markdown` 为 M14 增量）+ 图片 base64（`kind=embedded|page_render`）+ `warnings[]` |
+| `POST /api/v1/parse` | multipart `file` + `file_ext`（pdf/docx/txt/md/sql/xlsx/csv/html/htm，html 为 M12 增量，sql 与 txt/md 共用纯文本解析器）→ markdown + 按页文本与该页 markdown 切片（`scanned`/`ocr_source` 标记，`markdown` 为 M14 增量）+ 图片 base64（`kind=embedded|page_render`）+ `warnings[]` |
 | `POST /api/v1/parse/chat` | multipart `file` + `file_ext`（csv/xlsx/txt/html）+ 可选 `mapping_profile`/`profile_yaml` → 统一 ChatMessage 会话结构 + `skipped` 统计 |
 
 ### 4.3 模块结构

--- a/kb-rag-deploy/docs/M12-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M12-CONTRACTS.md
@@ -35,6 +35,7 @@
 
 ### 3.1 上传白名单（UploadValidator，一行配置）
 - `application.yml` `kb.upload.allowed-extensions` 默认值追加 `html`（html 无魔数，UploadValidator 的 MAGIC 表不动——文本格式本就"仅验扩展名与大小"）。
+- **`htm` 补齐（后补，与代码一致）**：解析侧 §2 注册的是 `html`/`htm` 两个扩展名，上传白名单当期只追加了 `html`——`UploadValidator` 是上传路径唯一的 fast-fail 闸门，`.htm` 在那里即被判 `unsupported file extension: htm`，到不了解析服务；同一份白名单还管着 M14 外部数据源同步的对象过滤（`ExtSourceService`），桶里的 `.htm` 同样被静默跳过。默认值现补 `htm`，与解析侧注册表对齐。另：`KbProperties.Upload#allowedExtensions` 的兜底 `List.of(...)` 当期未同步追加 `html`，真实部署由 yml 覆盖故生产无影响，但直接 `new KbProperties()` 的单元测试一直把 `.html` 判为不支持——兜底值已补齐为与 yml 逐项一致。
 
 ### 3.2 SSRF 防线（UrlGuard，kb-domain service）
 - `UrlGuard.validate(url)`：仅 `http/https`；禁 userinfo（`user@host` 形态直接拒）；host 解析出的**每个** InetAddress 均须非回环/非私网（10/172.16-31/192.168）/非链路本地（169.254）/非组播/非通配（0.0.0.0）；解析失败 → INVALID_PARAM。中文拒绝消息（如"该地址指向内网，禁止抓取"）。

--- a/kb-rag-deploy/docs/openapi/kb-parser.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-parser.yaml
@@ -193,7 +193,10 @@ components:
       type: string
       description: |
         html/htm 为 M12 增量（docs/M12-CONTRACTS.md §2，通用 HTML 页面解析）。
-      enum: [pdf, docx, txt, md, xlsx, csv, html, htm]
+        sql 与 txt/md 共用纯文本解析器（原样透传，不臆造 markdown 语法），实现自
+        2026-07-29 起即已支持（同期 kb-rag-server 的 UPLOAD_ALLOWED_EXTENSIONS 默认值
+        也已放行），本枚举当时漏记，此处按实现补齐——非新增能力，故 schema 与版本号不变。
+      enum: [pdf, docx, txt, md, sql, xlsx, csv, html, htm]
 
     ChatFileExt:
       type: string

--- a/kb-rag-deploy/docs/openapi/kb-server.yaml
+++ b/kb-rag-deploy/docs/openapi/kb-server.yaml
@@ -1465,6 +1465,14 @@ paths:
       summary: 上传文档（异步进入索引管线）
       description: 'multipart 上传；服务端校验扩展名 + magic number + 文件大小（≤100MB）。
 
+        扩展名白名单为部署配置 kb.upload.allowed-extensions（UPLOAD_ALLOWED_EXTENSIONS），
+
+        默认放行 pdf/docx/txt/md/sql/xlsx/csv/html/htm 与 png/jpg/jpeg/webp/bmp/gif；
+
+        htm 为后补（M12 注册了 html/htm 两个解析扩展名，白名单当期只追加了 html）。
+
+        txt/md/sql/csv/html/htm 无魔数，只验扩展名与大小；不在白名单内一律 400 INVALID_PARAM。
+
         校验通过后立即返回，文档以 UPLOADED 状态异步进入解析/切分/索引管线。
 
         '

--- a/kb-rag-parser/CHANGELOG.md
+++ b/kb-rag-parser/CHANGELOG.md
@@ -13,6 +13,15 @@
 
 ### 修复
 
+- **清除 `config.py` 里两个零引用的影子白名单**：`SUPPORTED_FILE_EXTENSIONS` 与
+  `ZIP_BASED_FILE_EXTENSIONS` 全仓无任何引用——支持格式的判定一直由 `parsers/registry.py` 的
+  `_REGISTRY` 查表完成，zip 预检由 `docx.py`/`excel.py`/`chat/parser.py` 各自直接调用
+  `ensure_zip_is_safe`，两个常量从未参与决策。它们的注释却写着"kept in one place to avoid
+  scattering the whitelist across modules"，**读起来像是权威白名单**，而前者已经漂移（缺
+  `html`/`htm`，M12 加解析器时没同步）：下一个人照它判断"本服务支不支持某格式"会得到错误答案，
+  照它新增格式则改了个没人读的集合。两个常量删除，原处留一行注释指明唯一事实源是 `_REGISTRY`。
+  行为零变化（删的是死代码），`65 passed, 1 skipped` 保持不变。
+
 - **对外文档漏记 `sql` 扩展名**：`sql` 自 `f8f925c`（2026-07-29）起就已注册进 `app/parsers/registry.py`（与 `txt`/`md` 共用 `TextParser`，探测编码后原样透传），`tests/test_parse_text.py::test_parse_sql_returns_expected_structure` 一直覆盖着它，kb-rag-server 的上传白名单默认值同期也已放行——唯独三处对外文档的扩展名清单没跟着改：`kb-rag-deploy/docs/openapi/kb-parser.yaml` 的 `SupportedFileExt` 枚举、`kb-rag-deploy/docs/ARCHITECTURE.md` §4.2 的端点表、本仓 README 的 `file_ext` 说明与「支持格式一览」表。照契约对接的人会以为传 `file_ext=sql` 会被 400 拒绝，从而绕开一个早已可用的格式。本次按实现补齐这三处。**纯描述订正**：解析实现与测试均未改动，OpenAPI 的 schema 结构与版本号不变。
 
 ## [未发布] - M14

--- a/kb-rag-parser/CHANGELOG.md
+++ b/kb-rag-parser/CHANGELOG.md
@@ -11,6 +11,10 @@
 - `ImageAssetCollector` 新增 `has_capacity()`（原内联于 `try_add` 的数量上限判定提为公开方法），让调用方能在生产昂贵字节**之前**预判；warning 语义不变（每次越限追加一条）。
 - pytest 新增（`tests/test_parse_pdf_images.py`）：多页同一 logo 只报一张图且不写 warning、超上限的扫描页不再调用 `get_pixmap`、开本地 OCR 后超上限仍渲染并回填 `ocr_source`。
 
+### 修复
+
+- **对外文档漏记 `sql` 扩展名**：`sql` 自 `f8f925c`（2026-07-29）起就已注册进 `app/parsers/registry.py`（与 `txt`/`md` 共用 `TextParser`，探测编码后原样透传），`tests/test_parse_text.py::test_parse_sql_returns_expected_structure` 一直覆盖着它，kb-rag-server 的上传白名单默认值同期也已放行——唯独三处对外文档的扩展名清单没跟着改：`kb-rag-deploy/docs/openapi/kb-parser.yaml` 的 `SupportedFileExt` 枚举、`kb-rag-deploy/docs/ARCHITECTURE.md` §4.2 的端点表、本仓 README 的 `file_ext` 说明与「支持格式一览」表。照契约对接的人会以为传 `file_ext=sql` 会被 400 拒绝，从而绕开一个早已可用的格式。本次按实现补齐这三处。**纯描述订正**：解析实现与测试均未改动，OpenAPI 的 schema 结构与版本号不变。
+
 ## [未发布] - M14
 
 ### 新增

--- a/kb-rag-parser/README.md
+++ b/kb-rag-parser/README.md
@@ -83,7 +83,7 @@ python3 -m venv .venv
 | 字段 | 类型 | 说明 |
 |---|---|---|
 | `file` | file | 待解析的文档 |
-| `file_ext` | form 字段 | 文件扩展名（不带点），如 `pdf`/`docx`/`txt`/`md`/`xlsx`/`csv`/`html`/`htm` |
+| `file_ext` | form 字段 | 文件扩展名（不带点），如 `pdf`/`docx`/`txt`/`md`/`sql`/`xlsx`/`csv`/`html`/`htm` |
 
 成功响应 `data` 结构（M3-CONTRACTS.md §2.1，向后兼容 M1）：
 
@@ -159,6 +159,7 @@ html（M8-CONTRACTS.md §0.2，DOM 选择器）：
 | `docx` | python-docx | 按文档原始顺序抽取段落+表格+内嵌图片；docx 无可靠页码概念，整篇作为 `page_no=1` 返回 |
 | `txt` | 标准库 | 尽力探测编码（utf-8-sig/utf-8/gbk），原样返回 |
 | `md` | 标准库 | 原样透传，本身已是 markdown |
+| `sql` | 标准库 | 与 txt 同一解析器：探测编码后原样透传，不臆造 markdown 语法 |
 | `xlsx` | openpyxl | 每个 sheet 对应一个 `page_no`，同时渲染为 markdown 表格 |
 | `csv` | 标准库 `csv` | 自动探测分隔符（逗号/分号/tab），渲染为 markdown 表格 |
 | `html` / `htm` | 标准库 `html.parser`（M12） | 通用 HTML 页面→markdown：`<title>` 与 h1-h6 映射为标题、块级元素分段，剔除 script/style/noscript/template；单页返回（`page_no=1`）、不产出图片、绝不请求远程资源（URL 抓取与 SSRF 防护在 kb-rag-server 侧） |

--- a/kb-rag-parser/app/config.py
+++ b/kb-rag-parser/app/config.py
@@ -58,13 +58,10 @@ PARSE_TIMEOUT_SECONDS = 300
 # (MySQL/ES/Qdrant, typically).
 PARSER_EXECUTOR_MAX_WORKERS = _read_int_env("PARSER_MAX_WORKERS", 4)
 
-# Supported file extensions (registry keys), kept in one place to avoid
-# scattering the whitelist across modules.
-SUPPORTED_FILE_EXTENSIONS = frozenset({"pdf", "docx", "txt", "md", "sql", "xlsx", "csv"})
-
-# Zip-based formats that must go through the zip safety precheck before
-# being handed to python-docx / openpyxl.
-ZIP_BASED_FILE_EXTENSIONS = frozenset({"docx", "xlsx"})
+# 支持格式的唯一事实源是 app/parsers/registry.py 的 _REGISTRY——get_parser() 直接以它查表分派，
+# 这里不再另立一份影子白名单（曾有 SUPPORTED_FILE_EXTENSIONS / ZIP_BASED_FILE_EXTENSIONS 两个
+# frozenset，零引用且已漂移：前者缺 html/htm，后者的意图由 docx/excel/chat 三个解析器各自调用
+# ensure_zip_is_safe 实现，从不查表）。新增格式只需改 registry。
 
 
 # --- M3 multimodal parsing additions (M3-CONTRACTS.md §2.1) ---

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -43,6 +43,27 @@
 - 新增独立的 `FinalAnswerJudgeService`、聚合器与答案门禁纯函数。Judge 失败不折算 0 分；双跑只比较双方均成功 Judge 的共同 case；历史应用版本的答案门禁默认关闭。
 - 评测提交和费用预估支持绑定应用版本；发布门禁在显式开启时联合检索与答案结论，并新增 `GATE_ANSWER_SCORE_EPSILON`（默认 0.2）。完整契约见 `kb-rag-deploy/docs/M21-CONTRACTS.md`。
 
+### 修复（M12 后修复：`.htm` 上传被白名单挡下，兜底默认值与 yml 漂移）
+
+- **`.htm` 传不进来**：M12 给 kb-rag-parser 注册的是 `html` 与 `htm` 两个扩展名（同一个解析器），
+  上传白名单当期却只追加了 `html`。`UploadValidator` 是上传路径唯一的 fast-fail 闸门，`.htm`
+  在那里就被判 `unsupported file extension: htm`，压根到不了解析服务——一个解析侧早已支持的
+  格式，在入口被挡了两个里程碑。同一份白名单还管着 M14 外部数据源同步的对象过滤
+  （`ExtSourceService` 按它筛 S3 对象），所以桶里的 `.htm` 对象也一直被静默跳过。
+  `application.yml` 的 `kb.upload.allowed-extensions` 默认值补 `htm`。
+- **`KbProperties.Upload#allowedExtensions` 与 yml 漂移**：那份兜底 `List.of(...)` 里连 `html`
+  都没有（M12 只改了 yml）。真实部署总由 yml 覆盖，**生产未受影响**；但单元测试直接
+  `new KbProperties()` 吃的正是这份兜底值——**测试里 `.html` 一直是被拒的**，一个已上线两个
+  里程碑的格式在测试中处于"不支持"状态，任何走白名单的用例都在错误前提上通过。兜底值补齐为
+  与 yml 逐项一致，并在字段 javadoc 上写明这条必须同步的约束。
+- `htm` 与 `html`/`txt`/`md`/`sql`/`csv` 同属无魔数的文本格式，`MAGIC_BY_EXTENSION` 表不动，
+  仍是"仅验扩展名与大小"。
+- `UploadValidatorTest` 增 `shouldAcceptHtmlAndHtmAsTextFormats`（9 → 10 个用例）。变异验证：
+  抽掉兜底值里的 `html`/`htm`，该用例即以 `unsupported file extension: html` 转红。
+  全量单测 1339 → 1340，全绿。
+- **无 Flyway、无新增配置键，升级零操作**；**唯一对外行为变更**是 `.htm` 由 400 变为可上传。
+  已在 `.env` 里显式写死过 `UPLOAD_ALLOWED_EXTENSIONS` 的部署不会自动获得 `htm`，需手动追加。
+
 ### 安全加固（Actuator 管理平面）
 
 - `/actuator/health`、`/actuator/info` 与 `/actuator/prometheus` 从 `20000` 业务监听器迁至

--- a/kb-rag-server/kb-api/src/main/resources/application.yml
+++ b/kb-rag-server/kb-api/src/main/resources/application.yml
@@ -233,7 +233,7 @@ kb:
     cleanup-cron: ${AUDIT_OPERATION_CLEANUP_CRON:0 50 3 * * *}
   upload:
     max-file-size-mb: ${UPLOAD_MAX_FILE_SIZE_MB:100}
-    allowed-extensions: ${UPLOAD_ALLOWED_EXTENSIONS:pdf,docx,txt,md,sql,xlsx,csv,html,png,jpg,jpeg,webp,bmp,gif}
+    allowed-extensions: ${UPLOAD_ALLOWED_EXTENSIONS:pdf,docx,txt,md,sql,xlsx,csv,html,htm,png,jpg,jpeg,webp,bmp,gif}
   doc:
     version:
       # Non active READY versions kept per document; the older ones are archived and lose their chunks,

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/document/UploadValidatorTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/document/UploadValidatorTest.java
@@ -50,6 +50,15 @@ class UploadValidatorTest {
     }
 
     @Test
+    void shouldAcceptHtmlAndHtmAsTextFormats() {
+        // 兜底默认值曾漏 html/htm：yml 补过 html 而这份 List.of 没跟上，htm 则两边都没有——
+        // 于是 parser 早已注册的 .htm 在上传口被拒。本用例钉住两者都在白名单里。
+        byte[] page = "<html><body>hi</body></html>".getBytes(StandardCharsets.UTF_8);
+        assertEquals("html", validator.validate("page.html", page));
+        assertEquals("htm", validator.validate("page.HTM", page));
+    }
+
+    @Test
     void shouldRejectRenamedFile() {
         BizException e = assertThrows(BizException.class,
                 () -> validator.validate("payload.pdf", ZIP_HEADER));

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/config/KbProperties.java
@@ -928,9 +928,15 @@ public class KbProperties {
         /** Maximum accepted file size in megabytes. */
         private int maxFileSizeMb = 100;
 
-        /** Accepted lower case extensions. */
+        /**
+         * Accepted lower case extensions.
+         *
+         * <p>必须与 application.yml 的 kb.upload.allowed-extensions 默认值逐项一致：yml 在真实部署里
+         * 总会覆盖这里，但单元测试直接 new KbProperties() 吃的是这份兜底值——两者漂移会让测试放行/拒绝
+         * 的格式与生产不同（html 此前就只写进了 yml，测试里一直是被拒的）。
+         */
         private List<String> allowedExtensions =
-                List.of("pdf", "docx", "txt", "md", "sql", "xlsx", "csv",
+                List.of("pdf", "docx", "txt", "md", "sql", "xlsx", "csv", "html", "htm",
                         "png", "jpg", "jpeg", "webp", "bmp", "gif");
     }
 


### PR DESCRIPTION
## 起因

解析服务契约文档漏了 `sql` 扩展名。追溯下来，漏的不止一处，而且不止文档——同一类"注册表加了格式、周边没跟上"的欠账一共四笔，本 PR 一并结清。

`sql` 的源头是 `f8f925c`（2026-07-29，"pdf 乱码页不再入库；上传白名单补 sql"）：那次改了 `M3-CONTRACTS.md`、parser README 的两个段落和 `.env.example`，唯独没碰 OpenAPI 和 `ARCHITECTURE.md`。
`htm` 的源头更早，是 M12：解析器注册了 `html`/`htm` 两个扩展名，上传白名单只追加了 `html`。

## 四笔欠账

### 1. 契约与 README 漏记 `sql`（`183b9e5`，纯描述订正）

`sql` 在 [`registry.py:35`](https://github.com/liulangjietou/kb-rag/blob/docs/parser-sql-ext-contract/kb-rag-parser/app/parsers/registry.py#L35) 映射到与 `txt`/`md` 同一个 `TextParser`，`test_parse_sql_returns_expected_structure` 一直覆盖着它，server 的上传白名单默认值同期也已放行——只有三处对外清单没跟上：

| 位置 | 改动 |
|---|---|
| `openapi/kb-parser.yaml` | `SupportedFileExt` 枚举补 `sql`，description 说明来源 |
| `ARCHITECTURE.md` §4.2 | `/api/v1/parse` 端点的 `file_ext` 清单补 `sql` |
| `kb-rag-parser/README.md` | `file_ext` 说明行 + 「支持格式一览」表各补一处 |

照契约对接的人会以为传 `file_ext=sql` 会被 400 拒绝，从而绕开一个早已可用的格式。

**两套实现与测试均未改动**，OpenAPI 的 schema 结构与版本号不变（仍 `0.14.0-m14`）。

### 2. `.htm` 上传被白名单挡下（`a705454`，唯一的行为变更）

`UploadValidator` 是上传路径唯一的 fast-fail 闸门，`.htm` 在那里被判 `unsupported file extension: htm`，压根到不了解析服务——**同一个网页存成 `.htm` 就传不进来**。同一份白名单还管着 M14 外部数据源同步的对象过滤（`ExtSourceService` 按它筛 S3 对象），桶里的 `.htm` 对象一直被静默跳过：不报错、不计失败，只是不入库。

**另修一处只影响测试的漂移**：`KbProperties.Upload#allowedExtensions` 的兜底 `List.of(...)` 里连 `html` 都没有（M12 只改了 yml）。真实部署总由 yml 覆盖，**生产未受影响**；但单元测试直接 `new KbProperties()` 吃的正是这份兜底值——**测试里 `.html` 一直是被拒的**，一个已上线两个里程碑的格式在测试中处于"不支持"状态，任何走白名单的用例都在错误前提上通过。兜底值补齐为与 yml 逐项一致，字段 javadoc 写明这条约束。

`htm` 与 `html`/`txt`/`md`/`sql`/`csv` 同属无魔数的文本格式，`MAGIC_BY_EXTENSION` 表不动，仍是仅验扩展名与大小。

### 3. `config.py` 里两个零引用的影子白名单（`5d2ca98`）

`SUPPORTED_FILE_EXTENSIONS` 与 `ZIP_BASED_FILE_EXTENSIONS` 全仓无任何引用：格式判定一直由 `_REGISTRY` 查表完成，zip 预检由 `docx.py`/`excel.py`/`chat/parser.py` 各自直接调用 `ensure_zip_is_safe`。

留着不是无害的——注释写着 "kept in one place to avoid scattering the whitelist across modules"，读起来像权威白名单，而它已经漂移（缺 `html`/`htm`）。下一个人照它判断"本服务支不支持某格式"会得到错误答案，照它新增格式则改了一个没人读的集合。两个常量删除，原处留注释指明唯一事实源是 `_REGISTRY`。

### 4. deploy README 模块表的格式清单（`98cbca4`）

仓库一览里 parser 那行同时漏了 `sql` 与 `html`/`htm`，按注册表补齐。这是读者进仓库看到的第一份格式清单。

## 验证

| | 改前 | 改后 |
|---|---|---|
| kb-rag-server 全量单测 | 1339 | **1340**，全绿（kb-domain 402 / kb-infrastructure 67 / kb-app 786 / kb-api 85） |
| `UploadValidatorTest` | 9 | **10** |
| kb-rag-parser pytest | 65 passed / 1 skipped | **不变**（删的是死代码，文档改动不影响） |

**变异验证**：抽掉 `KbProperties` 兜底值里的 `html`/`htm`，`shouldAcceptHtmlAndHtmAsTextFormats` 即以 `unsupported file extension: html` 转红。

`application.yml` 那一行由部署生效、单测覆盖不到，靠与兜底默认值逐项一致来约束——这条已写进字段 javadoc。

`scripts/validate_config.py` 通过；两份 OpenAPI 经 `yaml.safe_load` 校验合法。

## 升级影响

- **无 Flyway 脚本、无新增环境变量与配置键，升级零操作**
- **唯一对外行为变更**：`.htm` 由 400 变为可上传
- **运维提醒**：已在 `.env` 里显式写死过 `UPLOAD_ALLOWED_EXTENSIONS` 的部署不会自动获得 `sql`/`htm`，需要手动补进那一行（与 M12 追加 `html`、`f8f925c` 追加 `sql` 时同一口径）
- OpenAPI 两份均为**纯描述订正，schema 与版本号不变**（`kb-parser.yaml` `0.14.0-m14`、`kb-server.yaml` `0.26.0-m24`）

## 同步的文档

`kb-rag-server/CHANGELOG.md`、`kb-rag-deploy/CHANGELOG.md`、`kb-rag-parser/CHANGELOG.md`、`openapi/kb-parser.yaml`、`openapi/kb-server.yaml`、`ARCHITECTURE.md` §4.2、`M12-CONTRACTS.md` §3.1（`htm` 后补说明）、两个 README。

## 一处留给 reviewer 判断

`ARCHITECTURE.md` 头部版本号**没升**（仍 v2.7）——§4.2 那处是端点表勘误，不是架构变更，升版会污染基线语义。若按"改了 ARCHITECTURE 就要升版"的既有口径，我可以补升。

## 附带说明

`kb-rag-parse-java` 侧的 `ParserRegistry` 同样注册了 `sql`、其 README 也已有 `sql` 行，但该模块尚未合入 `main`（只在 `feat/kb-rag-parse-java`），故本 PR 未触及。
