### PR TITLE
refactor(server): kb-app 四个上帝类按职责拆解

### DIFF
--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -30,6 +30,12 @@
 
 ### Changed
 
+- **kb-app 上帝类按职责拆解（重构，升级零操作）**：`IndexPipelineService`、`RetrievalService`、
+  `EvalRunService`、`ChatImportService` 的构造依赖由 31/25/22/21 降至 20/22/18/10，拆出 7 个
+  协作者类。**对运维无任何影响**：没有 Flyway 迁移、没有新增或改名的配置键与环境变量、没有新容器
+  或新第三方依赖、对外 HTTP 契约与 degraded 枚举完全不变，OpenAPI 版本号保持 `0.26.0-m24` 不动。
+  升级按常规发布即可，无需任何额外操作。`docs/ARCHITECTURE.md` 升至 v2.8，§3.4/§3.5 同步类归属
+  ——其中"`page` 策略由管线直接分流到 `PageSplitter`"一句已随本次重构失准，一并订正。
 - `.env.example` 新增 `MANAGEMENT_SERVER_PORT=20003` 与
   `MANAGEMENT_SERVER_ADDRESS=127.0.0.1`；OpenAPI 健康检查条目改为独立管理端口，需求文档升至
   v1.21。远程开放管理地址时必须同时配置防火墙、服务网格或带认证的反向代理。

--- a/kb-rag-deploy/docs/ARCHITECTURE.md
+++ b/kb-rag-deploy/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # kb-rag 架构文档
 
 
-> 版本：v2.7（基线 = v2.6 + M24 模型 Token 成本台账与租户配额，2026-08-14；v2.6 基线为 M23，其余历史见 Git）
-> 日期：2026-08-14
+> 版本：v2.8（基线 = v2.7 + kb-app 四个上帝类按职责拆解，2026-09-02；v2.7 基线为 M24，其余历史见 Git）
+> 日期：2026-09-02
 > 作者：RichardFyoung / Claude
 >
 > **文档定位**：本文描述系统的实际实现架构（以代码为准），与以下文档互补——
@@ -156,12 +156,14 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | `RoutingService` | LLM 提议、**白名单裁决**（结果与候选库集合取交集，注入防线③）；失败/未命中回退全部关联库（`route_fallback_all`）；缓存 key=query+候选集+生效 prompt，失败不入缓存 |
 | `RetrievalIndexContextResolver` | **调用上下文三分支的唯一分辨点**：RELEASED → 冻结快照索引+固化可见集；TESTING/调试/评测 → 实时别名+当前激活集合；旧 RELEASED（无快照）→ 兼容实时、不记降级 |
 | `VectorScoreNormalizer` | 跨引擎向量分统一：ES `(1+cos)/2` 先还原、Qdrant 原生 cosine，统一映射到 [0,1]；两实现共享一份"引擎一致性单测" |
+| `MultimodalRetrievalService`（M14） | 多模态路由的执行方，与 `GraphRetrievalService` 对称：别名解析、以文搜图/以图搜图的向量来源选择、多向量命中按 chunk 取最大相似度折叠成单列表；加权融合下拒绝运行并记 `mm_route_skipped`（多模态相似度与文本路不同量纲）。**快照守卫留在调用点**，与图路一致——“released 版本查自己的冻结语料”是调用的性质而非某条路由的性质 |
 | `FusionRouter` → `RrfFusion`/`WeightedFusion` | 加权融合先按候选集 min-max 归一化；开图路的库强制 RRF（`GraphFusionPolicy`——图关联度是第三种量纲） |
 | `CrossKbRrfFusion` + `KbQuotaAllocator` | 跨库只用名次不用分数；rerank 候选预算是**全局总量**按权重配额切分（向下取整、余量归最高权重库） |
 | `RerankService` | 候选上限 50（父子开启时联动 `max(50, top_n×5)`，硬上限 100）；超时 1.5s 降级粗排；rerank 分是唯一跨库跨路可比的绝对分；M14 新增 `rerank_mode=hybrid`：将语义重排分与原始融合分按 `rerank_w_semantic`（0-1，默认 0.7）线性加权，`semantic` 模式与旧行为一致 |
 | `ParentChildMerger` | 召回/融合/rerank 全在子片粒度，之后按 parent_id 归并、父片得分取子片 max；目标父片数 `max(top_n×3, 20)` |
 | `DisabledChildVisibility` + `ParentTextRedactor`（M9） | 含禁用子片的父片：默认整片返回并标注 `disabled_child_ids`；M9 起对偏移非 null 的禁用子片按 [start,end) **倒序**精确剔除文本段、置省略标记与 `redacted_child_count`；任一禁用子片偏移为 null 则整片回退（半剔除比不剔除更误导）；库级开关 `hide_parent_with_disabled_child` 打开则整父片隐藏 |
 | `ScoreThresholdPolicy` | 阈值只作用于 rerank 分；降级时作用于标准 cosine 分；BM25 单路阈值失效并透出 `threshold_inactive`；`score_type` 必须如实上报 |
+| `RetrievalNodeAssembler` | 管线只决定“哪些片段胜出”，本类决定“胜出者怎么描述”：两级单元取父片文本、分数键命名、禁用子片剔除、图片 key 转预签名 URL（签名失败只丢图不失败整次检索）。展示型 metadata 键全部写在此处且无人回读，是它与阶段编排分离的依据 |
 | `ActiveVersionResolver` | 版本可见集缓存（TTL 可配）+ 失效通知；快照路径绝不经过此处 |
 | `EngineChunkCleaner` | 召回命中事实源已删分片时反向清理引擎（**快照路径关闭自愈**，防跨索引误删——M6 红线） |
 | `OfflineExecutionContext` | ThreadLocal 离线评测标记：超时放宽至 10s、降级不计入生产监控 |
@@ -176,9 +178,11 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 
 - **上传事务只持久化事实**（MinIO 原件 + document/version 行），管线经 `TransactionSynchronization.afterCommit` 提交异步执行——异步 worker 用独立连接读版本行，事务内触发会产生提交竞态（M1 联调发现的真实缺陷，全仓仅 `DocumentService` 与 `EngineChunkCleaner` 两处使用该手法）。
 - `IndexPipelineService` 是管线主编排，五个 `@Async(INDEX_EXECUTOR)` 入口：`submit`（新上传）/ `submit(versionId, reuse)`（指纹复用）/ `submitRestore`（归档版重建）/ `submitRebuild`（配置重建）/ `submitConfirm`（预览确认后续跑）。
-- 阶段：解析（parser HTTP）→ 清洗/脱敏（`DocumentCleaner`/`TextDesensitizer`；按页切分的库走 `PagedContentAssembler` 逐页清洗后拼回并记录页区间）→ 图片资产与 VLM 文本代理插回（`ImageAssetService`/`ImagePlaceholderResolver`，单图失败不失败整篇）→ 切分（`SplitterRouter` 策略路由，未知 code 回落定长；`page` 策略由管线直接分流到 `PageSplitter`，因它还需要页区间；父子两级切分 `ParentChildSplitter`，仅与定长策略组合）→ 嵌入（`ChunkEmbedder`，零 Key 全部 SKIPPED）→ 双写（`ChunkIndexWriter`：**先写 PENDING 同步行、再调引擎、再更新状态**——补偿扫描的唯一证据链）。
+- 阶段：解析（parser HTTP）→ 清洗/脱敏（`DocumentCleaner`/`TextDesensitizer`；按页切分的库走 `PagedContentAssembler` 逐页清洗后拼回并记录页区间）→ 图片资产与 VLM 文本代理插回（`ImageAssetService`/`ImagePlaceholderResolver`，单图失败不失败整篇）→ 切分（`ChunkSplitter` 统一承担：`SplitterRouter` 策略路由，未知 code 回落定长；`page` 策略分流到 `PageSplitter`，因它还需要页区间；父子两级切分 `ParentChildSplitter`，仅与定长策略组合。“是否单图 / 是否页策略”由管线判定后随请求传入，切分器不重复推导——两处各自判断会让页策略静默退化为定长）→ 嵌入（`ChunkEmbedder`，零 Key 全部 SKIPPED）→ 双写（`ChunkIndexWriter`：**先写 PENDING 同步行、再调引擎、再更新状态**——补偿扫描的唯一证据链）。
 - **指纹复用**：`VersionFingerprintFactory` 产出 content_hash/解析指纹/分片指纹/嵌入版本，`VersionArtifactReuser` 在全匹配时复制上一构建的 chunk 行（新 ID、重写父链），跳过解析与切分。
 - **版本机制**：`DocumentVersionPlanner` 一次回答重复判定/版本号（major.minor）/可否复用；`DocumentVersionActivator` 激活时旧 active 退回 READY（支持秒级回滚）；`VersionRetentionService` 异步清理超保留窗口（默认 3）的旧版 chunk（保留原件与解析产物）；`AppVersionPinChecker` 保护被快照引用的版本不被清理。
+- **编排与执行分离**：`IndexPipelineService` 只保留阶段顺序与失败归类，三类执行下沉——`ChunkSplitter`（切分与分片落库）、`IndexTaskLifecycle`（`t_kb_task` 状态机：开始/进度/成功/失败，重试复用同一行并累加 `retry_count`）、`VersionActivationHandler`（激活及其全部后续：标注继承 → 评测用例置陈旧 → 保留窗口清理 → 图谱失效）。后者刻意区别于 `DocumentVersionActivator`：激活器只守“单一 active 版本”不变式，聊天导入与手工回滚也复用它，那条不变式不能依赖任何后续步骤成功。
+- **失败语义**：`PARSE_FAILED` 与 `INDEX_FAILED` 按异常错误码分流（运维据此判断该查解析服务还是索引链路）；构建失败一律把版本置 `BUILD_FAILED` 且绝不激活；`execute` 不向异步包装层抛出——状态已如实落库，再抛只会覆盖一条更准确的记录。
 - **标注跨版本（M4a + M9）**：`AnnotationInheritanceService` 按 chunk_text_hash 精确继承禁用类标注（新版本不自动继承其他标注）；M9 起 `AnnotationMigrationAdvisor`（domain 纯函数）以归一化字符 3-gram **Dice 系数**（对称指标——刻意不用评测的非对称重叠率）为待复核标注懒计算迁移建议（阈值 `kb.annotation.migration-min-score=0.35`、top 3、候选限同文档当前激活版本、短文本不推荐），`POST /api/v1/annotations/{id}/migrate` 人工逐条确认（仅禁用/编辑两类，幂等；刻意不做自动与批量迁移——误迁移代价大于逐条确认成本）。
 
 ### 3.6 应用发布与开放 API（`appcenter` + `openapi`）

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -7,6 +7,40 @@
 
 尚未打过 tag，以下条目全部属于首个发布版本的内容，按里程碑倒序排列。
 
+### 重构（kb-app 上帝类按职责拆解，行为不变）
+
+- **背景**：四个应用服务把多份互不相干的职责挤在一个类里，构造依赖分别达到 31 / 25 / 22 / 21 个。
+  判断边界的依据不是行数，而是**依赖的独占性**——某组协作者只被某一段代码读，那一段就是一个独立
+  职责。按这个尺子拆出 7 个协作者，四个类的行数与依赖数（实测）：
+
+  | 类 | 行数 | 构造依赖 |
+  |---|---|---|
+  | `IndexPipelineService` | 1119 → 871 | 31 → 20 |
+  | `RetrievalService` | 1396 → 919 | 25 → 22 |
+  | `EvalRunService` | 932 → 757 | 21 → 18 |
+  | `ChatImportService` | 473 → 279 | 22 → 10 |
+
+- **检索线**：`RetrievalNodeAssembler` 接手"胜出片段怎么描述"（`ParentTextRedactor`、`ObjectStorage`
+  与 22 个展示型 metadata 键只服务于它）；`MultimodalRetrievalService` 补齐一处既有的不对称——图路
+  早有独立的 `GraphRetrievalService`，多模态的执行逻辑却内联在管线里，而 `MultimodalRouteOutcome`
+  的注释本就写明自己是照 `GraphRouteOutcome` 建模的。顺带把图片分发"就地改写调用方 degraded 列表"
+  的副作用写法改为返回式 outcome，与 `RewriteOutcome`/`RoutingOutcome` 的既有惯例一致。
+- **索引线**：`ChunkSplitter`（切分与分片落库）、`IndexTaskLifecycle`（`t_kb_task` 状态机）、
+  `VersionActivationHandler`（激活及其四项后续）。管线只留阶段顺序与失败归类。
+- **聊天导入 / 评测线**：`ChatSessionImporter`（把一次会话写成一个文档版本，独占 13 个依赖）、
+  `EvalCaseRunner`（跑单个用例，不碰任何 mapper，因此可安全并发）。`answerJudgeRequested` 提为
+  `public static` 由费用预估与执行共用——两份副本就是"这个用例会不会调模型"的两个答案，而预估
+  存在的意义正是可被信任。
+- **顺带清理**：`judgeOneCase` / `judgeAll` 中只用于向下透传、从未被读取的参数 `k`；
+  `ReleaseGateService.runGate` 提取 `submitGateRuns`（88 → 65 行）。
+- **补测试**：`IndexPipelineService` 此前没有自己的单测（引用它的三个测试类都只把它当 mock）。
+  新增 `IndexPipelineServiceTest` 10 例，覆盖复用回退、待确认暂停、失败状态归类、页策略标志传递。
+  做过变异验证：注入 5 处缺陷（复用为空不回退 / 解析失败误报为索引失败 / 忽略待确认开关 /
+  单图走页切分 / 失败不置 `BUILD_FAILED`），5 处全部被对应用例捕获转红。
+- **零行为变更**：全部为 Extract Class 与 Extract Method，未改任何逻辑分支；无 schema 迁移、无
+  配置键、无 API 变更。测试 1340 → 1350 全绿（新增 10 例），246 个 Spring bean 的构造注入依赖图
+  经脚本验证无环。
+
 ### M24 · 模型 Token 成本台账与租户月度配额
 
 - `[schema]` Flyway V24 为租户增加 `monthly_token_quota`，新增月度原子计数器、调用明细台账与

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/appcenter/ReleaseGateService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/appcenter/ReleaseGateService.java
@@ -243,34 +243,11 @@ public class ReleaseGateService {
         AppVersion version = appVersionService.require(appVersionId);
         AppConfigSnapshot candidateConfig = appVersionService.parseConfig(version);
         AppVersion baselineVersion = appVersionService.currentReleased(version.getAppId());
-        String datasetId = version.getGateDatasetId();
-
-        List<EvalRetrievalConfig> configs = new ArrayList<>(2);
-        configs.add(toEvalConfig(CANDIDATE_LABEL, candidateConfig));
-        if (baselineVersion != null) {
-            configs.add(toEvalConfig(BASELINE_LABEL, appVersionService.parseConfig(baselineVersion)));
-        }
-        int k = candidateConfig.retrievalOrDefaults().getTopN() == null
-                ? properties.getRetrieval().getDefaultTopN()
-                : candidateConfig.retrievalOrDefaults().getTopN();
-
         AnswerGateConfig answerGateConfig = candidateConfig.answerGateOrDefaults();
         boolean answerGateEnabled = answerGateConfig.isEnabled();
-        List<EvalRun> runs;
-        if (answerGateEnabled) {
-            List<EvalRunService.AnswerRunSpec> specs = new ArrayList<>(configs.size());
-            specs.add(new EvalRunService.AnswerRunSpec(configs.get(0),
-                    new AnswerEvaluationConfig(version.getAppVersionId(), candidateConfig)));
-            if (baselineVersion != null) {
-                specs.add(new EvalRunService.AnswerRunSpec(configs.get(1),
-                        new AnswerEvaluationConfig(baselineVersion.getAppVersionId(),
-                                appVersionService.parseConfig(baselineVersion))));
-            }
-            runs = evalRunService.submitAnswerRuns(datasetId, k, specs, false);
-        } else {
-            runs = evalRunService.submit(datasetId, k, configs, false);
-        }
-        List<EvalRun> finished = awaitCompletion(runs);
+
+        List<EvalRun> finished = awaitCompletion(
+                submitGateRuns(version, candidateConfig, baselineVersion, answerGateEnabled));
         EvalRun candidateRun = finished.get(0);
         EvalRun baselineRun = finished.size() > 1 ? finished.get(1) : null;
 
@@ -341,6 +318,47 @@ public class ReleaseGateService {
      * @param snapshot frozen configuration of this side
      * @return evaluation configuration row
      */
+    /**
+     * Submits the gate's evaluation runs: the candidate always, the released baseline when there is one.
+     *
+     * <p>Both runs are submitted under one data set and one K by construction. A gate is a subtraction,
+     * and two runs measured at different K would yield two numbers the verdict has no right to subtract.
+     *
+     * <p>The answer gate does not add a third run - it upgrades the same two into runs that also generate
+     * and judge a final answer, so the retrieval verdict and the answer verdict always describe the very
+     * same executions.
+     *
+     * @param version           version under gate
+     * @param candidateConfig   parsed configuration of that version
+     * @param baselineVersion   currently released version, {@code null} on a first release
+     * @param answerGateEnabled {@code true} when the final answer gate runs alongside
+     * @return submitted runs, candidate first and baseline second
+     */
+    private List<EvalRun> submitGateRuns(AppVersion version, AppConfigSnapshot candidateConfig,
+                                         AppVersion baselineVersion, boolean answerGateEnabled) {
+        String datasetId = version.getGateDatasetId();
+        List<EvalRetrievalConfig> configs = new ArrayList<>(2);
+        configs.add(toEvalConfig(CANDIDATE_LABEL, candidateConfig));
+        if (baselineVersion != null) {
+            configs.add(toEvalConfig(BASELINE_LABEL, appVersionService.parseConfig(baselineVersion)));
+        }
+        int k = candidateConfig.retrievalOrDefaults().getTopN() == null
+                ? properties.getRetrieval().getDefaultTopN()
+                : candidateConfig.retrievalOrDefaults().getTopN();
+        if (!answerGateEnabled) {
+            return evalRunService.submit(datasetId, k, configs, false);
+        }
+        List<EvalRunService.AnswerRunSpec> specs = new ArrayList<>(configs.size());
+        specs.add(new EvalRunService.AnswerRunSpec(configs.get(0),
+                new AnswerEvaluationConfig(version.getAppVersionId(), candidateConfig)));
+        if (baselineVersion != null) {
+            specs.add(new EvalRunService.AnswerRunSpec(configs.get(1),
+                    new AnswerEvaluationConfig(baselineVersion.getAppVersionId(),
+                            appVersionService.parseConfig(baselineVersion))));
+        }
+        return evalRunService.submitAnswerRuns(datasetId, k, specs, false);
+    }
+
     private EvalRetrievalConfig toEvalConfig(String label, AppConfigSnapshot snapshot) {
         KbRetrievalConfig retrieval = snapshot.retrievalOrDefaults();
         EvalRetrievalConfig config = new EvalRetrievalConfig();

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/chat/ChatImportService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/chat/ChatImportService.java
@@ -1,42 +1,21 @@
 package io.kbrag.app.chat;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import io.kbrag.app.annotation.AnnotationInheritanceService;
-import io.kbrag.app.index.ChunkEmbedder;
-import io.kbrag.app.index.ChunkIndexWriter;
-import io.kbrag.app.index.DocumentVersionActivator;
 import io.kbrag.app.kb.KnowledgeBaseService;
 import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
-import io.kbrag.common.util.HashUtil;
 import io.kbrag.common.util.JsonUtil;
 import io.kbrag.domain.config.KbProperties;
-import io.kbrag.domain.constant.ChunkMetadataKeys;
-import io.kbrag.domain.entity.Chunk;
 import io.kbrag.domain.entity.Document;
-import io.kbrag.domain.entity.DocumentVersion;
 import io.kbrag.domain.entity.SourceMapping;
-import io.kbrag.domain.enums.ChunkType;
-import io.kbrag.domain.enums.DocumentVersionStatus;
-import io.kbrag.domain.enums.EmbeddingStatus;
-import io.kbrag.domain.enums.ProcessStatus;
 import io.kbrag.domain.enums.SourceMappingType;
-import io.kbrag.domain.mapper.ChunkMapper;
 import io.kbrag.domain.mapper.DocumentMapper;
-import io.kbrag.domain.mapper.DocumentVersionMapper;
-import io.kbrag.domain.model.ChatWindow;
 import io.kbrag.domain.model.CleanRules;
 import io.kbrag.domain.model.KbIndexConfig;
 import io.kbrag.domain.model.ParsedChatFile;
 import io.kbrag.domain.port.DocumentParserClient;
-import io.kbrag.domain.port.EmbeddingProvider;
 import io.kbrag.domain.port.ObjectStorage;
 import io.kbrag.domain.service.BizIdGenerator;
-import io.kbrag.domain.service.ChatWindowAggregator;
-import io.kbrag.domain.service.ChunkTextHasher;
-import io.kbrag.domain.service.DocumentCleaner;
-import io.kbrag.domain.service.DocumentVersionPlanner;
-import io.kbrag.domain.service.VersionFingerprintFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -48,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -94,30 +72,16 @@ public class ChatImportService {
      * intermediate model the pipeline consumes is the same whichever of them produced it.
      */
     private static final List<String> SUPPORTED_EXTENSIONS = List.of("csv", "xlsx", "txt", "html");
-    private static final String CHAT_FILE_EXT = "chat";
-    private static final int ENABLED = 1;
 
     private final DocumentMapper documentMapper;
-    private final DocumentVersionMapper documentVersionMapper;
-    private final ChunkMapper chunkMapper;
     private final ObjectStorage objectStorage;
     private final DocumentParserClient parserClient;
     private final KnowledgeBaseService knowledgeBaseService;
     private final ChatUploadTokenStore uploadTokenStore;
     private final SourceMappingService sourceMappingService;
     private final ChatSessionMatcher sessionMatcher;
-    private final ChatWindowAggregator windowAggregator;
-    private final ChatWindowRenderer windowRenderer;
-    private final DocumentCleaner documentCleaner;
-    private final ChunkTextHasher chunkTextHasher;
-    private final ChunkIndexWriter chunkIndexWriter;
-    private final ChunkEmbedder chunkEmbedder;
-    private final DocumentVersionActivator versionActivator;
-    private final AnnotationInheritanceService annotationInheritanceService;
-    private final EmbeddingProvider embeddingProvider;
+    private final ChatSessionImporter sessionImporter;
     private final BizIdGenerator bizIdGenerator;
-    private final VersionFingerprintFactory fingerprintFactory;
-    private final DocumentVersionPlanner versionPlanner;
     private final KbProperties properties;
 
     /**
@@ -186,171 +150,13 @@ public class ChatImportService {
                 log.info("skip empty chat session, kbId={}, sessionId={}", kbId, session.getSessionId());
                 continue;
             }
-            importedDocIds.add(importSession(kbId, session, config, rules,
+            importedDocIds.add(sessionImporter.importSession(kbId, session, config, rules,
                     existing.get(sessionMatcher.sourceKeyOf(session.getSessionId()))));
         }
         uploadTokenStore.consume(token);
         log.info("chat import confirmed, kbId={}, fileName={}, documents={}",
                 kbId, staged.fileName(), importedDocIds.size());
         return importedDocIds;
-    }
-
-    /**
-     * Imports one conversation as a new document or as a new version of an existing one.
-     *
-     * @param kbId          target knowledge base
-     * @param session       conversation to import
-     * @param config        knowledge base index configuration
-     * @param rules         cleaning rules of the chat path
-     * @param existingDocId document already carrying the conversation, {@code null} when it is new
-     * @return document business id
-     */
-    private String importSession(String kbId, ParsedChatFile.ChatSession session, KbIndexConfig config,
-                                 CleanRules rules, String existingDocId) {
-        Document document = existingDocId == null
-                ? createDocument(kbId, session)
-                : loadDocument(existingDocId, session);
-        DocumentVersion version = createVersion(document, session);
-
-        List<ChatWindow> windows = windowAggregator.aggregate(session.messagesOrEmpty(),
-                config.chatAggregationOrDefaults());
-        List<Chunk> chunks = new ArrayList<>(windows.size());
-        boolean embeddingConfigured = embeddingProvider.isConfigured();
-        for (ChatWindow window : windows) {
-            String text = documentCleaner.cleanFragment(windowRenderer.render(window), rules);
-            if (text == null || text.isBlank()) {
-                continue;
-            }
-            chunks.add(persistChunk(document, version, window, session, text, embeddingConfigured));
-        }
-        version.setChunkFingerprint(fingerprintFactory.chunkFingerprint(config));
-        version.setParseFingerprint(fingerprintFactory.parseFingerprint(config, CHAT_FILE_EXT));
-        version.setEmbeddingVersion(embeddingProvider.model());
-        documentVersionMapper.updateById(version);
-
-        if (CollectionUtils.isNotEmpty(chunks)) {
-            chunkIndexWriter.write(kbId, chunks, chunkEmbedder.embed(chunks));
-        }
-        // Replacing the whole content is the requirement for a re-import, so the chunks of the version that
-        // was active until now are removed only after the new ones are searchable.
-        removePreviousChunks(kbId, document, version.getVersionId());
-        versionActivator.activate(document, version);
-        // A conversation re-imported under the same identity is a new version of the same document, so the
-        // disable decisions taken on the previous one follow the text exactly as they do for an upload.
-        annotationInheritanceService.inherit(document, version);
-        log.info("chat session imported, kbId={}, docId={}, versionId={}, windows={}, chunks={}",
-                kbId, document.getDocId(), version.getVersionId(), windows.size(), chunks.size());
-        return document.getDocId();
-    }
-
-    private Document createDocument(String kbId, ParsedChatFile.ChatSession session) {
-        Document document = new Document();
-        document.setDocId(bizIdGenerator.documentId());
-        document.setKbId(kbId);
-        document.setFileName(sessionMatcher.displayNameOf(session));
-        document.setFileExt(CHAT_FILE_EXT);
-        document.setFileSize(0L);
-        document.setProcessStatus(ProcessStatus.INDEXING);
-        document.setConfigStale(0);
-        document.setSourceKey(sessionMatcher.sourceKeyOf(session.getSessionId()));
-        documentMapper.insert(document);
-        return document;
-    }
-
-    /**
-     * Loads the document a conversation already maps to and refreshes its display name.
-     *
-     * @param docId   document business id
-     * @param session conversation being re-imported
-     * @return document record
-     */
-    private Document loadDocument(String docId, ParsedChatFile.ChatSession session) {
-        Document document = documentMapper.selectOne(new LambdaQueryWrapper<Document>()
-                .eq(Document::getDocId, docId)
-                .last("limit 1"));
-        if (document == null) {
-            throw BizException.notFound("document not found: " + docId);
-        }
-        // A renamed conversation keeps its identity but should show its current name in the console.
-        document.setFileName(sessionMatcher.displayNameOf(session));
-        documentMapper.updateById(document);
-        return document;
-    }
-
-    /**
-     * Creates the version this import writes into.
-     *
-     * @param document document record
-     * @param session  conversation being imported
-     * @return persisted version row
-     */
-    private DocumentVersion createVersion(Document document, ParsedChatFile.ChatSession session) {
-        DocumentVersion version = new DocumentVersion();
-        version.setVersionId(bizIdGenerator.documentVersionId());
-        version.setDocId(document.getDocId());
-        version.setVersion(nextVersionNumber(document.getDocId()));
-        version.setContentHash(HashUtil.sha256Hex(
-                JsonUtil.toJson(session.messagesOrEmpty()).getBytes(StandardCharsets.UTF_8)));
-        version.setStatus(DocumentVersionStatus.BUILDING);
-        documentVersionMapper.insert(version);
-        return version;
-    }
-
-    /**
-     * Computes the next version number of a document.
-     *
-     * <p>The minor part is bumped: a re-import replaces the content of the same logical document, which is
-     * a revision of it and not a new lineage. The numbering itself is delegated so the upload path and the
-     * chat path can never drift into two different version ladders for the same table.
-     *
-     * @param docId document business id
-     * @return version number in {@code major.minor} form
-     */
-    private String nextVersionNumber(String docId) {
-        return versionPlanner.nextMinor(documentVersionMapper.selectList(
-                new LambdaQueryWrapper<DocumentVersion>().eq(DocumentVersion::getDocId, docId)));
-    }
-
-    private Chunk persistChunk(Document document, DocumentVersion version, ChatWindow window,
-                               ParsedChatFile.ChatSession session, String text, boolean embeddingConfigured) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ChunkMetadataKeys.SESSION_ID, session.getSessionId());
-        metadata.put(ChunkMetadataKeys.SESSION_NAME, sessionMatcher.displayNameOf(session));
-        metadata.put(ChunkMetadataKeys.SENDER, String.join(",", window.getSenders()));
-        metadata.put(ChunkMetadataKeys.MSG_TIME, window.getStartTime());
-        // Written for every window, overlap configured or not: the retrieval side recognises an aggregation
-        // window by the presence of the span, so writing it only when the overlap is on would make the
-        // near duplicate merging silently inapplicable to everything imported before the switch was flipped.
-        metadata.put(ChunkMetadataKeys.WINDOW_SEQ, window.getSeq());
-        metadata.put(ChunkMetadataKeys.MSG_SPAN, List.of(window.getMsgSpanStart(), window.getMsgSpanEnd()));
-
-        Chunk chunk = new Chunk();
-        chunk.setChunkId(bizIdGenerator.chunkId());
-        chunk.setKbId(document.getKbId());
-        chunk.setDocId(document.getDocId());
-        chunk.setDocumentVersionId(version.getVersionId());
-        chunk.setContent(text);
-        chunk.setChunkTextHash(chunkTextHasher.hash(text));
-        chunk.setSeq(window.getSeq());
-        chunk.setChunkType(ChunkType.CHAT_LOG);
-        chunk.setEnabled(ENABLED);
-        chunk.setMetadata(JsonUtil.toJson(metadata));
-        chunk.setEmbeddingStatus(embeddingConfigured ? EmbeddingStatus.PENDING : EmbeddingStatus.SKIPPED);
-        chunkMapper.insert(chunk);
-        return chunk;
-    }
-
-    /**
-     * Removes the chunks of every version of the document except the one just built.
-     *
-     * @param kbId         knowledge base business id
-     * @param document     document record
-     * @param keepVersionId version whose chunks must survive
-     */
-    private void removePreviousChunks(String kbId, Document document, String keepVersionId) {
-        knowledgeBaseService.removeChunks(kbId, new LambdaQueryWrapper<Chunk>()
-                .eq(Chunk::getDocId, document.getDocId())
-                .ne(Chunk::getDocumentVersionId, keepVersionId));
     }
 
     /**

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/chat/ChatSessionImporter.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/chat/ChatSessionImporter.java
@@ -1,0 +1,252 @@
+package io.kbrag.app.chat;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.kbrag.app.annotation.AnnotationInheritanceService;
+import io.kbrag.app.index.ChunkEmbedder;
+import io.kbrag.app.index.ChunkIndexWriter;
+import io.kbrag.app.index.DocumentVersionActivator;
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.common.util.HashUtil;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.constant.ChunkMetadataKeys;
+import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.DocumentVersion;
+import io.kbrag.domain.enums.ChunkType;
+import io.kbrag.domain.enums.DocumentVersionStatus;
+import io.kbrag.domain.enums.EmbeddingStatus;
+import io.kbrag.domain.enums.ProcessStatus;
+import io.kbrag.domain.mapper.ChunkMapper;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.DocumentVersionMapper;
+import io.kbrag.domain.model.ChatWindow;
+import io.kbrag.domain.model.CleanRules;
+import io.kbrag.domain.model.KbIndexConfig;
+import io.kbrag.domain.model.ParsedChatFile;
+import io.kbrag.domain.port.EmbeddingProvider;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.ChatWindowAggregator;
+import io.kbrag.domain.service.ChunkTextHasher;
+import io.kbrag.domain.service.DocumentCleaner;
+import io.kbrag.domain.service.DocumentVersionPlanner;
+import io.kbrag.domain.service.VersionFingerprintFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Writes one conversation into the knowledge base as a document version.
+ *
+ * <p>Split out of {@link ChatImportService} along the two halves of the chat import. The service owns the
+ * conversation with the operator - parse the upload, match the sessions, stage them, hand back a preview,
+ * then act on what was confirmed. This class owns what happens to a single confirmed conversation, which
+ * is a full indexing build in miniature: aggregate the messages into windows, clean and render them,
+ * persist the chunks, stamp the fingerprints, write the engines, retire the previous version's chunks and
+ * activate the new one.
+ *
+ * <p>Nearly every collaborator here is read nowhere else in the import path - the window aggregator and
+ * renderer, the cleaner, the embedder and index writer, the version activator, planner and fingerprint
+ * factory, the annotation inheritance. That is the evidence the two halves are separate jobs rather than
+ * one long one.
+ *
+ * <p><b>Ordering is a requirement, not an implementation detail.</b> The previous version's chunks are
+ * removed only after the new ones are searchable, and the version is activated only after that removal;
+ * a re-import must never leave the document with no findable content in between.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatSessionImporter {
+
+    /** File extension every chat document carries, whatever the export format was. */
+    private static final String CHAT_FILE_EXT = "chat";
+
+    /** Chunks are born enabled; an operator disables them afterwards. */
+    private static final int ENABLED = 1;
+
+    private final DocumentMapper documentMapper;
+    private final DocumentVersionMapper documentVersionMapper;
+    private final ChunkMapper chunkMapper;
+    private final KnowledgeBaseService knowledgeBaseService;
+    private final ChatSessionMatcher sessionMatcher;
+    private final ChatWindowAggregator windowAggregator;
+    private final ChatWindowRenderer windowRenderer;
+    private final DocumentCleaner documentCleaner;
+    private final ChunkTextHasher chunkTextHasher;
+    private final ChunkIndexWriter chunkIndexWriter;
+    private final ChunkEmbedder chunkEmbedder;
+    private final DocumentVersionActivator versionActivator;
+    private final AnnotationInheritanceService annotationInheritanceService;
+    private final EmbeddingProvider embeddingProvider;
+    private final BizIdGenerator bizIdGenerator;
+    private final VersionFingerprintFactory fingerprintFactory;
+    private final DocumentVersionPlanner versionPlanner;
+
+    /**
+     * Imports one conversation as a new document or as a new version of an existing one.
+     *
+     * @param kbId          target knowledge base
+     * @param session       conversation to import
+     * @param config        knowledge base index configuration
+     * @param rules         cleaning rules of the chat path
+     * @param existingDocId document already carrying the conversation, {@code null} when it is new
+     * @return document business id
+     */
+    public String importSession(String kbId, ParsedChatFile.ChatSession session, KbIndexConfig config,
+                                CleanRules rules, String existingDocId) {
+        Document document = existingDocId == null
+                ? createDocument(kbId, session)
+                : loadDocument(existingDocId, session);
+        DocumentVersion version = createVersion(document, session);
+
+        List<ChatWindow> windows = windowAggregator.aggregate(session.messagesOrEmpty(),
+                config.chatAggregationOrDefaults());
+        List<Chunk> chunks = new ArrayList<>(windows.size());
+        boolean embeddingConfigured = embeddingProvider.isConfigured();
+        for (ChatWindow window : windows) {
+            String text = documentCleaner.cleanFragment(windowRenderer.render(window), rules);
+            if (text == null || text.isBlank()) {
+                continue;
+            }
+            chunks.add(persistChunk(document, version, window, session, text, embeddingConfigured));
+        }
+        version.setChunkFingerprint(fingerprintFactory.chunkFingerprint(config));
+        version.setParseFingerprint(fingerprintFactory.parseFingerprint(config, CHAT_FILE_EXT));
+        version.setEmbeddingVersion(embeddingProvider.model());
+        documentVersionMapper.updateById(version);
+
+        if (CollectionUtils.isNotEmpty(chunks)) {
+            chunkIndexWriter.write(kbId, chunks, chunkEmbedder.embed(chunks));
+        }
+        // Replacing the whole content is the requirement for a re-import, so the chunks of the version that
+        // was active until now are removed only after the new ones are searchable.
+        removePreviousChunks(kbId, document, version.getVersionId());
+        versionActivator.activate(document, version);
+        // A conversation re-imported under the same identity is a new version of the same document, so the
+        // disable decisions taken on the previous one follow the text exactly as they do for an upload.
+        annotationInheritanceService.inherit(document, version);
+        log.info("chat session imported, kbId={}, docId={}, versionId={}, windows={}, chunks={}",
+                kbId, document.getDocId(), version.getVersionId(), windows.size(), chunks.size());
+        return document.getDocId();
+    }
+
+    private Document createDocument(String kbId, ParsedChatFile.ChatSession session) {
+        Document document = new Document();
+        document.setDocId(bizIdGenerator.documentId());
+        document.setKbId(kbId);
+        document.setFileName(sessionMatcher.displayNameOf(session));
+        document.setFileExt(CHAT_FILE_EXT);
+        document.setFileSize(0L);
+        document.setProcessStatus(ProcessStatus.INDEXING);
+        document.setConfigStale(0);
+        document.setSourceKey(sessionMatcher.sourceKeyOf(session.getSessionId()));
+        documentMapper.insert(document);
+        return document;
+    }
+
+    /**
+     * Loads the document a conversation already maps to and refreshes its display name.
+     *
+     * @param docId   document business id
+     * @param session conversation being re-imported
+     * @return document record
+     */
+    private Document loadDocument(String docId, ParsedChatFile.ChatSession session) {
+        Document document = documentMapper.selectOne(new LambdaQueryWrapper<Document>()
+                .eq(Document::getDocId, docId)
+                .last("limit 1"));
+        if (document == null) {
+            throw BizException.notFound("document not found: " + docId);
+        }
+        // A renamed conversation keeps its identity but should show its current name in the console.
+        document.setFileName(sessionMatcher.displayNameOf(session));
+        documentMapper.updateById(document);
+        return document;
+    }
+
+    /**
+     * Creates the version this import writes into.
+     *
+     * @param document document record
+     * @param session  conversation being imported
+     * @return persisted version row
+     */
+    private DocumentVersion createVersion(Document document, ParsedChatFile.ChatSession session) {
+        DocumentVersion version = new DocumentVersion();
+        version.setVersionId(bizIdGenerator.documentVersionId());
+        version.setDocId(document.getDocId());
+        version.setVersion(nextVersionNumber(document.getDocId()));
+        version.setContentHash(HashUtil.sha256Hex(
+                JsonUtil.toJson(session.messagesOrEmpty()).getBytes(StandardCharsets.UTF_8)));
+        version.setStatus(DocumentVersionStatus.BUILDING);
+        documentVersionMapper.insert(version);
+        return version;
+    }
+
+    /**
+     * Computes the next version number of a document.
+     *
+     * <p>The minor part is bumped: a re-import replaces the content of the same logical document, which is
+     * a revision of it and not a new lineage. The numbering itself is delegated so the upload path and the
+     * chat path can never drift into two different version ladders for the same table.
+     *
+     * @param docId document business id
+     * @return version number in {@code major.minor} form
+     */
+    private String nextVersionNumber(String docId) {
+        return versionPlanner.nextMinor(documentVersionMapper.selectList(
+                new LambdaQueryWrapper<DocumentVersion>().eq(DocumentVersion::getDocId, docId)));
+    }
+
+    private Chunk persistChunk(Document document, DocumentVersion version, ChatWindow window,
+                               ParsedChatFile.ChatSession session, String text, boolean embeddingConfigured) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ChunkMetadataKeys.SESSION_ID, session.getSessionId());
+        metadata.put(ChunkMetadataKeys.SESSION_NAME, sessionMatcher.displayNameOf(session));
+        metadata.put(ChunkMetadataKeys.SENDER, String.join(",", window.getSenders()));
+        metadata.put(ChunkMetadataKeys.MSG_TIME, window.getStartTime());
+        // Written for every window, overlap configured or not: the retrieval side recognises an aggregation
+        // window by the presence of the span, so writing it only when the overlap is on would make the
+        // near duplicate merging silently inapplicable to everything imported before the switch was flipped.
+        metadata.put(ChunkMetadataKeys.WINDOW_SEQ, window.getSeq());
+        metadata.put(ChunkMetadataKeys.MSG_SPAN, List.of(window.getMsgSpanStart(), window.getMsgSpanEnd()));
+
+        Chunk chunk = new Chunk();
+        chunk.setChunkId(bizIdGenerator.chunkId());
+        chunk.setKbId(document.getKbId());
+        chunk.setDocId(document.getDocId());
+        chunk.setDocumentVersionId(version.getVersionId());
+        chunk.setContent(text);
+        chunk.setChunkTextHash(chunkTextHasher.hash(text));
+        chunk.setSeq(window.getSeq());
+        chunk.setChunkType(ChunkType.CHAT_LOG);
+        chunk.setEnabled(ENABLED);
+        chunk.setMetadata(JsonUtil.toJson(metadata));
+        chunk.setEmbeddingStatus(embeddingConfigured ? EmbeddingStatus.PENDING : EmbeddingStatus.SKIPPED);
+        chunkMapper.insert(chunk);
+        return chunk;
+    }
+
+    /**
+     * Removes the chunks of every version of the document except the one just built.
+     *
+     * @param kbId          knowledge base business id
+     * @param document      document record
+     * @param keepVersionId version whose chunks must survive
+     */
+    private void removePreviousChunks(String kbId, Document document, String keepVersionId) {
+        knowledgeBaseService.removeChunks(kbId, new LambdaQueryWrapper<Chunk>()
+                .eq(Chunk::getDocId, document.getDocId())
+                .ne(Chunk::getDocumentVersionId, keepVersionId));
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalCaseRunner.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalCaseRunner.java
@@ -1,0 +1,243 @@
+package io.kbrag.app.eval;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.kbrag.app.chat.AnswerGenerationService;
+import io.kbrag.app.retrieval.OfflineExecutionContext;
+import io.kbrag.app.retrieval.RetrievalCommand;
+import io.kbrag.app.retrieval.RetrievalMetadataKeys;
+import io.kbrag.app.retrieval.RetrievalNodeView;
+import io.kbrag.app.retrieval.RetrievalService;
+import io.kbrag.app.retrieval.SearchOutcome;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.entity.EvalCase;
+import io.kbrag.domain.enums.AnchorType;
+import io.kbrag.domain.enums.EvalMode;
+import io.kbrag.domain.model.AnswerEvaluationConfig;
+import io.kbrag.domain.model.CaseJudgment;
+import io.kbrag.domain.model.ChatMessage;
+import io.kbrag.domain.model.EvalEvidence;
+import io.kbrag.domain.model.EvalRetrievalConfig;
+import io.kbrag.domain.service.EvalHitJudge;
+import io.kbrag.domain.service.OverlapRatioCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs one evaluation case end to end and reports what happened to it.
+ *
+ * <p>Split out of {@link EvalRunService} along the boundary between a run and a case. The service owns
+ * the run: it validates a submission, creates one row per configuration of the matrix, fans the cases out
+ * over the case executor, aggregates the metrics and writes the results. This class owns a single case -
+ * search, retry a degraded answer, judge the hit, optionally ask the LLM judge and optionally generate and
+ * judge a final answer - and knows nothing about runs, matrices or persistence.
+ *
+ * <p>Nothing here touches a mapper. A case is a pure function of the corpus and the configuration under
+ * test, which is what makes it safe to run many of them concurrently; the moment it wrote a row it would
+ * stop being one.
+ *
+ * <p>{@link #answerJudgeRequested} is static and public because the cost estimate has to predict the very
+ * same decision before any case runs. Two copies of that predicate would be two answers to "will this case
+ * call the model", and the estimate exists precisely to be trusted.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EvalCaseRunner {
+
+    private final RetrievalService retrievalService;
+    private final EvalJudgeService evalJudgeService;
+    private final AnswerGenerationService answerGenerationService;
+    private final FinalAnswerJudgeService finalAnswerJudgeService;
+    private final EvalHitJudge evalHitJudge;
+    private final OverlapRatioCalculator overlapRatioCalculator;
+    private final KbProperties properties;
+
+    /**
+     * What one case produced.
+     *
+     * @param caseId           case business id
+     * @param judgment         case level judgment
+     * @param overlapRatios    best individual overlap ratio per evidence, empty for a document anchor
+     * @param recalledChunkIds chunk ids the top K returned
+     * @param degraded         degradation markers observed on the final attempt
+     * @param retryCount       automatic retries actually performed
+     * @param judgeOutcome     LLM-as-judge outcome, {@code null} when not judged
+     * @param answerOutcome    generated answer and its judgment, {@code null} when not requested
+     * @param anchorType       anchoring granularity, for metrics grouping
+     * @param multiTurn        {@code true} when the case carries a conversation history
+     */
+    public record CaseOutcome(String caseId, CaseJudgment judgment, List<Double> overlapRatios,
+                              List<String> recalledChunkIds, List<String> degraded, int retryCount,
+                              EvalJudgeService.JudgeOutcome judgeOutcome, AnswerCaseOutcome answerOutcome,
+                              AnchorType anchorType,
+                              boolean multiTurn) {
+    }
+
+    /** Generated answer and its structured judgment for one judgeable case. */
+    public record AnswerCaseOutcome(String generatedAnswer, int generationLatencyMs,
+                                    FinalAnswerJudgeService.JudgeOutcome judgeOutcome) {
+    }
+
+    /**
+     * Tells whether a case asks for the final answer stage.
+     *
+     * <p>A refusal expectation counts: "this question must be declined" is judged on a generated answer
+     * exactly like a factual one, and skipping generation for it would make the refusal untestable.
+     *
+     * @param evalCase case being inspected
+     * @return {@code true} when the case is to be answered and judged
+     */
+    public static boolean answerJudgeRequested(EvalCase evalCase) {
+        return Boolean.TRUE.equals(evalCase.getExpectedRefusal())
+                || evalCase.getExpectedAnswer() != null && !evalCase.getExpectedAnswer().isBlank();
+    }
+
+    /**
+     * Searches for one case and judges what came back.
+     *
+     * <p>A degraded answer is retried up to the configured budget: a degradation means a route the
+     * configuration asked for did not run, so the numbers measured on it would describe a different
+     * configuration than the one under test.
+     *
+     * @param kbId         knowledge base business id
+     * @param evalCase     case to run
+     * @param config       retrieval configuration under test
+     * @param judgeEnabled {@code true} runs the LLM-as-judge stage
+     * @param answerConfig final answer configuration, {@code null} when the run does not answer
+     * @return the case outcome
+     */
+    public CaseOutcome run(String kbId, EvalCase evalCase, EvalRetrievalConfig config,
+                           boolean judgeEnabled, AnswerEvaluationConfig answerConfig) {
+        RetrievalCommand command = toCommand(evalCase, config);
+        int budget = properties.getEval().getDegradedRetry();
+        SearchOutcome outcome = OfflineExecutionContext.runOffline(() -> retrievalService.search(kbId, command));
+        int retries = 0;
+        while (!outcome.getDegraded().isEmpty() && retries < budget) {
+            retries++;
+            outcome = OfflineExecutionContext.runOffline(() -> retrievalService.search(kbId, command));
+        }
+
+        List<RetrievalNodeView> nodes = outcome.getNodes();
+        List<List<String>> candidateTextsPerRank = new ArrayList<>(nodes.size());
+        List<String> docIdPerRank = new ArrayList<>(nodes.size());
+        List<String> recalledChunkIds = new ArrayList<>(nodes.size());
+        for (RetrievalNodeView node : nodes) {
+            candidateTextsPerRank.add(childTextsOf(node));
+            docIdPerRank.add(node.getDocId());
+            recalledChunkIds.add(node.getChunkId());
+        }
+
+        List<EvalEvidence> evidences = evidencesOf(evalCase);
+        CaseJudgment judgment;
+        List<Double> overlapRatios = new ArrayList<>();
+        if (evalCase.getAnchorType() == AnchorType.SPAN) {
+            List<String> spans = evidences.stream().map(EvalEvidence::getSpan).toList();
+            judgment = evalHitJudge.judgeSpanCase(spans, candidateTextsPerRank,
+                    properties.getEval().getOverlapThreshold());
+            for (String span : spans) {
+                overlapRatios.add(bestOverlapRatio(candidateTextsPerRank, span));
+            }
+        } else {
+            List<String> docIds = evidences.stream().map(EvalEvidence::getDocId).toList();
+            judgment = evalHitJudge.judgeDocumentCase(docIds, docIdPerRank);
+        }
+
+        EvalJudgeService.JudgeOutcome judgeOutcome = null;
+        if (judgeEnabled && evalCase.getExpectedAnswer() != null && !evalCase.getExpectedAnswer().isBlank()
+                && evalJudgeService.isAvailable()) {
+            List<String> allTexts = candidateTextsPerRank.stream().flatMap(List::stream).toList();
+            judgeOutcome = evalJudgeService.judge(evalCase.getExpectedAnswer(), allTexts);
+        }
+
+        AnswerCaseOutcome answerOutcome = answerOneCase(evalCase, nodes, answerConfig);
+
+        boolean multiTurn = evalCase.getMessages() != null && !evalCase.getMessages().isBlank();
+        return new CaseOutcome(evalCase.getCaseId(), judgment, overlapRatios, recalledChunkIds,
+                outcome.getDegraded(), retries, judgeOutcome, answerOutcome, evalCase.getAnchorType(), multiTurn);
+    }
+
+    private AnswerCaseOutcome answerOneCase(EvalCase evalCase, List<RetrievalNodeView> nodes,
+                                            AnswerEvaluationConfig config) {
+        if (config == null || !answerJudgeRequested(evalCase)) {
+            return null;
+        }
+        long startedAt = System.currentTimeMillis();
+        String answer = answerGenerationService.generate(config.snapshot(), evalCase.getQuery(),
+                messagesOf(evalCase), nodes);
+        long elapsed = System.currentTimeMillis() - startedAt;
+        int latencyMs = elapsed > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) elapsed;
+        List<String> passages = nodes.stream().map(RetrievalNodeView::getContent).toList();
+        FinalAnswerJudgeService.JudgeOutcome judgment = finalAnswerJudgeService.judge(
+                evalCase.getExpectedAnswer(), Boolean.TRUE.equals(evalCase.getExpectedRefusal()),
+                config.snapshot().promptOrDefaults().isCitationEnabled(), answer, passages);
+        return new AnswerCaseOutcome(answer, latencyMs, judgment);
+    }
+
+    private double bestOverlapRatio(List<List<String>> candidateTextsPerRank, String span) {
+        double best = 0.0d;
+        for (List<String> rankTexts : candidateTextsPerRank) {
+            for (String text : rankTexts) {
+                best = Math.max(best, overlapRatioCalculator.overlapRatio(text, span));
+            }
+        }
+        return best;
+    }
+
+    private List<String> childTextsOf(RetrievalNodeView node) {
+        Object childrenRaw = node.getMetadata() == null ? null
+                : node.getMetadata().get(RetrievalMetadataKeys.CHILDREN);
+        if (!(childrenRaw instanceof List<?> children) || children.isEmpty()) {
+            return List.of(node.getContent());
+        }
+        List<String> texts = new ArrayList<>(children.size());
+        for (Object child : children) {
+            if (child instanceof Map<?, ?> map) {
+                Object content = map.get(RetrievalMetadataKeys.CHILD_CONTENT);
+                if (content != null) {
+                    texts.add(String.valueOf(content));
+                }
+            }
+        }
+        return texts.isEmpty() ? List.of(node.getContent()) : texts;
+    }
+
+    private RetrievalCommand toCommand(EvalCase evalCase, EvalRetrievalConfig config) {
+        EvalMode mode = config.getMode();
+        return RetrievalCommand.builder()
+                .query(evalCase.getQuery())
+                .messages(messagesOf(evalCase))
+                .recallTopK(config.getRecallTopK())
+                .topN(config.getTopN())
+                .fusionMode(config.getFusion())
+                .scoreThreshold(config.getScoreThreshold())
+                .rewriteEnabled(config.getRewriteEnabled())
+                .rerankEnabled(mode.rerankRequested())
+                .bm25RouteEnabled(mode.bm25RouteEnabled())
+                .vectorRouteEnabled(mode.vectorRouteEnabled())
+                .build();
+    }
+
+    private List<ChatMessage> messagesOf(EvalCase evalCase) {
+        if (evalCase.getMessages() == null || evalCase.getMessages().isBlank()) {
+            return List.of();
+        }
+        List<ChatMessage> messages = JsonUtil.parse(evalCase.getMessages(), new TypeReference<List<ChatMessage>>() {
+        });
+        return messages == null ? List.of() : messages;
+    }
+
+    private List<EvalEvidence> evidencesOf(EvalCase evalCase) {
+        List<EvalEvidence> evidences = JsonUtil.parse(evalCase.getEvidences(),
+                new TypeReference<List<EvalEvidence>>() {
+                });
+        return evidences == null ? List.of() : evidences;
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalRunService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/eval/EvalRunService.java
@@ -3,20 +3,17 @@ package io.kbrag.app.eval;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.kbrag.app.config.AsyncConfig;
 import io.kbrag.app.appcenter.AppVersionService;
 import io.kbrag.app.chat.AnswerGenerationService;
+import io.kbrag.app.eval.EvalCaseRunner.AnswerCaseOutcome;
+import io.kbrag.app.eval.EvalCaseRunner.CaseOutcome;
 import io.kbrag.app.retrieval.RetrievalCommand;
-import io.kbrag.app.retrieval.RetrievalNodeView;
-import io.kbrag.app.retrieval.RetrievalMetadataKeys;
 import io.kbrag.app.retrieval.RetrievalService;
 import io.kbrag.app.retrieval.OfflineExecutionContext;
-import io.kbrag.app.retrieval.SearchOutcome;
 import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.common.util.JsonUtil;
-import io.kbrag.domain.config.KbProperties;
 import io.kbrag.domain.entity.EvalCase;
 import io.kbrag.domain.entity.EvalDataset;
 import io.kbrag.domain.entity.EvalResult;
@@ -32,21 +29,16 @@ import io.kbrag.domain.mapper.EvalResultMapper;
 import io.kbrag.domain.mapper.EvalRunMapper;
 import io.kbrag.domain.model.CaseJudgment;
 import io.kbrag.domain.model.AnswerEvaluationConfig;
-import io.kbrag.domain.model.ChatMessage;
-import io.kbrag.domain.model.EvalEvidence;
 import io.kbrag.domain.model.EvalMetricsAtK;
 import io.kbrag.domain.model.EvalRetrievalConfig;
 import io.kbrag.domain.model.FinalAnswerCaseOutcome;
 import io.kbrag.domain.model.FinalAnswerJudgment;
-import io.kbrag.domain.model.FinalAnswerMetrics;
 import io.kbrag.domain.port.ChatProvider;
 import io.kbrag.domain.port.EmbeddingProvider;
 import io.kbrag.domain.port.RerankProvider;
 import io.kbrag.domain.service.BizIdGenerator;
-import io.kbrag.domain.service.EvalHitJudge;
 import io.kbrag.domain.service.EvalMetricsCalculator;
 import io.kbrag.domain.service.FinalAnswerMetricsCalculator;
-import io.kbrag.domain.service.OverlapRatioCalculator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -97,12 +89,12 @@ public class EvalRunService {
     private static final String QUEUE_FULL_REASON = "评测执行队列已满：当前并发评测数已达部署上限，本次运行未能进入"
             + "执行队列，请等待在跑的评测结束后重新提交";
 
+    private final EvalCaseRunner caseRunner;
     private final EvalDatasetService evalDatasetService;
     private final AppVersionService appVersionService;
     private final EvalRunMapper evalRunMapper;
     private final EvalResultMapper evalResultMapper;
     private final EvalCaseMapper evalCaseMapper;
-    private final RetrievalService retrievalService;
     private final EmbeddingProvider embeddingProvider;
     private final RerankProvider rerankProvider;
     private final ChatProvider chatProvider;
@@ -110,21 +102,18 @@ public class EvalRunService {
     private final AnswerGenerationService answerGenerationService;
     private final FinalAnswerJudgeService finalAnswerJudgeService;
     private final CorpusFingerprintFactory corpusFingerprintFactory;
-    private final EvalHitJudge evalHitJudge;
     private final EvalMetricsCalculator evalMetricsCalculator;
     private final FinalAnswerMetricsCalculator finalAnswerMetricsCalculator;
-    private final OverlapRatioCalculator overlapRatioCalculator;
     private final BizIdGenerator bizIdGenerator;
-    private final KbProperties properties;
     private final Executor evalExecutor;
     private final Executor evalCaseExecutor;
 
-    public EvalRunService(EvalDatasetService evalDatasetService,
+    public EvalRunService(EvalCaseRunner caseRunner,
+                          EvalDatasetService evalDatasetService,
                           AppVersionService appVersionService,
                           EvalRunMapper evalRunMapper,
                           EvalResultMapper evalResultMapper,
                           EvalCaseMapper evalCaseMapper,
-                          RetrievalService retrievalService,
                           EmbeddingProvider embeddingProvider,
                           RerankProvider rerankProvider,
                           ChatProvider chatProvider,
@@ -132,20 +121,17 @@ public class EvalRunService {
                           AnswerGenerationService answerGenerationService,
                           FinalAnswerJudgeService finalAnswerJudgeService,
                           CorpusFingerprintFactory corpusFingerprintFactory,
-                          EvalHitJudge evalHitJudge,
                           EvalMetricsCalculator evalMetricsCalculator,
                           FinalAnswerMetricsCalculator finalAnswerMetricsCalculator,
-                          OverlapRatioCalculator overlapRatioCalculator,
                           BizIdGenerator bizIdGenerator,
-                          KbProperties properties,
                           @Qualifier(AsyncConfig.EVAL_EXECUTOR) Executor evalExecutor,
                           @Qualifier(AsyncConfig.EVAL_CASE_EXECUTOR) Executor evalCaseExecutor) {
+        this.caseRunner = caseRunner;
         this.evalDatasetService = evalDatasetService;
         this.appVersionService = appVersionService;
         this.evalRunMapper = evalRunMapper;
         this.evalResultMapper = evalResultMapper;
         this.evalCaseMapper = evalCaseMapper;
-        this.retrievalService = retrievalService;
         this.embeddingProvider = embeddingProvider;
         this.rerankProvider = rerankProvider;
         this.chatProvider = chatProvider;
@@ -153,12 +139,9 @@ public class EvalRunService {
         this.answerGenerationService = answerGenerationService;
         this.finalAnswerJudgeService = finalAnswerJudgeService;
         this.corpusFingerprintFactory = corpusFingerprintFactory;
-        this.evalHitJudge = evalHitJudge;
         this.evalMetricsCalculator = evalMetricsCalculator;
         this.finalAnswerMetricsCalculator = finalAnswerMetricsCalculator;
-        this.overlapRatioCalculator = overlapRatioCalculator;
         this.bizIdGenerator = bizIdGenerator;
-        this.properties = properties;
         this.evalExecutor = evalExecutor;
         this.evalCaseExecutor = evalCaseExecutor;
     }
@@ -275,7 +258,7 @@ public class EvalRunService {
                         && !evalCase.getExpectedAnswer().isBlank())
                 .count();
         long judgeableCases = cases.stream()
-                .filter(this::answerJudgeRequested)
+                .filter(EvalCaseRunner::answerJudgeRequested)
                 .count();
         boolean answerAvailable = answerConfig == null
                 || answerGenerationService.isAvailable(answerConfig.snapshot())
@@ -565,7 +548,7 @@ public class EvalRunService {
 
             AnswerEvaluationConfig answerConfig = run.getAnswerEvalConfig() == null ? null
                     : JsonUtil.parse(run.getAnswerEvalConfig(), AnswerEvaluationConfig.class);
-            List<CaseOutcome> outcomes = judgeAll(run.getKbId(), effective, config, k, judgeEnabled,
+            List<CaseOutcome> outcomes = judgeAll(run.getKbId(), effective, config, judgeEnabled,
                     answerConfig);
             for (CaseOutcome outcome : outcomes) {
                 evalResultMapper.insert(toEntity(runId, outcome));
@@ -608,11 +591,10 @@ public class EvalRunService {
      * @param kbId         knowledge base business id
      * @param cases        the run's effective cases
      * @param config       retrieval configuration under test
-     * @param k            metrics {@code K}
      * @param judgeEnabled {@code true} runs the LLM-as-judge stage
      * @return one outcome per case, in the order the cases were given
      */
-    private List<CaseOutcome> judgeAll(String kbId, List<EvalCase> cases, EvalRetrievalConfig config, int k,
+    private List<CaseOutcome> judgeAll(String kbId, List<EvalCase> cases, EvalRetrievalConfig config,
                                        boolean judgeEnabled, AnswerEvaluationConfig answerConfig) {
         if (CollectionUtils.isEmpty(cases)) {
             return List.of();
@@ -620,7 +602,7 @@ public class EvalRunService {
         List<CompletableFuture<CaseOutcome>> futures = new ArrayList<>(cases.size());
         for (EvalCase evalCase : cases) {
             futures.add(CompletableFuture.supplyAsync(
-                    () -> judgeOneCase(kbId, evalCase, config, k, judgeEnabled, answerConfig),
+                    () -> caseRunner.run(kbId, evalCase, config, judgeEnabled, answerConfig),
                     evalCaseExecutor));
         }
         List<CaseOutcome> outcomes = new ArrayList<>(cases.size());
@@ -632,138 +614,6 @@ public class EvalRunService {
             throw new IllegalStateException("evaluation case execution failed", e.getCause());
         }
         return outcomes;
-    }
-
-    private CaseOutcome judgeOneCase(String kbId, EvalCase evalCase, EvalRetrievalConfig config, int k,
-                                     boolean judgeEnabled, AnswerEvaluationConfig answerConfig) {
-        RetrievalCommand command = toCommand(evalCase, config);
-        int budget = properties.getEval().getDegradedRetry();
-        SearchOutcome outcome = OfflineExecutionContext.runOffline(() -> retrievalService.search(kbId, command));
-        int retries = 0;
-        while (!outcome.getDegraded().isEmpty() && retries < budget) {
-            retries++;
-            outcome = OfflineExecutionContext.runOffline(() -> retrievalService.search(kbId, command));
-        }
-
-        List<RetrievalNodeView> nodes = outcome.getNodes();
-        List<List<String>> candidateTextsPerRank = new ArrayList<>(nodes.size());
-        List<String> docIdPerRank = new ArrayList<>(nodes.size());
-        List<String> recalledChunkIds = new ArrayList<>(nodes.size());
-        for (RetrievalNodeView node : nodes) {
-            candidateTextsPerRank.add(childTextsOf(node));
-            docIdPerRank.add(node.getDocId());
-            recalledChunkIds.add(node.getChunkId());
-        }
-
-        List<EvalEvidence> evidences = evidencesOf(evalCase);
-        CaseJudgment judgment;
-        List<Double> overlapRatios = new ArrayList<>();
-        if (evalCase.getAnchorType() == AnchorType.SPAN) {
-            List<String> spans = evidences.stream().map(EvalEvidence::getSpan).toList();
-            judgment = evalHitJudge.judgeSpanCase(spans, candidateTextsPerRank,
-                    properties.getEval().getOverlapThreshold());
-            for (String span : spans) {
-                overlapRatios.add(bestOverlapRatio(candidateTextsPerRank, span));
-            }
-        } else {
-            List<String> docIds = evidences.stream().map(EvalEvidence::getDocId).toList();
-            judgment = evalHitJudge.judgeDocumentCase(docIds, docIdPerRank);
-        }
-
-        EvalJudgeService.JudgeOutcome judgeOutcome = null;
-        if (judgeEnabled && evalCase.getExpectedAnswer() != null && !evalCase.getExpectedAnswer().isBlank()
-                && evalJudgeService.isAvailable()) {
-            List<String> allTexts = candidateTextsPerRank.stream().flatMap(List::stream).toList();
-            judgeOutcome = evalJudgeService.judge(evalCase.getExpectedAnswer(), allTexts);
-        }
-
-        AnswerCaseOutcome answerOutcome = answerOneCase(evalCase, nodes, answerConfig);
-
-        boolean multiTurn = evalCase.getMessages() != null && !evalCase.getMessages().isBlank();
-        return new CaseOutcome(evalCase.getCaseId(), judgment, overlapRatios, recalledChunkIds,
-                outcome.getDegraded(), retries, judgeOutcome, answerOutcome, evalCase.getAnchorType(), multiTurn);
-    }
-
-    private AnswerCaseOutcome answerOneCase(EvalCase evalCase, List<RetrievalNodeView> nodes,
-                                            AnswerEvaluationConfig config) {
-        if (config == null || !answerJudgeRequested(evalCase)) {
-            return null;
-        }
-        long startedAt = System.currentTimeMillis();
-        String answer = answerGenerationService.generate(config.snapshot(), evalCase.getQuery(),
-                messagesOf(evalCase), nodes);
-        long elapsed = System.currentTimeMillis() - startedAt;
-        int latencyMs = elapsed > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) elapsed;
-        List<String> passages = nodes.stream().map(RetrievalNodeView::getContent).toList();
-        FinalAnswerJudgeService.JudgeOutcome judgment = finalAnswerJudgeService.judge(
-                evalCase.getExpectedAnswer(), Boolean.TRUE.equals(evalCase.getExpectedRefusal()),
-                config.snapshot().promptOrDefaults().isCitationEnabled(), answer, passages);
-        return new AnswerCaseOutcome(answer, latencyMs, judgment);
-    }
-
-    private boolean answerJudgeRequested(EvalCase evalCase) {
-        return Boolean.TRUE.equals(evalCase.getExpectedRefusal())
-                || evalCase.getExpectedAnswer() != null && !evalCase.getExpectedAnswer().isBlank();
-    }
-
-    private double bestOverlapRatio(List<List<String>> candidateTextsPerRank, String span) {
-        double best = 0.0d;
-        for (List<String> rankTexts : candidateTextsPerRank) {
-            for (String text : rankTexts) {
-                best = Math.max(best, overlapRatioCalculator.overlapRatio(text, span));
-            }
-        }
-        return best;
-    }
-
-    private List<String> childTextsOf(RetrievalNodeView node) {
-        Object childrenRaw = node.getMetadata() == null ? null
-                : node.getMetadata().get(RetrievalMetadataKeys.CHILDREN);
-        if (!(childrenRaw instanceof List<?> children) || children.isEmpty()) {
-            return List.of(node.getContent());
-        }
-        List<String> texts = new ArrayList<>(children.size());
-        for (Object child : children) {
-            if (child instanceof Map<?, ?> map) {
-                Object content = map.get(RetrievalMetadataKeys.CHILD_CONTENT);
-                if (content != null) {
-                    texts.add(String.valueOf(content));
-                }
-            }
-        }
-        return texts.isEmpty() ? List.of(node.getContent()) : texts;
-    }
-
-    private RetrievalCommand toCommand(EvalCase evalCase, EvalRetrievalConfig config) {
-        EvalMode mode = config.getMode();
-        return RetrievalCommand.builder()
-                .query(evalCase.getQuery())
-                .messages(messagesOf(evalCase))
-                .recallTopK(config.getRecallTopK())
-                .topN(config.getTopN())
-                .fusionMode(config.getFusion())
-                .scoreThreshold(config.getScoreThreshold())
-                .rewriteEnabled(config.getRewriteEnabled())
-                .rerankEnabled(mode.rerankRequested())
-                .bm25RouteEnabled(mode.bm25RouteEnabled())
-                .vectorRouteEnabled(mode.vectorRouteEnabled())
-                .build();
-    }
-
-    private List<ChatMessage> messagesOf(EvalCase evalCase) {
-        if (evalCase.getMessages() == null || evalCase.getMessages().isBlank()) {
-            return List.of();
-        }
-        List<ChatMessage> messages = JsonUtil.parse(evalCase.getMessages(), new TypeReference<List<ChatMessage>>() {
-        });
-        return messages == null ? List.of() : messages;
-    }
-
-    private List<EvalEvidence> evidencesOf(EvalCase evalCase) {
-        List<EvalEvidence> evidences = JsonUtil.parse(evalCase.getEvidences(),
-                new TypeReference<List<EvalEvidence>>() {
-                });
-        return evidences == null ? List.of() : evidences;
     }
 
     private EvalResult toEntity(String runId, CaseOutcome outcome) {
@@ -863,31 +713,6 @@ public class EvalRunService {
             return "internal error";
         }
         return message.length() > 1024 ? message.substring(0, 1024) : message;
-    }
-
-    /**
-     * Judgment of one case together with everything the drill down and the metrics grouping need.
-     *
-     * @param caseId         case business id
-     * @param judgment       case level judgment
-     * @param overlapRatios  best individual overlap ratio per evidence, empty for a document anchor
-     * @param recalledChunkIds chunk ids the top K returned
-     * @param degraded       degradation markers observed on the final attempt
-     * @param retryCount     automatic retries actually performed
-     * @param judgeOutcome   LLM-as-judge outcome, {@code null} when not judged
-     * @param anchorType     anchoring granularity, for metrics grouping
-     * @param multiTurn      {@code true} when the case carries a conversation history
-     */
-    private record CaseOutcome(String caseId, CaseJudgment judgment, List<Double> overlapRatios,
-                               List<String> recalledChunkIds, List<String> degraded, int retryCount,
-                               EvalJudgeService.JudgeOutcome judgeOutcome, AnswerCaseOutcome answerOutcome,
-                               AnchorType anchorType,
-                               boolean multiTurn) {
-    }
-
-    /** Generated answer and its structured judgment for one judgeable case. */
-    private record AnswerCaseOutcome(String generatedAnswer, int generationLatencyMs,
-                                     FinalAnswerJudgeService.JudgeOutcome judgeOutcome) {
     }
 
     /**

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/ChunkSplitter.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/ChunkSplitter.java
@@ -1,0 +1,236 @@
+package io.kbrag.app.index;
+
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.constant.ChunkMetadataKeys;
+import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.DocumentVersion;
+import io.kbrag.domain.enums.ChunkType;
+import io.kbrag.domain.enums.EmbeddingStatus;
+import io.kbrag.domain.mapper.ChunkMapper;
+import io.kbrag.domain.model.KbIndexConfig;
+import io.kbrag.domain.model.PageRange;
+import io.kbrag.domain.model.ParentChunk;
+import io.kbrag.domain.model.ProxiedContent;
+import io.kbrag.domain.model.SplitChunk;
+import io.kbrag.domain.model.SplitParams;
+import io.kbrag.domain.service.BizIdGenerator;
+import io.kbrag.domain.service.ChunkTextHasher;
+import io.kbrag.domain.service.ImageChunkLinker;
+import io.kbrag.domain.service.MetadataRuleExtractor;
+import io.kbrag.domain.service.PageSplitter;
+import io.kbrag.domain.service.ParentChildSplitter;
+import io.kbrag.domain.service.SplitterRouter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cuts one staged document version into chunk rows.
+ *
+ * <p>Split out of {@link IndexPipelineService} along the collaborators: the four splitters, the text
+ * hasher, the metadata rule extractor and the image linker are read here and nowhere else in the
+ * pipeline. What the pipeline keeps is the decision of <em>when</em> to cut and what to do afterwards -
+ * stamping the version fingerprint, moving the task progress, driving the engines; what this class owns
+ * is the cut itself and the rows it produces.
+ *
+ * <p>The strategy questions are answered by the caller and arrive as {@link SplitRequest} flags rather
+ * than being re-derived here. A splitter that could ask "is this a standalone image" would be able to
+ * disagree with the pipeline stage that already decided it, and the two answers drive different
+ * branches - which chunk type is written, and whether the page route runs at all.
+ *
+ * <p>Both levels are persisted, only the indexable ones are returned: a parent is stored so the
+ * retrieval side can read its text out of MySQL, but it is never embedded and never reaches an engine.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChunkSplitter {
+
+    /** Chunks are born enabled; an operator disables them afterwards. */
+    private static final int ENABLED = 1;
+
+    private final SplitterRouter splitterRouter;
+    private final ParentChildSplitter parentChildSplitter;
+    private final PageSplitter pageSplitter;
+    private final ChunkTextHasher chunkTextHasher;
+    private final MetadataRuleExtractor metadataRuleExtractor;
+    private final ImageChunkLinker imageChunkLinker;
+    private final BizIdGenerator bizIdGenerator;
+    private final ChunkMapper chunkMapper;
+
+    /**
+     * One version's text together with every strategy question the pipeline already settled.
+     *
+     * @param document            document record
+     * @param version             version being built
+     * @param proxied             cleaned text and the image placements inside it
+     * @param pageRanges          page boundaries inside that text, empty for every strategy but {@code page}
+     * @param config              knowledge base index configuration
+     * @param embeddingConfigured {@code true} when the vector route is available
+     * @param standaloneImage     {@code true} when the document is one uploaded image
+     * @param pageStrategy        {@code true} when the page strategy applies to this document
+     */
+    public record SplitRequest(Document document, DocumentVersion version, ProxiedContent proxied,
+                               List<PageRange> pageRanges, KbIndexConfig config,
+                               boolean embeddingConfigured, boolean standaloneImage,
+                               boolean pageStrategy) {
+    }
+
+    /**
+     * Cuts the text according to the knowledge base configuration and persists the chunks.
+     *
+     * <p>A standalone image never takes the two level route: the document is a single picture whose whole
+     * text came from the vision model, so there is no structure for a parent to group.
+     *
+     * @param request text to cut and the strategy flags it is cut under
+     * @return chunks that have to reach the engines, parents excluded
+     */
+    public List<Chunk> split(SplitRequest request) {
+        return request.config().parentChildEnabled() && !request.standaloneImage()
+                ? splitTwoLevel(request)
+                : splitSingleLevel(request);
+    }
+
+    /**
+     * Cuts the text into a single level and links each chunk to the images it contains.
+     *
+     * @param request text to cut and the strategy flags it is cut under
+     * @return persisted chunks
+     */
+    private List<Chunk> splitSingleLevel(SplitRequest request) {
+        KbIndexConfig config = request.config();
+        ProxiedContent proxied = request.proxied();
+        SplitParams params = config.splitParams(cacheContextOf(request.document(), request.version()));
+        List<SplitChunk> splitChunks = request.pageStrategy()
+                ? pageSplitter.split(proxied.getMarkdown(), request.pageRanges(), params)
+                : splitterRouter.resolve(config.getSplitStrategy()).split(proxied.getMarkdown(), params);
+        Map<Integer, List<String>> imagesByChunk = imageChunkLinker.link(proxied.getMarkdown(),
+                proxied.getPlacements(), splitChunks.stream().map(SplitChunk::getContent).toList());
+        List<MetadataRuleExtractor.PreparedRule> rules =
+                metadataRuleExtractor.prepare(config.metadataRulesOrEmpty());
+        List<Chunk> chunks = new ArrayList<>(splitChunks.size());
+        for (int index = 0; index < splitChunks.size(); index++) {
+            List<String> imageKeys = imagesByChunk.get(index);
+            SplitChunk splitChunk = splitChunks.get(index);
+            Chunk chunk = persistChunk(request, splitChunk, null, request.embeddingConfigured(),
+                    request.standaloneImage() ? ChunkType.IMAGE : ChunkType.TEXT,
+                    metadataOf(imageKeys, splitChunk,
+                            metadataRuleExtractor.extract(rules, splitChunk.getContent())));
+            chunks.add(chunk);
+        }
+        return chunks;
+    }
+
+    /**
+     * Persists both levels and returns only the children.
+     *
+     * <p>Parents are stored with {@code embedding_status=SKIPPED} because they are never embedded and
+     * never written to an engine; marking them PENDING would make the compensation scan chase a write
+     * that is not supposed to happen.
+     *
+     * @param request text to cut and the strategy flags it is cut under
+     * @return child chunks
+     */
+    private List<Chunk> splitTwoLevel(SplitRequest request) {
+        KbIndexConfig config = request.config();
+        ProxiedContent proxied = request.proxied();
+        List<ParentChunk> groups = parentChildSplitter.split(proxied.getMarkdown(),
+                config.parentChildOrDisabled());
+        List<String> childContents = new ArrayList<>();
+        for (ParentChunk group : groups) {
+            for (SplitChunk child : group.getChildren()) {
+                childContents.add(child.getContent());
+            }
+        }
+        Map<Integer, List<String>> imagesByChunk = imageChunkLinker.link(proxied.getMarkdown(),
+                proxied.getPlacements(), childContents);
+        List<MetadataRuleExtractor.PreparedRule> rules =
+                metadataRuleExtractor.prepare(config.metadataRulesOrEmpty());
+
+        List<Chunk> children = new ArrayList<>();
+        int childIndex = 0;
+        for (ParentChunk group : groups) {
+            Chunk parent = persistChunk(request, group.getParent(), null, false, ChunkType.TEXT, null);
+            for (SplitChunk child : group.getChildren()) {
+                children.add(persistChunk(request, child, parent.getChunkId(),
+                        request.embeddingConfigured(), ChunkType.TEXT,
+                        metadataOf(imagesByChunk.get(childIndex++), child,
+                                metadataRuleExtractor.extract(rules, child.getContent()))));
+            }
+        }
+        return children;
+    }
+
+    /**
+     * Merges the image links a chunk carries with the title/summary/keywords the LLM semantic
+     * splitter attaches to it, requirement section 4.3, and with the operator extracted metadata of
+     * the M14 contract section 3.2.
+     *
+     * <p>The extracted values go in first so a reserved key wins any collision: the platform written
+     * semantics of {@code title} or {@code image_urls} must never be silently replaced by a rule an
+     * operator happened to name the same way.
+     *
+     * @param imageKeys  object storage keys of the images this chunk contains, may be empty
+     * @param splitChunk splitter output, {@code null} metadata for every strategy but the LLM one
+     * @param extracted  metadata rule output for this chunk, may be empty
+     * @return JSON metadata document, {@code null} when there is nothing to store
+     */
+    private String metadataOf(List<String> imageKeys, SplitChunk splitChunk, Map<String, Object> extracted) {
+        Map<String, Object> metadata = new LinkedHashMap<>(extracted);
+        if (CollectionUtils.isNotEmpty(imageKeys)) {
+            metadata.put(ChunkMetadataKeys.IMAGE_URLS, imageKeys);
+        }
+        if (splitChunk != null && splitChunk.getMetadata() != null && !splitChunk.getMetadata().isEmpty()) {
+            metadata.putAll(splitChunk.getMetadata());
+        }
+        return metadata.isEmpty() ? null : JsonUtil.toJson(metadata);
+    }
+
+    /**
+     * Builds the LLM semantic splitter's cache coordinates for one document version.
+     *
+     * @param document document record
+     * @param version  version being built
+     * @return cache context, safe to pass to every strategy since only the LLM one reads it
+     */
+    private SplitParams.CacheContext cacheContextOf(Document document, DocumentVersion version) {
+        return new SplitParams.CacheContext(document.getKbId(), document.getDocId(),
+                version.getVersionId(), version.getContentHash());
+    }
+
+    private Chunk persistChunk(SplitRequest request, SplitChunk splitChunk, String parentId,
+                               boolean embeddingConfigured, ChunkType chunkType, String metadata) {
+        Document document = request.document();
+        Chunk chunk = new Chunk();
+        chunk.setChunkId(bizIdGenerator.chunkId());
+        chunk.setKbId(document.getKbId());
+        chunk.setDocId(document.getDocId());
+        chunk.setDocumentVersionId(request.version().getVersionId());
+        chunk.setContent(splitChunk.getContent());
+        chunk.setChunkTextHash(chunkTextHasher.hash(splitChunk.getContent()));
+        chunk.setParentId(parentId);
+        if (parentId != null) {
+            // Only a child has a position worth storing: the offsets of a single level chunk are relative
+            // to the whole document, and storing them in a column the retrieval side reads as "inside my
+            // parent" would make it cut a passage out of the wrong text.
+            chunk.setParentStartOffset(splitChunk.getStartOffset());
+            chunk.setParentEndOffset(splitChunk.getEndOffset());
+        }
+        chunk.setSeq(splitChunk.getSeq());
+        chunk.setChunkType(chunkType);
+        chunk.setEnabled(ENABLED);
+        chunk.setMetadata(metadata);
+        chunk.setEmbeddingStatus(embeddingConfigured ? EmbeddingStatus.PENDING : EmbeddingStatus.SKIPPED);
+        chunkMapper.insert(chunk);
+        return chunk;
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/IndexPipelineService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/IndexPipelineService.java
@@ -2,56 +2,38 @@ package io.kbrag.app.index;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
-import io.kbrag.app.alert.TaskFailureTracker;
-import io.kbrag.app.annotation.AnnotationInheritanceService;
 import io.kbrag.app.config.AsyncConfig;
-import io.kbrag.app.eval.EvalCaseStalenessService;
-import io.kbrag.app.graph.GraphExtractionService;
 import io.kbrag.app.kb.KnowledgeBaseService;
 import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.common.util.JsonUtil;
-import io.kbrag.domain.constant.ChunkMetadataKeys;
 import io.kbrag.domain.entity.Chunk;
 import io.kbrag.domain.entity.Document;
 import io.kbrag.domain.entity.DocumentVersion;
 import io.kbrag.domain.entity.ImageAsset;
 import io.kbrag.domain.entity.KbTask;
-import io.kbrag.domain.enums.ChunkType;
 import io.kbrag.domain.enums.DocumentVersionStatus;
-import io.kbrag.domain.enums.EmbeddingStatus;
 import io.kbrag.domain.enums.ProcessStatus;
-import io.kbrag.domain.enums.TaskStatus;
 import io.kbrag.domain.enums.TaskType;
 import io.kbrag.domain.mapper.ChunkMapper;
 import io.kbrag.domain.mapper.DocumentMapper;
 import io.kbrag.domain.mapper.DocumentVersionMapper;
-import io.kbrag.domain.mapper.KbTaskMapper;
 import io.kbrag.domain.model.CleanRules;
 import io.kbrag.domain.model.KbIndexConfig;
 import io.kbrag.domain.model.PageRange;
 import io.kbrag.domain.model.PagedContent;
-import io.kbrag.domain.model.ParentChunk;
 import io.kbrag.domain.model.ParsePreview;
 import io.kbrag.domain.model.ParsedDocument;
 import io.kbrag.domain.model.ProxiedContent;
-import io.kbrag.domain.model.SplitChunk;
-import io.kbrag.domain.model.SplitParams;
 import io.kbrag.domain.port.DocumentParserClient;
 import io.kbrag.domain.port.EmbeddingProvider;
 import io.kbrag.domain.port.ObjectStorage;
 import io.kbrag.domain.port.VisionProvider;
-import io.kbrag.domain.service.BizIdGenerator;
-import io.kbrag.domain.service.ChunkTextHasher;
 import io.kbrag.domain.service.DocumentCleaner;
 import io.kbrag.domain.service.DocumentVersionPlanner;
-import io.kbrag.domain.service.ImageChunkLinker;
 import io.kbrag.domain.service.ImagePlaceholderResolver;
-import io.kbrag.domain.service.MetadataRuleExtractor;
 import io.kbrag.domain.service.PageSplitter;
 import io.kbrag.domain.service.PagedContentAssembler;
-import io.kbrag.domain.service.ParentChildSplitter;
-import io.kbrag.domain.service.SplitterRouter;
 import io.kbrag.domain.service.VersionFingerprintFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -104,46 +86,32 @@ public class IndexPipelineService {
     private static final String PREVIEW_OBJECT_TEMPLATE = "kb/%s/doc/%s/%s/preview.json";
     private static final String LEGACY_MARKDOWN_SUFFIX = ".md";
     private static final String CONTENT_TYPE_JSON = "application/json";
-    private static final int ENABLED = 1;
     private static final int PROGRESS_PARSED = 30;
     private static final int PROGRESS_CHUNKED = 60;
     private static final int PROGRESS_INDEXED = 90;
-    private static final int PROGRESS_DONE = 100;
     private static final int NOT_STALE = 0;
     private static final int DELETE_BATCH_SIZE = 500;
-    private static final int FAIL_REASON_MAX_LENGTH = 1024;
 
     private final DocumentMapper documentMapper;
     private final DocumentVersionMapper documentVersionMapper;
     private final ChunkMapper chunkMapper;
-    private final KbTaskMapper kbTaskMapper;
     private final ObjectStorage objectStorage;
     private final DocumentParserClient parserClient;
-    private final SplitterRouter splitterRouter;
-    private final ParentChildSplitter parentChildSplitter;
-    private final PageSplitter pageSplitter;
-    private final ChunkTextHasher chunkTextHasher;
     private final EmbeddingProvider embeddingProvider;
     private final ChunkEmbedder chunkEmbedder;
+    private final ChunkSplitter chunkSplitter;
+    private final IndexTaskLifecycle taskLifecycle;
     private final VisionProvider visionProvider;
     private final ChunkIndexWriter chunkIndexWriter;
     private final MultimodalIndexManager multimodalIndexManager;
     private final KnowledgeBaseService knowledgeBaseService;
-    private final BizIdGenerator bizIdGenerator;
     private final VersionFingerprintFactory fingerprintFactory;
     private final ImageAssetService imageAssetService;
     private final DocumentCleaner documentCleaner;
     private final PagedContentAssembler pagedContentAssembler;
     private final ImagePlaceholderResolver placeholderResolver;
-    private final ImageChunkLinker imageChunkLinker;
-    private final MetadataRuleExtractor metadataRuleExtractor;
-    private final DocumentVersionActivator versionActivator;
     private final VersionArtifactReuser versionArtifactReuser;
-    private final VersionRetentionService versionRetentionService;
-    private final AnnotationInheritanceService annotationInheritanceService;
-    private final TaskFailureTracker taskFailureTracker;
-    private final EvalCaseStalenessService evalCaseStalenessService;
-    private final GraphExtractionService graphExtractionService;
+    private final VersionActivationHandler activationHandler;
 
     /**
      * Queues a document version for indexing.
@@ -215,7 +183,7 @@ public class IndexPipelineService {
     public void execute(String versionId, DocumentVersionPlanner.Reuse reuse) {
         DocumentVersion version = requireVersion(versionId);
         Document document = requireDocument(version.getDocId());
-        KbTask task = startTask(versionId, TaskType.INDEX);
+        KbTask task = taskLifecycle.start(versionId, TaskType.INDEX);
         try {
             KbIndexConfig config = knowledgeBaseService.indexConfigOf(document.getKbId());
             if (reuse.reusesChunks() && indexReusedChunks(document, version, config, reuse, task)) {
@@ -226,7 +194,7 @@ public class IndexPipelineService {
             StagedContent staged = prepare(document, version, config, null, task, adoptParsed(version, reuse));
             if (config.isParsePreviewRequired()) {
                 pauseForConfirmation(document, version, config, staged, null);
-                completeTask(task);
+                taskLifecycle.complete(task);
                 return;
             }
             indexStaged(document, version, config, staged, task);
@@ -257,7 +225,7 @@ public class IndexPipelineService {
     public void confirm(String versionId) {
         DocumentVersion version = requireVersion(versionId);
         Document document = requireDocument(version.getDocId());
-        KbTask task = startTask(versionId, TaskType.INDEX);
+        KbTask task = taskLifecycle.start(versionId, TaskType.INDEX);
         try {
             KbIndexConfig config = knowledgeBaseService.indexConfigOf(document.getKbId());
             ParsePreview preview = readPreview(document, version);
@@ -286,12 +254,12 @@ public class IndexPipelineService {
     public ParsePreview reparse(String versionId, CleanRules override) {
         DocumentVersion version = requireVersion(versionId);
         Document document = requireDocument(version.getDocId());
-        KbTask task = startTask(versionId, TaskType.PARSE);
+        KbTask task = taskLifecycle.start(versionId, TaskType.PARSE);
         try {
             KbIndexConfig config = knowledgeBaseService.indexConfigOf(document.getKbId());
             StagedContent staged = prepare(document, version, config, override, task, true);
             ParsePreview preview = pauseForConfirmation(document, version, config, staged, override);
-            completeTask(task);
+            taskLifecycle.complete(task);
             return preview;
         } catch (Exception e) {
             fail(document, version, task, ProcessStatus.PARSE_FAILED, e.getMessage());
@@ -344,7 +312,7 @@ public class IndexPipelineService {
     private void rebuild(String versionId, boolean activate) {
         DocumentVersion version = requireVersion(versionId);
         Document document = requireDocument(version.getDocId());
-        KbTask task = startTask(versionId, TaskType.REBUILD);
+        KbTask task = taskLifecycle.start(versionId, TaskType.REBUILD);
         try {
             if (activate) {
                 version.setStatus(DocumentVersionStatus.BUILDING);
@@ -363,7 +331,7 @@ public class IndexPipelineService {
             removeObsolete(document.getKbId(), versionId, obsolete);
 
             if (activate) {
-                activateAndFollowUp(document, version);
+                activationHandler.activateAndFollowUp(document, version);
             } else {
                 documentMapper.update(null, new LambdaUpdateWrapper<Document>()
                         .set(Document::getProcessStatus, ProcessStatus.INDEXED.name())
@@ -371,7 +339,7 @@ public class IndexPipelineService {
                         .set(Document::getFailReason, null)
                         .eq(Document::getDocId, document.getDocId()));
             }
-            completeTask(task);
+            taskLifecycle.complete(task);
             log.info("rebuild finished, docId={}, versionId={}, newChunks={}, removedChunks={}, activated={}",
                     document.getDocId(), versionId, chunks.size(), obsolete.size(), activate);
         } catch (Exception e) {
@@ -429,33 +397,11 @@ public class IndexPipelineService {
         version.setChunkFingerprint(fingerprintFactory.chunkFingerprint(config));
         version.setEmbeddingVersion(embeddingProvider.model());
         documentVersionMapper.updateById(version);
-        updateProgress(task, PROGRESS_CHUNKED);
+        taskLifecycle.progress(task, PROGRESS_CHUNKED);
         index(document, version, copied, config, task);
-        activateAndFollowUp(document, version);
-        completeTask(task);
+        activationHandler.activateAndFollowUp(document, version);
+        taskLifecycle.complete(task);
         return true;
-    }
-
-    /**
-     * Makes a freshly built version the active one and runs everything that depends on that.
-     *
-     * <p>Both follow ups belong here rather than inside the activator: the activator is also used by the
-     * chat import path and by a manual rollback, which need the switch without necessarily needing the
-     * same follow ups, and the single active version invariant must not depend on either of them
-     * succeeding.
-     *
-     * @param document document record
-     * @param version  version that finished building
-     */
-    private void activateAndFollowUp(Document document, DocumentVersion version) {
-        versionActivator.activate(document, version);
-        annotationInheritanceService.inherit(document, version);
-        evalCaseStalenessService.markStale(document.getDocId(), version.getVersionId());
-        versionRetentionService.submit(document.getDocId());
-        // Requirement section 4.9: an activation is what invalidates the entities and relations the
-        // superseded versions contributed, otherwise the graph route would keep answering out of a corpus
-        // the other two routes can no longer see - version isolation broken from the side.
-        graphExtractionService.onVersionActivated(document, version);
     }
 
     /**
@@ -617,8 +563,8 @@ public class IndexPipelineService {
         deleteExistingChunks(document.getKbId(), version.getVersionId());
         List<Chunk> chunks = split(document, version, staged, config, task);
         index(document, version, chunks, config, task);
-        activateAndFollowUp(document, version);
-        completeTask(task);
+        activationHandler.activateAndFollowUp(document, version);
+        taskLifecycle.complete(task);
     }
 
     /**
@@ -706,7 +652,7 @@ public class IndexPipelineService {
         version.setParsedObject(parsedKey(document, version));
         documentVersionMapper.updateById(version);
         updateProcessStatus(document, ProcessStatus.PARSED, null);
-        updateProgress(task, PROGRESS_PARSED);
+        taskLifecycle.progress(task, PROGRESS_PARSED);
         return parsed;
     }
 
@@ -768,162 +714,19 @@ public class IndexPipelineService {
     private List<Chunk> split(Document document, DocumentVersion version, StagedContent staged,
                               KbIndexConfig config, KbTask task) {
         boolean embeddingConfigured = embeddingProvider.isConfigured();
-        boolean standaloneImage = imageAssetService.isStandaloneImage(document.getFileExt());
-        List<Chunk> indexable = config.parentChildEnabled() && !standaloneImage
-                ? splitTwoLevel(document, version, staged, config, embeddingConfigured)
-                : splitSingleLevel(document, version, staged, config, embeddingConfigured, standaloneImage);
+        List<Chunk> indexable = chunkSplitter.split(new ChunkSplitter.SplitRequest(document, version,
+                staged.proxied(), staged.pageRanges(), config, embeddingConfigured,
+                imageAssetService.isStandaloneImage(document.getFileExt()),
+                usesPageStrategy(document, config)));
 
         version.setChunkFingerprint(fingerprintFactory.chunkFingerprint(config));
         version.setEmbeddingVersion(embeddingProvider.model());
         documentVersionMapper.updateById(version);
-        updateProgress(task, PROGRESS_CHUNKED);
+        taskLifecycle.progress(task, PROGRESS_CHUNKED);
         log.info("chunks persisted, docId={}, versionId={}, indexable={}, parentChild={}, embeddingConfigured={}",
                 document.getDocId(), version.getVersionId(), indexable.size(),
                 config.parentChildEnabled(), embeddingConfigured);
         return indexable;
-    }
-
-    /**
-     * Cuts the text into a single level and links each chunk to the images it contains.
-     *
-     * @param document            document record
-     * @param version             version being built
-     * @param staged              text to cut
-     * @param config              knowledge base index configuration
-     * @param embeddingConfigured {@code true} when the vector route is available
-     * @param standaloneImage     {@code true} when the document is one uploaded image
-     * @return persisted chunks
-     */
-    private List<Chunk> splitSingleLevel(Document document, DocumentVersion version, StagedContent staged,
-                                         KbIndexConfig config, boolean embeddingConfigured,
-                                         boolean standaloneImage) {
-        SplitParams params = config.splitParams(cacheContextOf(document, version));
-        List<SplitChunk> splitChunks = usesPageStrategy(document, config)
-                ? pageSplitter.split(staged.proxied().getMarkdown(), staged.pageRanges(), params)
-                : splitterRouter.resolve(config.getSplitStrategy())
-                        .split(staged.proxied().getMarkdown(), params);
-        Map<Integer, List<String>> imagesByChunk = imageChunkLinker.link(staged.proxied().getMarkdown(),
-                staged.proxied().getPlacements(), splitChunks.stream().map(SplitChunk::getContent).toList());
-        List<MetadataRuleExtractor.PreparedRule> rules =
-                metadataRuleExtractor.prepare(config.metadataRulesOrEmpty());
-        List<Chunk> chunks = new ArrayList<>(splitChunks.size());
-        for (int index = 0; index < splitChunks.size(); index++) {
-            List<String> imageKeys = imagesByChunk.get(index);
-            SplitChunk splitChunk = splitChunks.get(index);
-            Chunk chunk = persistChunk(document, version, splitChunk, null, embeddingConfigured,
-                    standaloneImage ? ChunkType.IMAGE : ChunkType.TEXT,
-                    metadataOf(imageKeys, splitChunk,
-                            metadataRuleExtractor.extract(rules, splitChunk.getContent())));
-            chunks.add(chunk);
-        }
-        return chunks;
-    }
-
-    /**
-     * Persists both levels and returns only the children.
-     *
-     * <p>Parents are stored with {@code embedding_status=SKIPPED} because they are never embedded and
-     * never written to an engine; marking them PENDING would make the compensation scan chase a write
-     * that is not supposed to happen.
-     *
-     * @param document            document record
-     * @param version             version being built
-     * @param staged              text to cut
-     * @param config              knowledge base index configuration
-     * @param embeddingConfigured {@code true} when the vector route is available
-     * @return child chunks
-     */
-    private List<Chunk> splitTwoLevel(Document document, DocumentVersion version, StagedContent staged,
-                                      KbIndexConfig config, boolean embeddingConfigured) {
-        List<ParentChunk> groups = parentChildSplitter.split(staged.proxied().getMarkdown(),
-                config.parentChildOrDisabled());
-        List<String> childContents = new ArrayList<>();
-        for (ParentChunk group : groups) {
-            for (SplitChunk child : group.getChildren()) {
-                childContents.add(child.getContent());
-            }
-        }
-        Map<Integer, List<String>> imagesByChunk = imageChunkLinker.link(staged.proxied().getMarkdown(),
-                staged.proxied().getPlacements(), childContents);
-        List<MetadataRuleExtractor.PreparedRule> rules =
-                metadataRuleExtractor.prepare(config.metadataRulesOrEmpty());
-
-        List<Chunk> children = new ArrayList<>();
-        int childIndex = 0;
-        for (ParentChunk group : groups) {
-            Chunk parent = persistChunk(document, version, group.getParent(), null, false,
-                    ChunkType.TEXT, null);
-            for (SplitChunk child : group.getChildren()) {
-                children.add(persistChunk(document, version, child, parent.getChunkId(), embeddingConfigured,
-                        ChunkType.TEXT, metadataOf(imagesByChunk.get(childIndex++), child,
-                                metadataRuleExtractor.extract(rules, child.getContent()))));
-            }
-        }
-        return children;
-    }
-
-    /**
-     * Merges the image links a chunk carries with the title/summary/keywords the LLM semantic
-     * splitter attaches to it, requirement section 4.3, and with the operator extracted metadata of
-     * the M14 contract section 3.2.
-     *
-     * <p>The extracted values go in first so a reserved key wins any collision: the platform written
-     * semantics of {@code title} or {@code image_urls} must never be silently replaced by a rule an
-     * operator happened to name the same way.
-     *
-     * @param imageKeys  object storage keys of the images this chunk contains, may be empty
-     * @param splitChunk splitter output, {@code null} metadata for every strategy but the LLM one
-     * @param extracted  metadata rule output for this chunk, may be empty
-     * @return JSON metadata document, {@code null} when there is nothing to store
-     */
-    private String metadataOf(List<String> imageKeys, SplitChunk splitChunk, Map<String, Object> extracted) {
-        Map<String, Object> metadata = new LinkedHashMap<>(extracted);
-        if (CollectionUtils.isNotEmpty(imageKeys)) {
-            metadata.put(ChunkMetadataKeys.IMAGE_URLS, imageKeys);
-        }
-        if (splitChunk != null && splitChunk.getMetadata() != null && !splitChunk.getMetadata().isEmpty()) {
-            metadata.putAll(splitChunk.getMetadata());
-        }
-        return metadata.isEmpty() ? null : JsonUtil.toJson(metadata);
-    }
-
-    /**
-     * Builds the LLM semantic splitter's cache coordinates for one document version.
-     *
-     * @param document document record
-     * @param version  version being built
-     * @return cache context, safe to pass to every strategy since only the LLM one reads it
-     */
-    private SplitParams.CacheContext cacheContextOf(Document document, DocumentVersion version) {
-        return new SplitParams.CacheContext(document.getKbId(), document.getDocId(),
-                version.getVersionId(), version.getContentHash());
-    }
-
-    private Chunk persistChunk(Document document, DocumentVersion version, SplitChunk splitChunk,
-                               String parentId, boolean embeddingConfigured, ChunkType chunkType,
-                               String metadata) {
-        Chunk chunk = new Chunk();
-        chunk.setChunkId(bizIdGenerator.chunkId());
-        chunk.setKbId(document.getKbId());
-        chunk.setDocId(document.getDocId());
-        chunk.setDocumentVersionId(version.getVersionId());
-        chunk.setContent(splitChunk.getContent());
-        chunk.setChunkTextHash(chunkTextHasher.hash(splitChunk.getContent()));
-        chunk.setParentId(parentId);
-        if (parentId != null) {
-            // Only a child has a position worth storing: the offsets of a single level chunk are relative
-            // to the whole document, and storing them in a column the retrieval side reads as "inside my
-            // parent" would make it cut a passage out of the wrong text.
-            chunk.setParentStartOffset(splitChunk.getStartOffset());
-            chunk.setParentEndOffset(splitChunk.getEndOffset());
-        }
-        chunk.setSeq(splitChunk.getSeq());
-        chunk.setChunkType(chunkType);
-        chunk.setEnabled(ENABLED);
-        chunk.setMetadata(metadata);
-        chunk.setEmbeddingStatus(embeddingConfigured ? EmbeddingStatus.PENDING : EmbeddingStatus.SKIPPED);
-        chunkMapper.insert(chunk);
-        return chunk;
     }
 
     /**
@@ -938,12 +741,12 @@ public class IndexPipelineService {
     private void index(Document document, DocumentVersion version, List<Chunk> chunks,
                        KbIndexConfig config, KbTask task) {
         if (CollectionUtils.isEmpty(chunks)) {
-            updateProgress(task, PROGRESS_INDEXED);
+            taskLifecycle.progress(task, PROGRESS_INDEXED);
             return;
         }
         chunkIndexWriter.write(document.getKbId(), chunks, chunkEmbedder.embed(chunks));
         multimodalIndexManager.index(document.getKbId(), version.getVersionId(), chunks, config);
-        updateProgress(task, PROGRESS_INDEXED);
+        taskLifecycle.progress(task, PROGRESS_INDEXED);
     }
 
     /**
@@ -980,58 +783,13 @@ public class IndexPipelineService {
         }
     }
 
-    private KbTask startTask(String versionId, TaskType taskType) {
-        KbTask task = kbTaskMapper.selectOne(new LambdaQueryWrapper<KbTask>()
-                .eq(KbTask::getBizId, versionId)
-                .eq(KbTask::getTaskType, taskType)
-                .orderByDesc(KbTask::getId)
-                .last("limit 1"));
-        if (task == null) {
-            task = new KbTask();
-            task.setTaskId(bizIdGenerator.taskId());
-            task.setTaskType(taskType);
-            task.setBizId(versionId);
-            task.setRetryCount(0);
-            task.setStatus(TaskStatus.RUNNING);
-            task.setProgress(0);
-            kbTaskMapper.insert(task);
-            return task;
-        }
-        task.setStatus(TaskStatus.RUNNING);
-        task.setProgress(0);
-        task.setFailReason(null);
-        task.setRetryCount(task.getRetryCount() == null ? 1 : task.getRetryCount() + 1);
-        kbTaskMapper.update(null, new LambdaUpdateWrapper<KbTask>()
-                .set(KbTask::getStatus, TaskStatus.RUNNING.name())
-                .set(KbTask::getProgress, 0)
-                .set(KbTask::getFailReason, null)
-                .set(KbTask::getRetryCount, task.getRetryCount())
-                .eq(KbTask::getTaskId, task.getTaskId()));
-        return task;
-    }
-
-    private void updateProgress(KbTask task, int progress) {
-        task.setProgress(progress);
-        kbTaskMapper.updateById(task);
-    }
-
-    private void completeTask(KbTask task) {
-        task.setStatus(TaskStatus.SUCCESS);
-        task.setProgress(PROGRESS_DONE);
-        kbTaskMapper.updateById(task);
-        taskFailureTracker.recordSuccess(task.getTaskType());
-    }
-
     private void fail(Document document, DocumentVersion version, KbTask task,
                       ProcessStatus status, String reason) {
-        String safeReason = truncate(reason);
+        String safeReason = IndexTaskLifecycle.truncateReason(reason);
         updateProcessStatus(document, status, safeReason);
         version.setStatus(DocumentVersionStatus.BUILD_FAILED);
         documentVersionMapper.updateById(version);
-        task.setStatus(TaskStatus.FAILED);
-        task.setFailReason(safeReason);
-        kbTaskMapper.updateById(task);
-        taskFailureTracker.recordFailure(task.getTaskType(), safeReason);
+        taskLifecycle.fail(task, safeReason);
     }
 
     /**
@@ -1098,12 +856,6 @@ public class IndexPipelineService {
         }
     }
 
-    private String truncate(String reason) {
-        if (reason == null) {
-            return null;
-        }
-        return reason.length() > FAIL_REASON_MAX_LENGTH ? reason.substring(0, FAIL_REASON_MAX_LENGTH) : reason;
-    }
 
     /**
      * Text ready to be cut, together with what produced it.

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/IndexTaskLifecycle.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/IndexTaskLifecycle.java
@@ -1,0 +1,138 @@
+package io.kbrag.app.index;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import io.kbrag.app.alert.TaskFailureTracker;
+import io.kbrag.domain.entity.KbTask;
+import io.kbrag.domain.enums.TaskStatus;
+import io.kbrag.domain.enums.TaskType;
+import io.kbrag.domain.mapper.KbTaskMapper;
+import io.kbrag.domain.service.BizIdGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * The state machine of one {@code t_kb_task} row.
+ *
+ * <p>Split out of {@link IndexPipelineService} because a task's states are orthogonal to what the task is
+ * building: start, progress, succeed, fail is the same ladder whether the run is a first build, a rebuild,
+ * a restore or a confirmation. The three collaborators it needs - the task table, the id generator and the
+ * failure tracker - exist in the pipeline for this ladder and nothing else.
+ *
+ * <p><b>What stays outside.</b> A failed build also has to move the document's processing status and the
+ * version's status, which belong to two other aggregates. Those writes stay with the pipeline, and only
+ * the task half of the failure is asked of this class - one aggregate per owner, rather than a "task"
+ * object that quietly updates documents.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class IndexTaskLifecycle {
+
+    /** Progress of a finished task. */
+    private static final int PROGRESS_DONE = 100;
+
+    /** Column width of {@code fail_reason}; a longer cause is stored truncated rather than rejected. */
+    private static final int FAIL_REASON_MAX_LENGTH = 1024;
+
+    private final KbTaskMapper kbTaskMapper;
+    private final BizIdGenerator bizIdGenerator;
+    private final TaskFailureTracker taskFailureTracker;
+
+    /**
+     * Cuts a failure cause down to what the column can hold.
+     *
+     * <p>Exposed as a static helper because the same string is written to three tables by three different
+     * owners; truncating it in only one of them would leave the console showing two different causes for
+     * one failure.
+     *
+     * @param reason classified failure cause, may be {@code null}
+     * @return the cause, truncated when it exceeds the column
+     */
+    public static String truncateReason(String reason) {
+        if (reason == null) {
+            return null;
+        }
+        return reason.length() > FAIL_REASON_MAX_LENGTH ? reason.substring(0, FAIL_REASON_MAX_LENGTH) : reason;
+    }
+
+    /**
+     * Opens the task of a build, reusing the row of a previous attempt when there is one.
+     *
+     * <p>A retry increments {@code retry_count} on the existing row rather than inserting a second one: an
+     * operator asking "how did this version build" must get one answer, and the explicit update is what
+     * lets a rerun clear the {@code fail_reason} an entity based update would skip.
+     *
+     * @param versionId version being built, the task's business id
+     * @param taskType  kind of build
+     * @return the running task row
+     */
+    public KbTask start(String versionId, TaskType taskType) {
+        KbTask task = kbTaskMapper.selectOne(new LambdaQueryWrapper<KbTask>()
+                .eq(KbTask::getBizId, versionId)
+                .eq(KbTask::getTaskType, taskType)
+                .orderByDesc(KbTask::getId)
+                .last("limit 1"));
+        if (task == null) {
+            task = new KbTask();
+            task.setTaskId(bizIdGenerator.taskId());
+            task.setTaskType(taskType);
+            task.setBizId(versionId);
+            task.setRetryCount(0);
+            task.setStatus(TaskStatus.RUNNING);
+            task.setProgress(0);
+            kbTaskMapper.insert(task);
+            return task;
+        }
+        task.setStatus(TaskStatus.RUNNING);
+        task.setProgress(0);
+        task.setFailReason(null);
+        task.setRetryCount(task.getRetryCount() == null ? 1 : task.getRetryCount() + 1);
+        kbTaskMapper.update(null, new LambdaUpdateWrapper<KbTask>()
+                .set(KbTask::getStatus, TaskStatus.RUNNING.name())
+                .set(KbTask::getProgress, 0)
+                .set(KbTask::getFailReason, null)
+                .set(KbTask::getRetryCount, task.getRetryCount())
+                .eq(KbTask::getTaskId, task.getTaskId()));
+        return task;
+    }
+
+    /**
+     * Records how far the build has got.
+     *
+     * @param task     running task, kept in sync in memory
+     * @param progress percentage reached
+     */
+    public void progress(KbTask task, int progress) {
+        task.setProgress(progress);
+        kbTaskMapper.updateById(task);
+    }
+
+    /**
+     * Closes the task as successful and clears the consecutive failure streak of its type.
+     *
+     * @param task running task, kept in sync in memory
+     */
+    public void complete(KbTask task) {
+        task.setStatus(TaskStatus.SUCCESS);
+        task.setProgress(PROGRESS_DONE);
+        kbTaskMapper.updateById(task);
+        taskFailureTracker.recordSuccess(task.getTaskType());
+    }
+
+    /**
+     * Closes the task as failed and feeds the alerting streak of its type.
+     *
+     * @param task       running task, kept in sync in memory
+     * @param safeReason classified failure cause, already truncated by {@link #truncateReason}
+     */
+    public void fail(KbTask task, String safeReason) {
+        task.setStatus(TaskStatus.FAILED);
+        task.setFailReason(safeReason);
+        kbTaskMapper.updateById(task);
+        taskFailureTracker.recordFailure(task.getTaskType(), safeReason);
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/VersionActivationHandler.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/index/VersionActivationHandler.java
@@ -1,0 +1,55 @@
+package io.kbrag.app.index;
+
+import io.kbrag.app.annotation.AnnotationInheritanceService;
+import io.kbrag.app.eval.EvalCaseStalenessService;
+import io.kbrag.app.graph.GraphExtractionService;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.DocumentVersion;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Makes a freshly built version the active one and runs everything that depends on that.
+ *
+ * <p>Not to be confused with {@link DocumentVersionActivator}, which this class calls: the activator owns
+ * the single active version invariant and nothing else, while this class owns the consequences of an
+ * activation. The distinction is load bearing - the activator is also used by the chat import path and by
+ * a manual rollback, which need the switch without necessarily needing the same follow ups, and the
+ * invariant must not depend on any of them succeeding.
+ *
+ * <p>Split out of {@link IndexPipelineService} because these five collaborators exist in that class for
+ * this one moment and nothing else. Gathering them here also gives the follow up chain a single place to
+ * grow: the next thing that has to react to an activation is added once, not at each of the three build
+ * paths that reach this point.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VersionActivationHandler {
+
+    private final DocumentVersionActivator versionActivator;
+    private final AnnotationInheritanceService annotationInheritanceService;
+    private final EvalCaseStalenessService evalCaseStalenessService;
+    private final VersionRetentionService versionRetentionService;
+    private final GraphExtractionService graphExtractionService;
+
+    /**
+     * Activates a version and runs every follow up that an activation triggers.
+     *
+     * @param document document record
+     * @param version  version that finished building
+     */
+    public void activateAndFollowUp(Document document, DocumentVersion version) {
+        versionActivator.activate(document, version);
+        annotationInheritanceService.inherit(document, version);
+        evalCaseStalenessService.markStale(document.getDocId(), version.getVersionId());
+        versionRetentionService.submit(document.getDocId());
+        // Requirement section 4.9: an activation is what invalidates the entities and relations the
+        // superseded versions contributed, otherwise the graph route would keep answering out of a corpus
+        // the other two routes can no longer see - version isolation broken from the side.
+        graphExtractionService.onVersionActivated(document, version);
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/MultimodalRetrievalService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/MultimodalRetrievalService.java
@@ -1,0 +1,252 @@
+package io.kbrag.app.retrieval;
+
+import io.kbrag.app.index.MultimodalIndexManager;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.domain.enums.DegradedReason;
+import io.kbrag.domain.enums.FusionMode;
+import io.kbrag.domain.enums.RetrievalSource;
+import io.kbrag.domain.model.ImageInput;
+import io.kbrag.domain.model.KbIndexConfig;
+import io.kbrag.domain.model.RetrievalFilter;
+import io.kbrag.domain.model.ScoredChunk;
+import io.kbrag.domain.model.VectorQuery;
+import io.kbrag.domain.port.MultimodalEmbeddingProvider;
+import io.kbrag.domain.port.VectorStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The multimodal route and the image dispatch that decides whether it runs at all, the M14 contract
+ * sections 6.3 and 7.
+ *
+ * <p>The counterpart of {@code GraphRetrievalService}: the two are the pipeline's optional routes, they
+ * return the same shape of outcome, and neither knows anything about the stages that consume it.
+ * {@link MultimodalRouteOutcome} was already modelled on {@code GraphRouteOutcome}; this class completes
+ * the symmetry on the executing side, so that "how a route is run" lives next to the collaborators only
+ * that route needs - {@link MultimodalIndexManager}, {@link MultimodalEmbeddingProvider} and
+ * {@link ImageQueryService} are read here and nowhere else in the pipeline.
+ *
+ * <p>What stays with {@link RetrievalService} is the decision of <em>whether</em> to ask at all: the
+ * snapshot guard sits at the call site for both routes, because "a released version searches its own
+ * frozen corpus" is a property of the call rather than of any one route.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MultimodalRetrievalService {
+
+    private final MultimodalIndexManager multimodalIndexManager;
+    private final MultimodalEmbeddingProvider multimodalEmbeddingProvider;
+    private final ImageQueryService imageQueryService;
+    private final VectorStore vectorStore;
+
+    /**
+     * A candidate knowledge base as the multimodal route sees it.
+     *
+     * <p>The two fields are all the route needs to address a base, which is deliberately less than the
+     * pipeline's own notion of a target: a route that could read the retrieval config would be able to
+     * re-decide questions the pipeline already settled.
+     *
+     * @param kbId        knowledge base business id
+     * @param indexConfig index configuration of that base, read for the multimodal switch
+     */
+    public record Target(String kbId, KbIndexConfig indexConfig) {
+    }
+
+    /**
+     * What the image dispatch decided: the query every pipeline stage reads and the image vectors, if any,
+     * the multimodal route embeds instead of the text.
+     *
+     * <p>The markers are returned rather than appended to a list the caller passed in: the dispatch is one
+     * more stage whose degradations the pipeline collects, and a stage that reaches into the caller's
+     * accumulator cannot be tested without one.
+     *
+     * @param query             query the pipeline runs with, enriched by the vision fallback when it ran
+     * @param imageQueryVectors embedded images for the multimodal route, empty on the fallback path
+     * @param degraded          markers this dispatch produced, empty when nothing degraded
+     */
+    public record ImageDispatch(String query, List<float[]> imageQueryVectors, List<String> degraded) {
+    }
+
+    /**
+     * Decides what the attached images do, the single dispatch point of the M14 contract section 7.
+     *
+     * <p>Two outcomes, one of them per call. When the searched corpus can embed images - a multimodal
+     * provider is configured, at least one selected base has the multimodal switch on, the call is not a
+     * frozen release snapshot and a written query is present - the pictures are embedded and steer the
+     * multimodal route directly (image to image, image to rendered page). Otherwise they fall back to the
+     * vision transcription that folds their description into the query, exactly the path the open API used
+     * before this milestone, so a deployment without the multimodal capability keeps its image search.
+     *
+     * <p><b>A written query stays mandatory on the image route.</b> Pure image retrieval is out of scope for
+     * this milestone, so an image only call is never routed to the multimodal space; it takes the vision
+     * fallback, whose own gate rejects a call that has nothing at all to search for.
+     *
+     * <p><b>A release snapshot never takes the image route.</b> The multimodal index holds no frozen copy, so
+     * the per base route is off on the snapshot path anyway; sending images there would embed them for a
+     * route that cannot run, so a snapshot call transcribes them into its query instead.
+     *
+     * @param command call parameters, read for the images and the query
+     * @param targets knowledge bases the call will search
+     * @return the query the pipeline runs with, the image vectors the route embeds, and any markers
+     */
+    public ImageDispatch dispatchImages(RetrievalCommand command, List<Target> targets) {
+        List<String> images = command.getImages();
+        if (usableForImages(command, images, targets)) {
+            List<String> degraded = new ArrayList<>(1);
+            return new ImageDispatch(command.getQuery(), embedQueryImages(images, degraded), degraded);
+        }
+        ImageQueryService.ImageQueryOutcome outcome = imageQueryService.enrich(command.getQuery(), images);
+        return new ImageDispatch(outcome.query(), List.of(), outcome.degraded());
+    }
+
+    /**
+     * Runs the multimodal route, the M14 contract section 6.3.
+     *
+     * <p><b>Weighted fusion refuses the route and says so.</b> Weighted fusion blends normalised route
+     * scores, and a multimodal similarity is on a scale the text routes never see; there is no meaningful
+     * weight for it, so the route is skipped and the caller is told through {@code mm_route_skipped},
+     * mirroring the way the graph route is refused under weighted fusion.
+     *
+     * <p><b>A configured but unreachable provider degrades, it never fails the search.</b> Embedding the
+     * query into the multimodal space is the one model call this route makes; when it fails the marker
+     * {@code mm_route_unavailable} is reported and the remaining routes answer.
+     *
+     * @param target            knowledge base being searched
+     * @param query             query the other routes ran with
+     * @param imageQueryVectors images the caller attached, already embedded, empty for a text only call
+     * @param filter            the very predicate the engine side routes were filtered by
+     * @param settings          effective retrieval parameters, read for the fusion mode and the recall size
+     * @return multimodal route outcome, empty when the route was not asked to run
+     */
+    public MultimodalRouteOutcome recall(Target target, String query, List<float[]> imageQueryVectors,
+                                         RetrievalFilter filter, RetrievalSettings settings) {
+        String alias = multimodalIndexManager.multimodalAlias(target.kbId(), target.indexConfig());
+        if (alias == null) {
+            return MultimodalRouteOutcome.skipped();
+        }
+        if (settings.getFusion().getMode() == FusionMode.WEIGHTED) {
+            log.info("multimodal route skipped under weighted fusion, kbId={}", target.kbId());
+            return MultimodalRouteOutcome.degraded(DegradedReason.MM_ROUTE_SKIPPED.code());
+        }
+        List<float[]> queryVectors;
+        if (CollectionUtils.isNotEmpty(imageQueryVectors)) {
+            // F6: the caller attached images and this base can search them, so the route embeds the pictures
+            // rather than the text - image to image and image to rendered page, the M14 contract section 7.
+            queryVectors = imageQueryVectors;
+        } else {
+            try {
+                queryVectors = List.of(multimodalEmbeddingProvider.embedTexts(List.of(query)).get(0));
+            } catch (Exception e) {
+                log.error("multimodal query embedding failed, errorCode={}, kbId={}",
+                        ErrorCode.UPSTREAM_MODEL_ERROR, target.kbId(), e);
+                return MultimodalRouteOutcome.degraded(DegradedReason.MM_ROUTE_UNAVAILABLE.code());
+            }
+        }
+        List<ScoredChunk> candidates = searchMultimodal(alias, queryVectors, filter, settings.getRecallTopK());
+        if (candidates.isEmpty()) {
+            return MultimodalRouteOutcome.skipped();
+        }
+        log.info("multimodal route finished, kbId={}, queries={}, candidates={}",
+                target.kbId(), queryVectors.size(), candidates.size());
+        return MultimodalRouteOutcome.of(candidates);
+    }
+
+    /**
+     * Searches the multimodal alias with every query vector and folds the hits into one ranking.
+     *
+     * <p>A text query issues one vector; an image query issues one per attached image. Overlapping hits are
+     * collapsed on the chunk id keeping the strongest similarity, so a chunk matched by two images is ranked
+     * once on its best score rather than counted twice, and the reciprocal rank fusion downstream sees a
+     * single ordered list exactly like the other routes.
+     *
+     * @param alias        multimodal alias to search
+     * @param queryVectors one or more query vectors
+     * @param filter       the very predicate the engine side routes were filtered by
+     * @param recallTopK   candidates the route contributes at most
+     * @return merged candidates ordered by descending similarity, tagged as the multimodal route
+     */
+    private List<ScoredChunk> searchMultimodal(String alias, List<float[]> queryVectors,
+                                               RetrievalFilter filter, int recallTopK) {
+        Map<String, Double> scoreByChunk = new LinkedHashMap<>();
+        for (float[] queryVector : queryVectors) {
+            List<ScoredChunk> hits = vectorStore.search(alias, VectorQuery.builder()
+                    .queryVector(queryVector).topK(recallTopK).filter(filter).build());
+            if (CollectionUtils.isEmpty(hits)) {
+                continue;
+            }
+            for (ScoredChunk hit : hits) {
+                scoreByChunk.merge(hit.getChunkId(), hit.getScore(), Math::max);
+            }
+        }
+        if (scoreByChunk.isEmpty()) {
+            return List.of();
+        }
+        List<ScoredChunk> candidates = new ArrayList<>(scoreByChunk.size());
+        for (Map.Entry<String, Double> entry : scoreByChunk.entrySet()) {
+            candidates.add(new ScoredChunk(entry.getKey(), entry.getValue(), RetrievalSource.MM));
+        }
+        candidates.sort(Comparator.comparingDouble(ScoredChunk::getScore).reversed()
+                .thenComparing(ScoredChunk::getChunkId));
+        return candidates.size() > recallTopK
+                ? new ArrayList<>(candidates.subList(0, recallTopK)) : candidates;
+    }
+
+    /**
+     * Tells whether the attached images can steer the multimodal route rather than the vision fallback.
+     *
+     * @param command call parameters, read for the query and the snapshot binding
+     * @param images  attached images
+     * @param targets knowledge bases the call will search
+     * @return {@code true} when the images are to be embedded into the multimodal space
+     */
+    private boolean usableForImages(RetrievalCommand command, List<String> images, List<Target> targets) {
+        if (CollectionUtils.isEmpty(images) || !multimodalEmbeddingProvider.isConfigured()) {
+            return false;
+        }
+        if (command.getQuery() == null || command.getQuery().isBlank()) {
+            return false;
+        }
+        if (MapUtils.isNotEmpty(command.getIndexOverride())) {
+            return false;
+        }
+        return targets.stream().anyMatch(target ->
+                multimodalIndexManager.multimodalAlias(target.kbId(), target.indexConfig()) != null);
+    }
+
+    /**
+     * Embeds the attached images into the multimodal space, degrading rather than failing when the provider
+     * call itself breaks.
+     *
+     * <p>The count and size validation runs first and outside the try: an over sized or over counted image
+     * set is a caller error the pipeline rejects, not a degradation. A provider timeout or error, by
+     * contrast, leaves the written query and the other routes to answer, so it is reported through
+     * {@code mm_route_unavailable} and returns no vectors.
+     *
+     * @param images   attached images, already known to be present
+     * @param degraded markers of this dispatch, appended in place
+     * @return one vector per image, or empty when the provider call failed
+     */
+    private List<float[]> embedQueryImages(List<String> images, List<String> degraded) {
+        List<ImageInput> inputs = imageQueryService.decodeForEmbedding(images);
+        try {
+            return multimodalEmbeddingProvider.embedImages(inputs);
+        } catch (Exception e) {
+            log.error("query image embedding failed, errorCode={}, images={}",
+                    ErrorCode.UPSTREAM_MODEL_ERROR, inputs.size(), e);
+            degraded.add(DegradedReason.MM_ROUTE_UNAVAILABLE.code());
+            return List.of();
+        }
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalNodeAssembler.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalNodeAssembler.java
@@ -1,0 +1,374 @@
+package io.kbrag.app.retrieval;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.config.KbProperties;
+import io.kbrag.domain.constant.ChunkMetadataKeys;
+import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.enums.FusionMode;
+import io.kbrag.domain.enums.RetrievalSource;
+import io.kbrag.domain.mapper.ChunkMapper;
+import io.kbrag.domain.model.FusedChunk;
+import io.kbrag.domain.model.GraphChunkRelevance;
+import io.kbrag.domain.port.ObjectStorage;
+import io.kbrag.domain.service.ParentTextRedactor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Describes the units that survived the pipeline as the transport neutral nodes a caller receives.
+ *
+ * <p>Split out of {@link RetrievalService} because the two answer different questions. The service
+ * decides <em>which</em> passages win - it orders the stages, runs the routes, merges the bases and
+ * applies the threshold. This class decides <em>how</em> a winner is described: which chunk's text is
+ * returned for a two level unit, what the score keys are called, which passages are cut out of a
+ * returned parent, and how a stored image key becomes a link the caller can open. The split follows the
+ * collaborators rather than a line count: {@link ParentTextRedactor} and {@link ObjectStorage} are read
+ * here and nowhere else in the pipeline, and every display only metadata key below is written here and
+ * read by nothing - which is why they do not belong next to the stage ordering.
+ *
+ * <p>MySQL stays the fact source on this side of the split as well: a parent's text is read from the
+ * database rather than from a search engine, because parents are never indexed.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RetrievalNodeAssembler {
+
+    private static final String META_FUSED_SCORE = "fused_score";
+    private static final String META_VECTOR_SCORE = "vector_score";
+    private static final String META_BM25_SCORE = "bm25_score";
+    private static final String META_NORM_VECTOR_SCORE = "norm_vector_score";
+    private static final String META_NORM_BM25_SCORE = "norm_bm25_score";
+    private static final String META_RERANK_SCORE = "rerank_score";
+    private static final String META_VECTOR_RANK = "vector_rank";
+    private static final String META_BM25_RANK = "bm25_rank";
+
+    /**
+     * Graph route detail, requirement section 4.9: the relevance the in base ranking used, the hop count
+     * that produced it and the entity names that reached the chunk. Present only on a node the graph route
+     * contributed, so a caller can tell a three route call from a two route one node by node.
+     */
+    private static final String META_GRAPH_SCORE = "graph_score";
+    private static final String META_GRAPH_HOPS = "graph_hops";
+    private static final String META_GRAPH_ENTITIES = "graph_entities";
+    private static final String META_CHUNK_SEQ = "chunk_seq";
+    private static final String META_CHILD_IDS = "child_ids";
+    private static final String META_DISABLED_CHILD_IDS = "disabled_child_ids";
+
+    /**
+     * Disabled children whose passage was actually cut out of the returned parent text, requirement
+     * section 4.5. Present only when a cut happened, so its absence means "the parent is complete" - a
+     * parent that could not be redacted precisely carries {@code disabled_child_ids} and no count.
+     */
+    private static final String META_REDACTED_CHILD_COUNT = "redacted_child_count";
+
+    /**
+     * Chat window chunks this result absorbed because their message ranges overlapped it, requirement
+     * section 4.2. Present only on a node that absorbed at least one, so its absence means "nothing was
+     * merged" rather than "this deployment does not merge".
+     */
+    private static final String META_MERGED_WINDOW_CHUNK_IDS = "merged_window_chunk_ids";
+    private static final String META_CHILDREN = RetrievalMetadataKeys.CHILDREN;
+    private static final String META_CHILD_CHUNK_ID = "chunk_id";
+    private static final String META_CHILD_CONTENT = RetrievalMetadataKeys.CHILD_CONTENT;
+    private static final String META_CHILD_SCORE = "score";
+    private static final String META_CHILD_SCORE_TYPE = "score_type";
+
+    /**
+     * Knowledge base a node came from. Present on every node, single base calls included: a caller that
+     * has to branch on whether the key exists cannot use it, and the value is a fact of the chunk row
+     * rather than a property of the routing stage.
+     */
+    private static final String META_KB_ID = "kb_id";
+
+    private final ChunkMapper chunkMapper;
+    private final ScoreThresholdPolicy scoreThresholdPolicy;
+    private final ParentTextRedactor parentTextRedactor;
+    private final ObjectStorage objectStorage;
+    private final KbProperties properties;
+
+    /**
+     * The pipeline verdicts a node is described against, gathered so the stages that produced them stay
+     * out of the assembler's signature.
+     *
+     * @param decision               threshold decision of this search
+     * @param orderingMode           strategy that produced the final ordering: the in base one on a single
+     *                               base call, reciprocal rank fusion once bases were merged
+     * @param disabledChildrenByUnit disabled children to report per unit
+     * @param nearDuplicates         outcome of the near duplicate window merge
+     */
+    public record AssemblyContext(ScoreThresholdPolicy.ThresholdDecision decision,
+                                  FusionMode orderingMode,
+                                  Map<String, List<DisabledChildVisibility.DisabledChild>>
+                                          disabledChildrenByUnit,
+                                  NearDuplicateWindowMerger.Outcome nearDuplicates) {
+    }
+
+    /**
+     * Turns the surviving units into the transport neutral nodes.
+     *
+     * @param units   surviving units in ranking order
+     * @param context pipeline verdicts these nodes are described against
+     * @return ordered nodes
+     */
+    public List<RetrievalNodeView> assemble(List<RetrievalUnit> units, AssemblyContext context) {
+        if (CollectionUtils.isEmpty(units)) {
+            return List.of();
+        }
+        Map<String, Chunk> parentById = loadParents(units);
+        List<RetrievalNodeView> nodes = new ArrayList<>(units.size());
+        for (RetrievalUnit unit : units) {
+            RetrievalCandidate best = unit.best();
+            ScoreThresholdPolicy.ReportedScore reported =
+                    scoreThresholdPolicy.report(best, context.decision(), context.orderingMode());
+            Chunk answerChunk = unit.isParent()
+                    ? parentById.getOrDefault(unit.getUnitId(), best.getChunk())
+                    : best.getChunk();
+            List<DisabledChildVisibility.DisabledChild> disabledChildren =
+                    context.disabledChildrenByUnit().get(unit.getUnitId());
+            ParentTextRedactor.Redaction redaction = redact(answerChunk, disabledChildren);
+            nodes.add(RetrievalNodeView.builder()
+                    .docId(answerChunk.getDocId())
+                    .documentVersionId(answerChunk.getDocumentVersionId())
+                    .chunkId(answerChunk.getChunkId())
+                    .chunkType(answerChunk.getChunkType().code())
+                    .content(redaction.text())
+                    .score(reported.getValue())
+                    .scoreType(reported.getType().code())
+                    .retrievalSource(best.getFused().getPrimarySource().code())
+                    .metadata(buildMetadata(unit, answerChunk, context, disabledChildren, redaction,
+                            // Keyed by the best member rather than by the unit: the merge judged candidates,
+                            // and on a two level base the unit id is a parent that was never a candidate.
+                            context.nearDuplicates().mergedIdsOf(best.chunkId())))
+                    .imageUrls(presignedImageUrls(unit, answerChunk))
+                    .previewUrl(null)
+                    .build());
+        }
+        return nodes;
+    }
+
+    /**
+     * Cuts the excluded passages out of a returned parent text, requirement section 4.5.
+     *
+     * <p>Reached only for a parent the knowledge base decided to return - the strict switch removed the
+     * others before this point - and only when the disabled children still know where they sit. Otherwise
+     * the redactor hands the text back untouched, which is the pre M9 behaviour.
+     *
+     * @param answerChunk      chunk whose text is returned
+     * @param disabledChildren excluded children of that chunk, {@code null} when there are none
+     * @return text to return with the number of passages that were cut
+     */
+    private ParentTextRedactor.Redaction redact(
+            Chunk answerChunk, List<DisabledChildVisibility.DisabledChild> disabledChildren) {
+        if (CollectionUtils.isEmpty(disabledChildren)) {
+            return new ParentTextRedactor.Redaction(answerChunk.getContent(), 0);
+        }
+        return parentTextRedactor.redact(answerChunk.getContent(), disabledChildren.stream()
+                .map(DisabledChildVisibility.DisabledChild::toSpan).toList());
+    }
+
+    /**
+     * Turns the stored image keys of a result into time limited pre signed URLs.
+     *
+     * <p>The keys are minted per response rather than stored as URLs: a link that lived in the index would
+     * be public for as long as the index exists, and it would already be expired by the time it is read.
+     *
+     * <p>A two level result collects the keys of its matched children as well as its own, because the parent
+     * text is what is returned and the image that made a child match is part of that text.
+     *
+     * @param unit        merged unit being returned
+     * @param answerChunk chunk whose text is returned
+     * @return pre signed URLs, empty when the result derives from no image
+     */
+    private List<String> presignedImageUrls(RetrievalUnit unit, Chunk answerChunk) {
+        List<String> keys = new ArrayList<>(imageKeysOf(answerChunk));
+        if (unit.isParent()) {
+            for (RetrievalCandidate member : unit.getMembers()) {
+                for (String key : imageKeysOf(member.getChunk())) {
+                    if (!keys.contains(key)) {
+                        keys.add(key);
+                    }
+                }
+            }
+        }
+        if (CollectionUtils.isEmpty(keys)) {
+            return List.of();
+        }
+        Duration ttl = Duration.ofMinutes(properties.getMinio().getPresignedTtlMinutes());
+        List<String> urls = new ArrayList<>(keys.size());
+        for (String key : keys) {
+            try {
+                urls.add(objectStorage.presignedUrl(key, ttl));
+            } catch (Exception e) {
+                // A thumbnail that cannot be signed must not fail a search: the passage is the answer.
+                log.info("image could not be presigned for a search result, object={}", key);
+            }
+        }
+        return urls;
+    }
+
+    /**
+     * Reads the image keys a chunk recorded.
+     *
+     * @param chunk fact source row
+     * @return object storage keys, empty when the chunk derives from no image
+     */
+    private List<String> imageKeysOf(Chunk chunk) {
+        Object value = storedMetadata(chunk).get(ChunkMetadataKeys.IMAGE_URLS);
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        List<String> keys = new ArrayList<>(items.size());
+        for (Object item : items) {
+            if (item != null) {
+                keys.add(String.valueOf(item));
+            }
+        }
+        return keys;
+    }
+
+    /**
+     * Parses the metadata column of a chunk.
+     *
+     * @param chunk fact source row
+     * @return metadata document, empty when the column is blank
+     */
+    private Map<String, Object> storedMetadata(Chunk chunk) {
+        if (chunk == null || chunk.getMetadata() == null || chunk.getMetadata().isBlank()) {
+            return Map.of();
+        }
+        Map<String, Object> parsed = JsonUtil.parse(chunk.getMetadata(),
+                new TypeReference<Map<String, Object>>() {
+                });
+        return parsed == null ? Map.of() : parsed;
+    }
+
+    /**
+     * Loads the parent rows of the two level units.
+     *
+     * <p>Parents are never indexed, so their text only exists in MySQL; this is the single reason the
+     * engines can stay child only while the caller still receives a passage large enough to read.
+     *
+     * @param units merged units
+     * @return parent chunk per parent chunk id
+     */
+    private Map<String, Chunk> loadParents(List<RetrievalUnit> units) {
+        List<String> parentIds = units.stream()
+                .filter(RetrievalUnit::isParent)
+                .map(RetrievalUnit::getUnitId)
+                .toList();
+        if (CollectionUtils.isEmpty(parentIds)) {
+            return Map.of();
+        }
+        List<Chunk> parents = chunkMapper.selectList(new LambdaQueryWrapper<Chunk>()
+                .in(Chunk::getChunkId, parentIds));
+        Map<String, Chunk> parentById = new HashMap<>(parents.size());
+        for (Chunk parent : parents) {
+            parentById.put(parent.getChunkId(), parent);
+        }
+        return parentById;
+    }
+
+    private Map<String, Object> buildMetadata(RetrievalUnit unit, Chunk answerChunk,
+                                              AssemblyContext context,
+                                              List<DisabledChildVisibility.DisabledChild> disabledChildren,
+                                              ParentTextRedactor.Redaction redaction,
+                                              List<String> mergedWindowChunkIds) {
+        Map<String, Object> metadata = new LinkedHashMap<>(scoreMetadata(unit.best()));
+        // Read from the fact source row rather than from the routing decision: a node has to be traceable
+        // to its base even when routing never ran, and the row is the only place that cannot disagree.
+        metadata.put(META_KB_ID, answerChunk.getKbId());
+        metadata.put(META_CHUNK_SEQ, answerChunk.getSeq());
+        // The stored document facts travel next to the scores so a chat result card can show its
+        // conversation, its senders and its time without a second round trip. The image keys are excluded:
+        // they leave through image_urls as pre signed links and the raw keys are of no use to a caller.
+        storedMetadata(answerChunk).forEach((key, value) -> {
+            if (!ChunkMetadataKeys.IMAGE_URLS.equals(key)) {
+                metadata.putIfAbsent(key, value);
+            }
+        });
+        if (CollectionUtils.isNotEmpty(mergedWindowChunkIds)) {
+            metadata.put(META_MERGED_WINDOW_CHUNK_IDS, mergedWindowChunkIds);
+        }
+        if (!unit.isParent()) {
+            return metadata;
+        }
+        if (CollectionUtils.isNotEmpty(disabledChildren)) {
+            // Reported whether or not the text could be cut: the caller has to be able to tell that
+            // something inside this parent was excluded, and the two cases differ only by the count below.
+            metadata.put(META_DISABLED_CHILD_IDS, disabledChildren.stream()
+                    .map(DisabledChildVisibility.DisabledChild::chunkId).toList());
+        }
+        if (redaction.applied()) {
+            metadata.put(META_REDACTED_CHILD_COUNT, redaction.redactedChildCount());
+        }
+        metadata.put(META_CHILD_IDS, unit.getMembers().stream().map(RetrievalCandidate::chunkId).toList());
+        List<Map<String, Object>> children = new ArrayList<>(unit.getMembers().size());
+        for (RetrievalCandidate member : unit.getMembers()) {
+            ScoreThresholdPolicy.ReportedScore reported =
+                    scoreThresholdPolicy.report(member, context.decision(), context.orderingMode());
+            Map<String, Object> child = new LinkedHashMap<>();
+            child.put(META_CHILD_CHUNK_ID, member.chunkId());
+            child.put(META_CHILD_CONTENT, member.getChunk().getContent());
+            child.put(META_CHILD_SCORE, reported.getValue());
+            child.put(META_CHILD_SCORE_TYPE, reported.getType().code());
+            child.putAll(scoreMetadata(member));
+            children.add(child);
+        }
+        metadata.put(META_CHILDREN, children);
+        return metadata;
+    }
+
+    /**
+     * Per route evidence of one candidate, shared by the node metadata and by the child detail list.
+     *
+     * <p>Both the raw and the normalised score are exposed when they exist: the raw value is what the
+     * engine reported and is the only one comparable with a manual query, while the normalised value
+     * is what the weighted strategy actually summed, and a debug page that shows one without the other
+     * cannot explain a ranking.
+     *
+     * @param candidate candidate being described
+     * @return score keys, ordered for readability
+     */
+    private Map<String, Object> scoreMetadata(RetrievalCandidate candidate) {
+        FusedChunk fused = candidate.getFused();
+        Map<String, Object> scores = new LinkedHashMap<>();
+        scores.put(META_FUSED_SCORE, fused.getFusedScore());
+        putIfPresent(scores, META_VECTOR_SCORE, fused.routeScore(RetrievalSource.VECTOR));
+        putIfPresent(scores, META_VECTOR_RANK, fused.getRouteRanks().get(RetrievalSource.VECTOR));
+        putIfPresent(scores, META_NORM_VECTOR_SCORE, fused.normalizedScore(RetrievalSource.VECTOR));
+        putIfPresent(scores, META_BM25_SCORE, fused.routeScore(RetrievalSource.BM25));
+        putIfPresent(scores, META_BM25_RANK, fused.getRouteRanks().get(RetrievalSource.BM25));
+        putIfPresent(scores, META_NORM_BM25_SCORE, fused.normalizedScore(RetrievalSource.BM25));
+        putIfPresent(scores, META_RERANK_SCORE, candidate.getRerankScore());
+        GraphChunkRelevance graph = candidate.getGraphEvidence();
+        if (graph != null) {
+            // The relevance is reported from the graph evidence rather than from the route score map: the
+            // two are the same number, and reading it from the object that also carries the hop count keeps
+            // the three keys of the debug row provably consistent with one another.
+            scores.put(META_GRAPH_SCORE, graph.score());
+            scores.put(META_GRAPH_HOPS, graph.hops());
+            scores.put(META_GRAPH_ENTITIES, graph.entityNames());
+        }
+        return scores;
+    }
+
+    private void putIfPresent(Map<String, Object> target, String key, Object value) {
+        if (value != null) {
+            target.put(key, value);
+        }
+    }
+}

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/retrieval/RetrievalService.java
@@ -1,18 +1,14 @@
 package io.kbrag.app.retrieval;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.kbrag.app.alert.RetrievalDegradeMonitor;
 import io.kbrag.app.graph.GraphRetrievalService;
 import io.kbrag.app.graph.GraphRouteOutcome;
 import io.kbrag.app.index.EngineChunkCleaner;
-import io.kbrag.app.index.MultimodalIndexManager;
 import io.kbrag.app.kb.KnowledgeBaseService;
-import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.common.util.JsonUtil;
 import io.kbrag.domain.config.KbProperties;
-import io.kbrag.domain.constant.ChunkMetadataKeys;
 import io.kbrag.domain.entity.Chunk;
 import io.kbrag.domain.entity.KnowledgeBase;
 import io.kbrag.domain.enums.DegradedReason;
@@ -23,7 +19,6 @@ import io.kbrag.domain.mapper.ChunkMapper;
 import io.kbrag.domain.model.FulltextQuery;
 import io.kbrag.domain.model.FusedChunk;
 import io.kbrag.domain.model.GraphChunkRelevance;
-import io.kbrag.domain.model.ImageInput;
 import io.kbrag.domain.model.KbIndexConfig;
 import io.kbrag.domain.model.KbRef;
 import io.kbrag.domain.model.KbRetrievalConfig;
@@ -32,20 +27,15 @@ import io.kbrag.domain.model.ScoredChunk;
 import io.kbrag.domain.model.VectorQuery;
 import io.kbrag.domain.port.EmbeddingProvider;
 import io.kbrag.domain.port.FulltextStore;
-import io.kbrag.domain.port.MultimodalEmbeddingProvider;
-import io.kbrag.domain.port.ObjectStorage;
 import io.kbrag.domain.port.VectorStore;
 import io.kbrag.domain.service.CrossKbRrfFusion;
 import io.kbrag.domain.service.FusionRouter;
 import io.kbrag.domain.service.KbQuotaAllocator;
-import io.kbrag.domain.service.ParentTextRedactor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.MapUtils;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
@@ -107,53 +97,6 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class RetrievalService {
 
-    private static final String META_FUSED_SCORE = "fused_score";
-    private static final String META_VECTOR_SCORE = "vector_score";
-    private static final String META_BM25_SCORE = "bm25_score";
-    private static final String META_NORM_VECTOR_SCORE = "norm_vector_score";
-    private static final String META_NORM_BM25_SCORE = "norm_bm25_score";
-    private static final String META_RERANK_SCORE = "rerank_score";
-    private static final String META_VECTOR_RANK = "vector_rank";
-    private static final String META_BM25_RANK = "bm25_rank";
-
-    /**
-     * Graph route detail, requirement section 4.9: the relevance the in base ranking used, the hop count
-     * that produced it and the entity names that reached the chunk. Present only on a node the graph route
-     * contributed, so a caller can tell a three route call from a two route one node by node.
-     */
-    private static final String META_GRAPH_SCORE = "graph_score";
-    private static final String META_GRAPH_HOPS = "graph_hops";
-    private static final String META_GRAPH_ENTITIES = "graph_entities";
-    private static final String META_CHUNK_SEQ = "chunk_seq";
-    private static final String META_CHILD_IDS = "child_ids";
-    private static final String META_DISABLED_CHILD_IDS = "disabled_child_ids";
-
-    /**
-     * Disabled children whose passage was actually cut out of the returned parent text, requirement
-     * section 4.5. Present only when a cut happened, so its absence means "the parent is complete" - a
-     * parent that could not be redacted precisely carries {@code disabled_child_ids} and no count.
-     */
-    private static final String META_REDACTED_CHILD_COUNT = "redacted_child_count";
-
-    /**
-     * Chat window chunks this result absorbed because their message ranges overlapped it, requirement
-     * section 4.2. Present only on a node that absorbed at least one, so its absence means "nothing was
-     * merged" rather than "this deployment does not merge".
-     */
-    private static final String META_MERGED_WINDOW_CHUNK_IDS = "merged_window_chunk_ids";
-    private static final String META_CHILDREN = RetrievalMetadataKeys.CHILDREN;
-    private static final String META_CHILD_CHUNK_ID = "chunk_id";
-    private static final String META_CHILD_CONTENT = RetrievalMetadataKeys.CHILD_CONTENT;
-    private static final String META_CHILD_SCORE = "score";
-    private static final String META_CHILD_SCORE_TYPE = "score_type";
-
-    /**
-     * Knowledge base a node came from. Present on every node, single base calls included: a caller that
-     * has to branch on whether the key exists cannot use it, and the value is a fact of the chunk row
-     * rather than a property of the routing stage.
-     */
-    private static final String META_KB_ID = "kb_id";
-
     private static final int ENABLED = 1;
 
     /** Below this spread the BM25 route is treated as constant scored in the hybrid blend. */
@@ -172,9 +115,7 @@ public class RetrievalService {
     private final CrossKbRrfFusion crossKbRrfFusion;
     private final KbQuotaAllocator kbQuotaAllocator;
     private final GraphRetrievalService graphRetrievalService;
-    private final MultimodalIndexManager multimodalIndexManager;
-    private final MultimodalEmbeddingProvider multimodalEmbeddingProvider;
-    private final ImageQueryService imageQueryService;
+    private final MultimodalRetrievalService multimodalRetrievalService;
     private final RoutingService routingService;
     private final RewriteService rewriteService;
     private final RerankService rerankService;
@@ -182,9 +123,8 @@ public class RetrievalService {
     private final ParentChildMerger parentChildMerger;
     private final NearDuplicateWindowMerger nearDuplicateWindowMerger;
     private final DisabledChildVisibility disabledChildVisibility;
-    private final ParentTextRedactor parentTextRedactor;
+    private final RetrievalNodeAssembler nodeAssembler;
     private final EngineChunkCleaner engineChunkCleaner;
-    private final ObjectStorage objectStorage;
     private final RetrievalDegradeMonitor degradeMonitor;
     private final KbProperties properties;
 
@@ -228,7 +168,9 @@ public class RetrievalService {
         List<String> degraded = new ArrayList<>();
         // F6 image dispatch, the single point that decides between the multimodal image route and the vision
         // text fallback before any pipeline stage reads the question, the M14 contract section 7.
-        ImageDispatch imageDispatch = dispatchImages(command, targets, degraded);
+        MultimodalRetrievalService.ImageDispatch imageDispatch = multimodalRetrievalService
+                .dispatchImages(command, targets.stream().map(KbTarget::multimodalTarget).toList());
+        imageDispatch.degraded().forEach(reason -> addMarker(degraded, reason));
         RewriteOutcome rewrite = rewriteService.rewrite(imageDispatch.query(), command.getMessages(),
                 shouldRun(settings.isRewriteEnabled(), rewriteService.isAvailable(),
                         command.getRewriteEnabled(), primary.rewriteEnabled()));
@@ -326,8 +268,9 @@ public class RetrievalService {
             units = units.subList(0, settings.getTopN());
         }
 
-        List<RetrievalNodeView> nodes = toNodes(units, decision, orderingMode,
-                visibility.disabledChildrenByUnit(), nearDuplicates);
+        List<RetrievalNodeView> nodes = nodeAssembler.assemble(units,
+                new RetrievalNodeAssembler.AssemblyContext(decision, orderingMode,
+                        visibility.disabledChildrenByUnit(), nearDuplicates));
         log.info("search finished, routedKbIds={}, recallTopK={}, topN={}, fusion={}, candidates={}, "
                         + "units={}, returned={}, rerank={}, degraded={}",
                 routing.getKbIds(), settings.getRecallTopK(), settings.getTopN(), orderingMode.code(),
@@ -462,167 +405,8 @@ public class RetrievalService {
         if (context.snapshotBound()) {
             return MultimodalRouteOutcome.skipped();
         }
-        String alias = multimodalIndexManager.multimodalAlias(target.kbId(), target.indexConfig());
-        if (alias == null) {
-            return MultimodalRouteOutcome.skipped();
-        }
-        if (settings.getFusion().getMode() == FusionMode.WEIGHTED) {
-            log.info("multimodal route skipped under weighted fusion, kbId={}", target.kbId());
-            return MultimodalRouteOutcome.degraded(DegradedReason.MM_ROUTE_SKIPPED.code());
-        }
-        List<float[]> queryVectors;
-        if (CollectionUtils.isNotEmpty(imageQueryVectors)) {
-            // F6: the caller attached images and this base can search them, so the route embeds the pictures
-            // rather than the text - image to image and image to rendered page, the M14 contract section 7.
-            queryVectors = imageQueryVectors;
-        } else {
-            try {
-                queryVectors = List.of(multimodalEmbeddingProvider.embedTexts(List.of(query)).get(0));
-            } catch (Exception e) {
-                log.error("multimodal query embedding failed, errorCode={}, kbId={}",
-                        ErrorCode.UPSTREAM_MODEL_ERROR, target.kbId(), e);
-                return MultimodalRouteOutcome.degraded(DegradedReason.MM_ROUTE_UNAVAILABLE.code());
-            }
-        }
-        List<ScoredChunk> candidates = searchMultimodal(alias, queryVectors, filter, settings.getRecallTopK());
-        if (candidates.isEmpty()) {
-            return MultimodalRouteOutcome.skipped();
-        }
-        log.info("multimodal route finished, kbId={}, queries={}, candidates={}",
-                target.kbId(), queryVectors.size(), candidates.size());
-        return MultimodalRouteOutcome.of(candidates);
-    }
-
-    /**
-     * Searches the multimodal alias with every query vector and folds the hits into one ranking.
-     *
-     * <p>A text query issues one vector; an image query issues one per attached image. Overlapping hits are
-     * collapsed on the chunk id keeping the strongest similarity, so a chunk matched by two images is ranked
-     * once on its best score rather than counted twice, and the reciprocal rank fusion downstream sees a
-     * single ordered list exactly like the other routes.
-     *
-     * @param alias        multimodal alias to search
-     * @param queryVectors one or more query vectors
-     * @param filter       the very predicate the engine side routes were filtered by
-     * @param recallTopK   candidates the route contributes at most
-     * @return merged candidates ordered by descending similarity, tagged as the multimodal route
-     */
-    private List<ScoredChunk> searchMultimodal(String alias, List<float[]> queryVectors,
-                                               RetrievalFilter filter, int recallTopK) {
-        Map<String, Double> scoreByChunk = new LinkedHashMap<>();
-        for (float[] queryVector : queryVectors) {
-            List<ScoredChunk> hits = vectorStore.search(alias, VectorQuery.builder()
-                    .queryVector(queryVector).topK(recallTopK).filter(filter).build());
-            if (CollectionUtils.isEmpty(hits)) {
-                continue;
-            }
-            for (ScoredChunk hit : hits) {
-                scoreByChunk.merge(hit.getChunkId(), hit.getScore(), Math::max);
-            }
-        }
-        if (scoreByChunk.isEmpty()) {
-            return List.of();
-        }
-        List<ScoredChunk> candidates = new ArrayList<>(scoreByChunk.size());
-        for (Map.Entry<String, Double> entry : scoreByChunk.entrySet()) {
-            candidates.add(new ScoredChunk(entry.getKey(), entry.getValue(), RetrievalSource.MM));
-        }
-        candidates.sort(Comparator.comparingDouble(ScoredChunk::getScore).reversed()
-                .thenComparing(ScoredChunk::getChunkId));
-        return candidates.size() > recallTopK
-                ? new ArrayList<>(candidates.subList(0, recallTopK)) : candidates;
-    }
-
-    /**
-     * Decides what the attached images do, the single dispatch point of the M14 contract section 7.
-     *
-     * <p>Two outcomes, one of them per call. When the searched corpus can embed images - a multimodal
-     * provider is configured, at least one selected base has the multimodal switch on, the call is not a
-     * frozen release snapshot and a written query is present - the pictures are embedded and steer the
-     * multimodal route directly (image to image, image to rendered page). Otherwise they fall back to the
-     * vision transcription that folds their description into the query, exactly the path the open API used
-     * before this milestone, so a deployment without the multimodal capability keeps its image search.
-     *
-     * <p><b>A written query stays mandatory on the image route.</b> Pure image retrieval is out of scope for
-     * this milestone, so an image only call is never routed to the multimodal space; it takes the vision
-     * fallback, whose own gate rejects a call that has nothing at all to search for.
-     *
-     * <p><b>A release snapshot never takes the image route.</b> The multimodal index holds no frozen copy, so
-     * the per base route is off on the snapshot path anyway; sending images there would embed them for a
-     * route that cannot run, so a snapshot call transcribes them into its query instead.
-     *
-     * @param command call parameters, read for the images and the query
-     * @param targets knowledge bases the call will search
-     * @param degraded running degradation markers, appended in place
-     * @return the query the pipeline runs with and the image vectors the multimodal route embeds
-     */
-    private ImageDispatch dispatchImages(RetrievalCommand command, List<KbTarget> targets,
-                                         List<String> degraded) {
-        List<String> images = command.getImages();
-        if (multimodalUsableForImages(command, images, targets)) {
-            return new ImageDispatch(command.getQuery(), embedQueryImages(images, degraded));
-        }
-        ImageQueryService.ImageQueryOutcome outcome = imageQueryService.enrich(command.getQuery(), images);
-        outcome.degraded().forEach(reason -> addMarker(degraded, reason));
-        return new ImageDispatch(outcome.query(), List.of());
-    }
-
-    /**
-     * Tells whether the attached images can steer the multimodal route rather than the vision fallback.
-     *
-     * @param command call parameters, read for the query and the snapshot binding
-     * @param images  attached images
-     * @param targets knowledge bases the call will search
-     * @return {@code true} when the images are to be embedded into the multimodal space
-     */
-    private boolean multimodalUsableForImages(RetrievalCommand command, List<String> images,
-                                              List<KbTarget> targets) {
-        if (CollectionUtils.isEmpty(images) || !multimodalEmbeddingProvider.isConfigured()) {
-            return false;
-        }
-        if (command.getQuery() == null || command.getQuery().isBlank()) {
-            return false;
-        }
-        if (MapUtils.isNotEmpty(command.getIndexOverride())) {
-            return false;
-        }
-        return targets.stream().anyMatch(target ->
-                multimodalIndexManager.multimodalAlias(target.kbId(), target.indexConfig()) != null);
-    }
-
-    /**
-     * Embeds the attached images into the multimodal space, degrading rather than failing when the provider
-     * call itself breaks.
-     *
-     * <p>The count and size validation runs first and outside the try: an over sized or over counted image
-     * set is a caller error the pipeline rejects, not a degradation. A provider timeout or error, by
-     * contrast, leaves the written query and the other routes to answer, so it is reported through
-     * {@code mm_route_unavailable} and returns no vectors.
-     *
-     * @param images   attached images, already known to be present
-     * @param degraded running degradation markers, appended in place
-     * @return one vector per image, or empty when the provider call failed
-     */
-    private List<float[]> embedQueryImages(List<String> images, List<String> degraded) {
-        List<ImageInput> inputs = imageQueryService.decodeForEmbedding(images);
-        try {
-            return multimodalEmbeddingProvider.embedImages(inputs);
-        } catch (Exception e) {
-            log.error("query image embedding failed, errorCode={}, images={}",
-                    ErrorCode.UPSTREAM_MODEL_ERROR, inputs.size(), e);
-            addMarker(degraded, DegradedReason.MM_ROUTE_UNAVAILABLE.code());
-            return List.of();
-        }
-    }
-
-    /**
-     * What the image dispatch decided: the query every pipeline stage reads and the image vectors, if any,
-     * the multimodal route embeds instead of the text.
-     *
-     * @param query             query the pipeline runs with, enriched by the vision fallback when it ran
-     * @param imageQueryVectors embedded images for the multimodal route, empty on the fallback path
-     */
-    private record ImageDispatch(String query, List<float[]> imageQueryVectors) {
+        return multimodalRetrievalService.recall(target.multimodalTarget(), query, imageQueryVectors,
+                filter, settings);
     }
 
     /**
@@ -756,6 +540,11 @@ public class RetrievalService {
 
         boolean graphEnabled() {
             return retrievalConfig != null && retrievalConfig.graphEnabled();
+        }
+
+        /** The subset of this target the multimodal route is allowed to see. */
+        MultimodalRetrievalService.Target multimodalTarget() {
+            return new MultimodalRetrievalService.Target(kbId(), indexConfig);
         }
     }
 
@@ -1103,266 +892,6 @@ public class RetrievalService {
     }
 
     /**
-     * Turns the surviving units into the transport neutral nodes.
-     *
-     * @param orderingMode           strategy that produced the final ordering: the in base one on a single
-     *                               base call, reciprocal rank fusion once bases were merged
-     * @param units                  surviving units in ranking order
-     * @param decision               threshold decision of this search
-     * @param disabledChildrenByUnit disabled children to report per unit
-     * @param nearDuplicates         outcome of the near duplicate window merge
-     * @return ordered nodes
-     */
-    private List<RetrievalNodeView> toNodes(List<RetrievalUnit> units,
-                                            ScoreThresholdPolicy.ThresholdDecision decision,
-                                            FusionMode orderingMode,
-                                            Map<String, List<DisabledChildVisibility.DisabledChild>>
-                                                    disabledChildrenByUnit,
-                                            NearDuplicateWindowMerger.Outcome nearDuplicates) {
-        if (CollectionUtils.isEmpty(units)) {
-            return List.of();
-        }
-        Map<String, Chunk> parentById = loadParents(units);
-        List<RetrievalNodeView> nodes = new ArrayList<>(units.size());
-        for (RetrievalUnit unit : units) {
-            RetrievalCandidate best = unit.best();
-            ScoreThresholdPolicy.ReportedScore reported =
-                    scoreThresholdPolicy.report(best, decision, orderingMode);
-            Chunk answerChunk = unit.isParent()
-                    ? parentById.getOrDefault(unit.getUnitId(), best.getChunk())
-                    : best.getChunk();
-            List<DisabledChildVisibility.DisabledChild> disabledChildren =
-                    disabledChildrenByUnit.get(unit.getUnitId());
-            ParentTextRedactor.Redaction redaction = redact(answerChunk, disabledChildren);
-            nodes.add(RetrievalNodeView.builder()
-                    .docId(answerChunk.getDocId())
-                    .documentVersionId(answerChunk.getDocumentVersionId())
-                    .chunkId(answerChunk.getChunkId())
-                    .chunkType(answerChunk.getChunkType().code())
-                    .content(redaction.text())
-                    .score(reported.getValue())
-                    .scoreType(reported.getType().code())
-                    .retrievalSource(best.getFused().getPrimarySource().code())
-                    .metadata(buildMetadata(unit, answerChunk, decision, orderingMode,
-                            disabledChildren, redaction,
-                            // Keyed by the best member rather than by the unit: the merge judged candidates,
-                            // and on a two level base the unit id is a parent that was never a candidate.
-                            nearDuplicates.mergedIdsOf(best.chunkId())))
-                    .imageUrls(presignedImageUrls(unit, answerChunk))
-                    .previewUrl(null)
-                    .build());
-        }
-        return nodes;
-    }
-
-    /**
-     * Cuts the excluded passages out of a returned parent text, requirement section 4.5.
-     *
-     * <p>Reached only for a parent the knowledge base decided to return - the strict switch removed the
-     * others before this point - and only when the disabled children still know where they sit. Otherwise
-     * the redactor hands the text back untouched, which is the pre M9 behaviour.
-     *
-     * @param answerChunk      chunk whose text is returned
-     * @param disabledChildren excluded children of that chunk, {@code null} when there are none
-     * @return text to return with the number of passages that were cut
-     */
-    private ParentTextRedactor.Redaction redact(
-            Chunk answerChunk, List<DisabledChildVisibility.DisabledChild> disabledChildren) {
-        if (CollectionUtils.isEmpty(disabledChildren)) {
-            return new ParentTextRedactor.Redaction(answerChunk.getContent(), 0);
-        }
-        return parentTextRedactor.redact(answerChunk.getContent(), disabledChildren.stream()
-                .map(DisabledChildVisibility.DisabledChild::toSpan).toList());
-    }
-
-    /**
-     * Turns the stored image keys of a result into time limited pre signed URLs.
-     *
-     * <p>The keys are minted per response rather than stored as URLs: a link that lived in the index would
-     * be public for as long as the index exists, and it would already be expired by the time it is read.
-     *
-     * <p>A two level result collects the keys of its matched children as well as its own, because the parent
-     * text is what is returned and the image that made a child match is part of that text.
-     *
-     * @param unit        merged unit being returned
-     * @param answerChunk chunk whose text is returned
-     * @return pre signed URLs, empty when the result derives from no image
-     */
-    private List<String> presignedImageUrls(RetrievalUnit unit, Chunk answerChunk) {
-        List<String> keys = new ArrayList<>(imageKeysOf(answerChunk));
-        if (unit.isParent()) {
-            for (RetrievalCandidate member : unit.getMembers()) {
-                for (String key : imageKeysOf(member.getChunk())) {
-                    if (!keys.contains(key)) {
-                        keys.add(key);
-                    }
-                }
-            }
-        }
-        if (CollectionUtils.isEmpty(keys)) {
-            return List.of();
-        }
-        Duration ttl = Duration.ofMinutes(properties.getMinio().getPresignedTtlMinutes());
-        List<String> urls = new ArrayList<>(keys.size());
-        for (String key : keys) {
-            try {
-                urls.add(objectStorage.presignedUrl(key, ttl));
-            } catch (Exception e) {
-                // A thumbnail that cannot be signed must not fail a search: the passage is the answer.
-                log.info("image could not be presigned for a search result, object={}", key);
-            }
-        }
-        return urls;
-    }
-
-    /**
-     * Reads the image keys a chunk recorded.
-     *
-     * @param chunk fact source row
-     * @return object storage keys, empty when the chunk derives from no image
-     */
-    private List<String> imageKeysOf(Chunk chunk) {
-        Object value = storedMetadata(chunk).get(ChunkMetadataKeys.IMAGE_URLS);
-        if (!(value instanceof List<?> items)) {
-            return List.of();
-        }
-        List<String> keys = new ArrayList<>(items.size());
-        for (Object item : items) {
-            if (item != null) {
-                keys.add(String.valueOf(item));
-            }
-        }
-        return keys;
-    }
-
-    /**
-     * Parses the metadata column of a chunk.
-     *
-     * @param chunk fact source row
-     * @return metadata document, empty when the column is blank
-     */
-    private Map<String, Object> storedMetadata(Chunk chunk) {
-        if (chunk == null || chunk.getMetadata() == null || chunk.getMetadata().isBlank()) {
-            return Map.of();
-        }
-        Map<String, Object> parsed = JsonUtil.parse(chunk.getMetadata(),
-                new TypeReference<Map<String, Object>>() {
-                });
-        return parsed == null ? Map.of() : parsed;
-    }
-
-    /**
-     * Loads the parent rows of the two level units.
-     *
-     * <p>Parents are never indexed, so their text only exists in MySQL; this is the single reason the
-     * engines can stay child only while the caller still receives a passage large enough to read.
-     *
-     * @param units merged units
-     * @return parent chunk per parent chunk id
-     */
-    private Map<String, Chunk> loadParents(List<RetrievalUnit> units) {
-        List<String> parentIds = units.stream()
-                .filter(RetrievalUnit::isParent)
-                .map(RetrievalUnit::getUnitId)
-                .toList();
-        if (CollectionUtils.isEmpty(parentIds)) {
-            return Map.of();
-        }
-        List<Chunk> parents = chunkMapper.selectList(new LambdaQueryWrapper<Chunk>()
-                .in(Chunk::getChunkId, parentIds));
-        Map<String, Chunk> parentById = new HashMap<>(parents.size());
-        for (Chunk parent : parents) {
-            parentById.put(parent.getChunkId(), parent);
-        }
-        return parentById;
-    }
-
-    private Map<String, Object> buildMetadata(RetrievalUnit unit, Chunk answerChunk,
-                                              ScoreThresholdPolicy.ThresholdDecision decision,
-                                              FusionMode orderingMode,
-                                              List<DisabledChildVisibility.DisabledChild> disabledChildren,
-                                              ParentTextRedactor.Redaction redaction,
-                                              List<String> mergedWindowChunkIds) {
-        Map<String, Object> metadata = new LinkedHashMap<>(scoreMetadata(unit.best()));
-        // Read from the fact source row rather than from the routing decision: a node has to be traceable
-        // to its base even when routing never ran, and the row is the only place that cannot disagree.
-        metadata.put(META_KB_ID, answerChunk.getKbId());
-        metadata.put(META_CHUNK_SEQ, answerChunk.getSeq());
-        // The stored document facts travel next to the scores so a chat result card can show its
-        // conversation, its senders and its time without a second round trip. The image keys are excluded:
-        // they leave through image_urls as pre signed links and the raw keys are of no use to a caller.
-        storedMetadata(answerChunk).forEach((key, value) -> {
-            if (!ChunkMetadataKeys.IMAGE_URLS.equals(key)) {
-                metadata.putIfAbsent(key, value);
-            }
-        });
-        if (CollectionUtils.isNotEmpty(mergedWindowChunkIds)) {
-            metadata.put(META_MERGED_WINDOW_CHUNK_IDS, mergedWindowChunkIds);
-        }
-        if (!unit.isParent()) {
-            return metadata;
-        }
-        if (CollectionUtils.isNotEmpty(disabledChildren)) {
-            // Reported whether or not the text could be cut: the caller has to be able to tell that
-            // something inside this parent was excluded, and the two cases differ only by the count below.
-            metadata.put(META_DISABLED_CHILD_IDS, disabledChildren.stream()
-                    .map(DisabledChildVisibility.DisabledChild::chunkId).toList());
-        }
-        if (redaction.applied()) {
-            metadata.put(META_REDACTED_CHILD_COUNT, redaction.redactedChildCount());
-        }
-        metadata.put(META_CHILD_IDS, unit.getMembers().stream().map(RetrievalCandidate::chunkId).toList());
-        List<Map<String, Object>> children = new ArrayList<>(unit.getMembers().size());
-        for (RetrievalCandidate member : unit.getMembers()) {
-            ScoreThresholdPolicy.ReportedScore reported =
-                    scoreThresholdPolicy.report(member, decision, orderingMode);
-            Map<String, Object> child = new LinkedHashMap<>();
-            child.put(META_CHILD_CHUNK_ID, member.chunkId());
-            child.put(META_CHILD_CONTENT, member.getChunk().getContent());
-            child.put(META_CHILD_SCORE, reported.getValue());
-            child.put(META_CHILD_SCORE_TYPE, reported.getType().code());
-            child.putAll(scoreMetadata(member));
-            children.add(child);
-        }
-        metadata.put(META_CHILDREN, children);
-        return metadata;
-    }
-
-    /**
-     * Per route evidence of one candidate, shared by the node metadata and by the child detail list.
-     *
-     * <p>Both the raw and the normalised score are exposed when they exist: the raw value is what the
-     * engine reported and is the only one comparable with a manual query, while the normalised value
-     * is what the weighted strategy actually summed, and a debug page that shows one without the other
-     * cannot explain a ranking.
-     *
-     * @param candidate candidate being described
-     * @return score keys, ordered for readability
-     */
-    private Map<String, Object> scoreMetadata(RetrievalCandidate candidate) {
-        FusedChunk fused = candidate.getFused();
-        Map<String, Object> scores = new LinkedHashMap<>();
-        scores.put(META_FUSED_SCORE, fused.getFusedScore());
-        putIfPresent(scores, META_VECTOR_SCORE, fused.routeScore(RetrievalSource.VECTOR));
-        putIfPresent(scores, META_VECTOR_RANK, fused.getRouteRanks().get(RetrievalSource.VECTOR));
-        putIfPresent(scores, META_NORM_VECTOR_SCORE, fused.normalizedScore(RetrievalSource.VECTOR));
-        putIfPresent(scores, META_BM25_SCORE, fused.routeScore(RetrievalSource.BM25));
-        putIfPresent(scores, META_BM25_RANK, fused.getRouteRanks().get(RetrievalSource.BM25));
-        putIfPresent(scores, META_NORM_BM25_SCORE, fused.normalizedScore(RetrievalSource.BM25));
-        putIfPresent(scores, META_RERANK_SCORE, candidate.getRerankScore());
-        GraphChunkRelevance graph = candidate.getGraphEvidence();
-        if (graph != null) {
-            // The relevance is reported from the graph evidence rather than from the route score map: the
-            // two are the same number, and reading it from the object that also carries the hop count keeps
-            // the three keys of the debug row provably consistent with one another.
-            scores.put(META_GRAPH_SCORE, graph.score());
-            scores.put(META_GRAPH_HOPS, graph.hops());
-            scores.put(META_GRAPH_ENTITIES, graph.entityNames());
-        }
-        return scores;
-    }
-
-    /**
      * Builds the applied parameter summary.
      *
      * @param usedQuery          query the recall stage ran with
@@ -1380,12 +909,6 @@ public class RetrievalService {
                 .thresholdAppliedOn(thresholdAppliedOn)
                 .routedKbIds(routedKbIds)
                 .build();
-    }
-
-    private void putIfPresent(Map<String, Object> target, String key, Object value) {
-        if (value != null) {
-            target.put(key, value);
-        }
     }
 
     private void addMarker(List<String> degraded, String marker) {

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/chat/ChatImportServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/chat/ChatImportServiceTest.java
@@ -110,13 +110,19 @@ class ChatImportServiceTest {
         when(fingerprintFactory.chunkFingerprint(any())).thenReturn("cf");
         when(fingerprintFactory.parseFingerprint(any(), anyString())).thenReturn("pf");
 
-        service = new ChatImportService(documentMapper, documentVersionMapper, chunkMapper, objectStorage,
-                parserClient, knowledgeBaseService, uploadTokenStore, sourceMappingService,
-                new ChatSessionMatcher(), new ChatWindowAggregator(), new ChatWindowRenderer(),
+        // One matcher instance for both halves, as the container wires it: the source key that decides
+        // which document a conversation maps to has to be the same string on the preview and on the import.
+        ChatSessionMatcher sessionMatcher = new ChatSessionMatcher();
+        ChatSessionImporter sessionImporter = new ChatSessionImporter(documentMapper, documentVersionMapper,
+                chunkMapper, knowledgeBaseService, sessionMatcher, new ChatWindowAggregator(),
+                new ChatWindowRenderer(),
                 new DocumentCleaner(new HeaderFooterDetector(), new TextDesensitizer()),
                 new ChunkTextHasher(), chunkIndexWriter, chunkEmbedder, versionActivator,
                 annotationInheritanceService, embeddingProvider, bizIdGenerator, fingerprintFactory,
-                versionPlanner, properties);
+                versionPlanner);
+        service = new ChatImportService(documentMapper, objectStorage, parserClient, knowledgeBaseService,
+                uploadTokenStore, sourceMappingService, sessionMatcher, sessionImporter, bizIdGenerator,
+                properties);
     }
 
     @Test

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/eval/EvalRunServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/eval/EvalRunServiceTest.java
@@ -133,13 +133,17 @@ class EvalRunServiceTest {
      * @return service under test
      */
     private EvalRunService newService(Executor evalExecutor, Executor evalCaseExecutor) {
-        return new EvalRunService(evalDatasetService, appVersionService, evalRunMapper, evalResultMapper, evalCaseMapper,
-                retrievalService, embeddingProvider, rerankProvider, chatProvider, evalJudgeService,
-                answerGenerationService, finalAnswerJudgeService, corpusFingerprintFactory,
-                new EvalHitJudge(new OverlapRatioCalculator(new ChunkTextHasher())),
+        // One calculator instance behind both the hit judge and the overlap reporting, as the container
+        // wires it: a case judged a hit on one threshold must not report a ratio computed by another.
+        OverlapRatioCalculator overlapRatioCalculator = new OverlapRatioCalculator(new ChunkTextHasher());
+        EvalCaseRunner caseRunner = new EvalCaseRunner(retrievalService, evalJudgeService,
+                answerGenerationService, finalAnswerJudgeService,
+                new EvalHitJudge(overlapRatioCalculator), overlapRatioCalculator, properties);
+        return new EvalRunService(caseRunner, evalDatasetService, appVersionService, evalRunMapper,
+                evalResultMapper, evalCaseMapper, embeddingProvider, rerankProvider, chatProvider,
+                evalJudgeService, answerGenerationService, finalAnswerJudgeService, corpusFingerprintFactory,
                 new EvalMetricsCalculator(), new FinalAnswerMetricsCalculator(),
-                new OverlapRatioCalculator(new ChunkTextHasher()),
-                bizIdGenerator, properties, evalExecutor, evalCaseExecutor);
+                bizIdGenerator, evalExecutor, evalCaseExecutor);
     }
 
     @Test

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/index/IndexPipelineServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/index/IndexPipelineServiceTest.java
@@ -1,0 +1,355 @@
+package io.kbrag.app.index;
+
+import io.kbrag.app.kb.KnowledgeBaseService;
+import io.kbrag.app.support.MybatisLambdaCache;
+import io.kbrag.common.api.ErrorCode;
+import io.kbrag.common.exception.BizException;
+import io.kbrag.common.util.JsonUtil;
+import io.kbrag.domain.entity.Chunk;
+import io.kbrag.domain.entity.Document;
+import io.kbrag.domain.entity.DocumentVersion;
+import io.kbrag.domain.entity.KbTask;
+import io.kbrag.domain.enums.ProcessStatus;
+import io.kbrag.domain.enums.DocumentVersionStatus;
+import io.kbrag.domain.enums.TaskType;
+import io.kbrag.domain.mapper.ChunkMapper;
+import io.kbrag.domain.mapper.DocumentMapper;
+import io.kbrag.domain.mapper.DocumentVersionMapper;
+import io.kbrag.domain.model.KbIndexConfig;
+import io.kbrag.domain.model.ParsePreview;
+import io.kbrag.domain.model.ParsedDocument;
+import io.kbrag.domain.model.ProxiedContent;
+import io.kbrag.domain.port.DocumentParserClient;
+import io.kbrag.domain.port.EmbeddingProvider;
+import io.kbrag.domain.port.ObjectStorage;
+import io.kbrag.domain.port.VisionProvider;
+import io.kbrag.domain.service.DocumentCleaner;
+import io.kbrag.domain.service.DocumentVersionPlanner;
+import io.kbrag.domain.service.ImagePlaceholderResolver;
+import io.kbrag.domain.service.PageSplitter;
+import io.kbrag.domain.service.PagedContentAssembler;
+import io.kbrag.domain.service.VersionFingerprintFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the routing decisions of the index pipeline, not the extraction it delegates.
+ *
+ * <p>Every stage of a build lives behind a collaborator - the parser client, {@link ChunkSplitter},
+ * {@link ChunkIndexWriter}, {@link VersionActivationHandler}, {@link IndexTaskLifecycle} - and each of
+ * those is tested where it lives. What is left here, and what these tests are about, is the part no
+ * collaborator can check: <em>which</em> of them run, in which order, and what the document is left
+ * looking like when one of them throws.
+ *
+ * <p>Three risks make that worth its own test class. A reuse that silently produced nothing would leave
+ * a document indexed with zero chunks - invisible until somebody searches for it. A parse failure
+ * reported as an index failure sends an operator to the wrong half of the system. And a knowledge base
+ * that requires a parse confirmation must never reach the engines before a human says so, which is a
+ * property of what is <em>not</em> called.
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class IndexPipelineServiceTest {
+
+    private static final String KB_ID = "kb_test";
+    private static final String DOC_ID = "doc_test";
+    private static final String VERSION_ID = "dv_test";
+    private static final String SOURCE_VERSION_ID = "dv_source";
+    private static final String PARSED_OBJECT = "kb/kb_test/doc/doc_test/dv_source/parsed.json";
+    private static final String MARKDOWN = "hello world";
+
+    private DocumentMapper documentMapper;
+    private DocumentVersionMapper documentVersionMapper;
+    private ChunkMapper chunkMapper;
+    private ObjectStorage objectStorage;
+    private DocumentParserClient parserClient;
+    private EmbeddingProvider embeddingProvider;
+    private ChunkEmbedder chunkEmbedder;
+    private ChunkSplitter chunkSplitter;
+    private IndexTaskLifecycle taskLifecycle;
+    private VisionProvider visionProvider;
+    private ChunkIndexWriter chunkIndexWriter;
+    private MultimodalIndexManager multimodalIndexManager;
+    private KnowledgeBaseService knowledgeBaseService;
+    private VersionFingerprintFactory fingerprintFactory;
+    private ImageAssetService imageAssetService;
+    private DocumentCleaner documentCleaner;
+    private PagedContentAssembler pagedContentAssembler;
+    private ImagePlaceholderResolver placeholderResolver;
+    private VersionArtifactReuser versionArtifactReuser;
+    private VersionActivationHandler activationHandler;
+
+    private Document document;
+    private DocumentVersion version;
+    private KbIndexConfig config;
+    private KbTask task;
+    private IndexPipelineService service;
+
+    @BeforeEach
+    void setUp() {
+        // The pipeline writes null into fail_reason, which updateById skips by design, so it builds
+        // lambda update wrappers - and those need the column cache a Spring scan would have filled.
+        MybatisLambdaCache.register(Document.class, DocumentVersion.class, Chunk.class);
+        documentMapper = mock(DocumentMapper.class);
+        documentVersionMapper = mock(DocumentVersionMapper.class);
+        chunkMapper = mock(ChunkMapper.class);
+        objectStorage = mock(ObjectStorage.class);
+        parserClient = mock(DocumentParserClient.class);
+        embeddingProvider = mock(EmbeddingProvider.class);
+        chunkEmbedder = mock(ChunkEmbedder.class);
+        chunkSplitter = mock(ChunkSplitter.class);
+        taskLifecycle = mock(IndexTaskLifecycle.class);
+        visionProvider = mock(VisionProvider.class);
+        chunkIndexWriter = mock(ChunkIndexWriter.class);
+        multimodalIndexManager = mock(MultimodalIndexManager.class);
+        knowledgeBaseService = mock(KnowledgeBaseService.class);
+        fingerprintFactory = mock(VersionFingerprintFactory.class);
+        imageAssetService = mock(ImageAssetService.class);
+        documentCleaner = mock(DocumentCleaner.class);
+        pagedContentAssembler = mock(PagedContentAssembler.class);
+        placeholderResolver = mock(ImagePlaceholderResolver.class);
+        versionArtifactReuser = mock(VersionArtifactReuser.class);
+        activationHandler = mock(VersionActivationHandler.class);
+
+        document = document();
+        version = version();
+        config = new KbIndexConfig();
+        task = task();
+
+        when(documentVersionMapper.selectOne(any())).thenReturn(version);
+        when(documentMapper.selectOne(any())).thenReturn(document);
+        when(taskLifecycle.start(anyString(), any(TaskType.class))).thenReturn(task);
+        when(knowledgeBaseService.indexConfigOf(KB_ID)).thenReturn(config);
+        when(objectStorage.get(anyString())).thenAnswer(invocation -> stream(""));
+        when(parserClient.parse(anyString(), anyString(), any()))
+                .thenReturn(ParsedDocument.builder().markdown(MARKDOWN).build());
+        when(imageAssetService.isStandaloneImage(anyString())).thenReturn(false);
+        when(imageAssetService.materialize(any(), any(), any(), anyList())).thenReturn(List.of());
+        when(imageAssetService.findByVersion(anyString())).thenReturn(List.of());
+        when(documentCleaner.clean(anyString(), anyList(), any())).thenReturn(MARKDOWN);
+        when(placeholderResolver.resolve(anyString(), any()))
+                .thenReturn(new ProxiedContent(MARKDOWN, List.of()));
+        when(fingerprintFactory.parseFingerprint(any(), any())).thenReturn("pf");
+        when(fingerprintFactory.chunkFingerprint(any())).thenReturn("cf");
+        when(visionProvider.model()).thenReturn("none");
+        when(embeddingProvider.isConfigured()).thenReturn(false);
+        when(embeddingProvider.model()).thenReturn("none");
+        when(chunkSplitter.split(any())).thenReturn(List.of(chunk()));
+        when(chunkEmbedder.embed(anyList())).thenReturn(Map.of());
+        when(chunkMapper.selectList(any())).thenReturn(List.of());
+
+        service = new IndexPipelineService(documentMapper, documentVersionMapper, chunkMapper, objectStorage,
+                parserClient, embeddingProvider, chunkEmbedder, chunkSplitter, taskLifecycle, visionProvider,
+                chunkIndexWriter, multimodalIndexManager, knowledgeBaseService, fingerprintFactory,
+                imageAssetService, documentCleaner, pagedContentAssembler, placeholderResolver,
+                versionArtifactReuser, activationHandler);
+    }
+
+    @Test
+    void shouldSplitIndexAndActivateOnASuccessfulBuild() {
+        service.execute(VERSION_ID);
+
+        verify(chunkSplitter).split(any());
+        verify(chunkIndexWriter).write(eq(KB_ID), anyList(), any());
+        verify(activationHandler).activateAndFollowUp(document, version);
+        verify(taskLifecycle).complete(task);
+        verify(taskLifecycle, never()).fail(any(), anyString());
+    }
+
+    @Test
+    void shouldParkTheDocumentWithoutIndexingWhenAParseConfirmationIsRequired() {
+        config.setParsePreviewRequired(true);
+
+        service.execute(VERSION_ID);
+
+        // Nothing may reach the engines before a human confirms the preview, and the version must not be
+        // activated either - the whole point of the pause is that the document is not yet searchable.
+        verify(chunkSplitter, never()).split(any());
+        verify(chunkIndexWriter, never()).write(anyString(), anyList(), any());
+        verify(activationHandler, never()).activateAndFollowUp(any(), any());
+        // The task itself succeeded: it did everything it was asked to do and is now waiting on a person.
+        verify(taskLifecycle).complete(task);
+        assertEquals(ProcessStatus.PENDING_CONFIRM, document.getProcessStatus());
+    }
+
+    @Test
+    void shouldBuildFromTheCopiedGenerationWithoutCallingTheParserWhenChunkReuseSucceeds() {
+        when(versionArtifactReuser.copyChunks(any(), any(), eq(SOURCE_VERSION_ID), anyBoolean()))
+                .thenReturn(List.of(chunk()));
+
+        service.execute(VERSION_ID, DocumentVersionPlanner.Reuse.chunks(SOURCE_VERSION_ID, PARSED_OBJECT));
+
+        verify(parserClient, never()).parse(anyString(), anyString(), any());
+        verify(chunkSplitter, never()).split(any());
+        verify(activationHandler).activateAndFollowUp(document, version);
+        verify(taskLifecycle).complete(task);
+    }
+
+    @Test
+    void shouldFallBackToAFullBuildWhenTheReuseSourceCarriesNoChunk() {
+        // The source may have been archived between the intake decision and this call. Trusting the copy
+        // blindly would activate a version with zero chunks, which no caller could ever recall.
+        when(versionArtifactReuser.copyChunks(any(), any(), eq(SOURCE_VERSION_ID), anyBoolean()))
+                .thenReturn(List.of());
+
+        service.execute(VERSION_ID, DocumentVersionPlanner.Reuse.chunks(SOURCE_VERSION_ID, PARSED_OBJECT));
+
+        verify(chunkSplitter).split(any());
+        verify(chunkIndexWriter).write(eq(KB_ID), anyList(), any());
+        verify(activationHandler).activateAndFollowUp(document, version);
+    }
+
+    @Test
+    void shouldReportAParseFailureAsParseFailedRatherThanIndexFailed() {
+        when(parserClient.parse(anyString(), anyString(), any()))
+                .thenThrow(new BizException(ErrorCode.PARSE_FAILED, "unreadable pdf"));
+
+        service.execute(VERSION_ID);
+
+        // The status is what sends an operator to one half of the system or the other.
+        assertEquals(ProcessStatus.PARSE_FAILED, document.getProcessStatus());
+        assertEquals(DocumentVersionStatus.BUILD_FAILED, version.getStatus());
+        verify(taskLifecycle).fail(eq(task), anyString());
+        verify(activationHandler, never()).activateAndFollowUp(any(), any());
+    }
+
+    @Test
+    void shouldReportAnUnexpectedFailureAsIndexFailed() {
+        when(chunkSplitter.split(any())).thenThrow(new IllegalStateException("splitter exploded"));
+
+        service.execute(VERSION_ID);
+
+        assertEquals(ProcessStatus.INDEX_FAILED, document.getProcessStatus());
+        assertEquals(DocumentVersionStatus.BUILD_FAILED, version.getStatus());
+        verify(taskLifecycle).fail(eq(task), anyString());
+        verify(activationHandler, never()).activateAndFollowUp(any(), any());
+    }
+
+    @Test
+    void shouldNotLetAFailedBuildEscapeToTheAsyncCaller() {
+        when(chunkSplitter.split(any())).thenThrow(new IllegalStateException("splitter exploded"));
+
+        // A throw here would leave the async wrapper to log a second, less informative failure over a
+        // document whose state this method has already recorded correctly.
+        service.execute(VERSION_ID);
+
+        verify(taskLifecycle).fail(eq(task), anyString());
+    }
+
+    @Test
+    void shouldSplitTheStoredPreviewOnConfirmWithoutParsingAgain() {
+        when(objectStorage.get(anyString())).thenAnswer(invocation -> stream(JsonUtil.toJson(
+                ParsePreview.builder().markdown(MARKDOWN).build())));
+
+        service.confirm(VERSION_ID);
+
+        // Re-deriving the text would let a configuration change made after the preview was rendered alter
+        // what actually reaches the index - the operator would have approved something else.
+        verify(parserClient, never()).parse(anyString(), anyString(), any());
+        verify(documentCleaner, never()).clean(anyString(), anyList(), any());
+        verify(chunkSplitter).split(any());
+        verify(activationHandler).activateAndFollowUp(document, version);
+        verify(taskLifecycle).complete(task);
+    }
+
+    @Test
+    void shouldTellTheSplitterThatThePageStrategyApplies() {
+        config.setSplitStrategy(PageSplitter.STRATEGY_CODE);
+
+        service.execute(VERSION_ID);
+
+        // One gate, read by two stages: the preparation decides whether to assemble page by page and the
+        // splitter decides whether to dispatch to the page splitter. Two answers would silently degrade
+        // the strategy to fixed length.
+        assertTrue(capturedRequest().pageStrategy());
+        assertFalse(capturedRequest().standaloneImage());
+    }
+
+    @Test
+    void shouldNeverPageSplitAStandaloneImage() {
+        config.setSplitStrategy(PageSplitter.STRATEGY_CODE);
+        when(imageAssetService.isStandaloneImage(anyString())).thenReturn(true);
+        when(imageAssetService.materializeStandalone(any(), any(), any())).thenReturn(imageAsset());
+
+        service.execute(VERSION_ID);
+
+        // An uploaded image has no parse artifact and its whole text comes from the vision model, so the
+        // page route would find nothing and drop the one chunk the image needs.
+        ChunkSplitter.SplitRequest request = capturedRequest();
+        assertTrue(request.standaloneImage());
+        assertFalse(request.pageStrategy());
+        verify(parserClient, never()).parse(anyString(), anyString(), any());
+    }
+
+    private ChunkSplitter.SplitRequest capturedRequest() {
+        ArgumentCaptor<ChunkSplitter.SplitRequest> captor =
+                ArgumentCaptor.forClass(ChunkSplitter.SplitRequest.class);
+        verify(chunkSplitter).split(captor.capture());
+        return captor.getValue();
+    }
+
+    private static ByteArrayInputStream stream(String body) {
+        return new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Document document() {
+        Document document = new Document();
+        document.setDocId(DOC_ID);
+        document.setKbId(KB_ID);
+        document.setFileName("guide.pdf");
+        document.setFileExt("pdf");
+        return document;
+    }
+
+    private static DocumentVersion version() {
+        DocumentVersion version = new DocumentVersion();
+        version.setVersionId(VERSION_ID);
+        version.setDocId(DOC_ID);
+        version.setMinioObject("kb/kb_test/doc/doc_test/source.pdf");
+        return version;
+    }
+
+    private static KbTask task() {
+        KbTask task = new KbTask();
+        task.setTaskId("task_test");
+        task.setTaskType(TaskType.INDEX);
+        task.setBizId(VERSION_ID);
+        return task;
+    }
+
+    private static Chunk chunk() {
+        Chunk chunk = new Chunk();
+        chunk.setChunkId("ck_1");
+        chunk.setKbId(KB_ID);
+        chunk.setDocId(DOC_ID);
+        chunk.setDocumentVersionId(VERSION_ID);
+        chunk.setContent(MARKDOWN);
+        return chunk;
+    }
+
+    private static io.kbrag.domain.entity.ImageAsset imageAsset() {
+        io.kbrag.domain.entity.ImageAsset asset = new io.kbrag.domain.entity.ImageAsset();
+        asset.setImageId("img_1");
+        asset.setObjectKey("kb/kb_test/doc/doc_test/dv_test/img_1.png");
+        return asset;
+    }
+}

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/retrieval/RetrievalServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/retrieval/RetrievalServiceTest.java
@@ -157,16 +157,22 @@ class RetrievalServiceTest {
         indexContextResolver = new RetrievalIndexContextResolver(indexAliasManager,
                 new ActiveVersionResolver(documentMapper, properties), documentAclService,
                 fulltextStore, vectorStore);
+        // One policy instance for both collaborators, as the container wires it: the score a node reports
+        // and the score the threshold acted on have to come from the same rules to stay comparable.
+        ScoreThresholdPolicy scoreThresholdPolicy = new ScoreThresholdPolicy();
         retrievalService = new RetrievalService(knowledgeBaseService, chunkMapper,
                 fulltextStore, vectorStore, embeddingProvider, indexContextResolver,
                 new FusionRouter(List.of(new RrfFusion(), new WeightedFusion())),
                 new CrossKbRrfFusion(), new KbQuotaAllocator(), graphRetrievalService,
-                multimodalIndexManager, multimodalEmbeddingProvider,
-                new ImageQueryService(visionProvider, properties), routingService,
-                rewriteService, rerankService, new ScoreThresholdPolicy(), new ParentChildMerger(),
+                new MultimodalRetrievalService(multimodalIndexManager, multimodalEmbeddingProvider,
+                        new ImageQueryService(visionProvider, properties), vectorStore),
+                routingService,
+                rewriteService, rerankService, scoreThresholdPolicy, new ParentChildMerger(),
                 new NearDuplicateWindowMerger(),
-                new DisabledChildVisibility(chunkMapper), new ParentTextRedactor(),
-                engineChunkCleaner, objectStorage,
+                new DisabledChildVisibility(chunkMapper),
+                new RetrievalNodeAssembler(chunkMapper, scoreThresholdPolicy, new ParentTextRedactor(),
+                        objectStorage, properties),
+                engineChunkCleaner,
                 new RetrievalDegradeMonitor(properties), properties);
     }
 


### PR DESCRIPTION
## 起因

对 `kb-rag-server` 和 `kb-rag-parse-java` 做质量普查，先扫的是规范面，结果出乎意料地干净：

| 检查项 | kb-rag-server | kb-rag-parse-java |
|---|---|---|
| `log.warn`（规范禁止） | 0 | 0 |
| 吞异常 / `printStackTrace` | 0 | 0 |
| 空 catch 块 | 0 | 0 |
| `System.out` | 0 | 0 |

方法粒度也是好的——74563 行主代码里超过 60 行的方法只有 3 个。**真正的问题只有一个：类级别的职责过载**，四个应用服务的构造依赖分别达到 31 / 25 / 22 / 21 个。

## 拆分依据：依赖的独占性，不是行数

按行数切类会切出错误的边界。本 PR 每次抽取前都先验证一件事：**某组协作者是否只被某一段代码读**。是，才说明那一段是一个独立职责；否则就是切在了肌肉上。

举两个实例：

- `RetrievalService` 1396 行里，`ParentTextRedactor` 和 `ObjectStorage` 各自只出现 1 次，且都在视图组装段；22 个 `META_*` 展示型常量的引用也全部落在那一段内、无人回读 → 这是"胜出片段怎么描述"这一独立职责。
- `activateAndFollowUp` 只有 8 行代码，却独占 5 个依赖 → 依赖密度本身就是职责边界的证据。

## 七次抽取

**检索线**
- `RetrievalNodeAssembler`：管线决定"哪些片段胜出"，它决定"胜出者怎么描述"（两级单元取父片文本、分数键命名、禁用子片剔除、图片 key 转预签名 URL）。
- `MultimodalRetrievalService`：补齐一处**既有的不对称**——图路早有独立的 `GraphRetrievalService`，多模态的执行逻辑却内联在管线里，而 `MultimodalRouteOutcome` 的注释本就写明自己是照 `GraphRouteOutcome` 建模的。顺带把图片分发"就地改写调用方 degraded 列表"的副作用写法改成返回式 outcome，与 `RewriteOutcome`/`RoutingOutcome` 的既有惯例一致。

**索引线**
- `ChunkSplitter`、`IndexTaskLifecycle`（`t_kb_task` 状态机）、`VersionActivationHandler`（激活及其四项后续）。
- `VersionActivationHandler` 刻意区别于既有的 `DocumentVersionActivator`：后者只守"单一 active 版本"这条不变式，聊天导入与手工回滚也复用它，那条不变式不能依赖任何后续步骤成功。

**导入 / 评测线**
- `ChatSessionImporter`：把一次会话写成一个文档版本，独占 13 个依赖。
- `EvalCaseRunner`：跑单个用例，**不碰任何 mapper**——用例是语料与配置的纯函数，这正是它可以安全并发的前提；一旦它写了一行，就不再是了。`answerJudgeRequested` 提为 `public static` 由费用预估与执行共用，两份副本会变成"这个用例会不会调模型"的两个答案，而预估存在的意义正是可被信任。

## 实测结果

| 类 | 行数 | 构造依赖 |
|---|---|---|
| `IndexPipelineService` | 1119 → **871** | 31 → **20** |
| `RetrievalService` | 1396 → **919** | 25 → **22** |
| `EvalRunService` | 932 → **757** | 21 → **18** |
| `ChatImportService` | 473 → **279** | 22 → **10** |

顺带清理：`judgeOneCase` / `judgeAll` 中只用于向下透传、从未被读取的参数 `k`；`ReleaseGateService.runGate` 提取 `submitGateRuns`（88 → 65 行，全仓超 60 行的方法从 3 个减到 2 个）。

## 补测试与变异验证

`IndexPipelineService` 此前**没有自己的单测**（引用它的三个测试类都只把它当 mock），这是这条线上唯一的技术债。新增 `IndexPipelineServiceTest` 10 例，覆盖管线的路由决策而非它委派出去的抽取。

绿色测试不等于有效测试，所以做了变异验证——逐处注入缺陷，确认对应用例转红：

| 注入的缺陷 | 转红用例 |
|---|---|
| 复用源为空时不再回退到完整构建 | `shouldFallBackToAFullBuildWhenTheReuseSourceCarriesNoChunk` |
| 解析失败误报为索引失败 | `shouldReportAParseFailureAsParseFailedRatherThanIndexFailed` |
| 忽略"需要解析确认"开关 | `shouldParkTheDocumentWithoutIndexingWhenAParseConfirmationIsRequired` |
| 单图文档也走页切分 | `shouldNeverPageSplitAStandaloneImage` |
| 构建失败不置版本 `BUILD_FAILED` | `shouldReportAParseFailureAs...` + `shouldReportAnUnexpectedFailureAsIndexFailed` |

**5 处注入，5 处全部被捕获**（最后一处转红 2 个用例，因两条失败路径都断言该状态）。

## 验证

- **测试**：`mvn -o clean test` 非增量，kb-rag-server `402+67+796+85 = 1350` 例（1340 → 1350，新增 10 例）、kb-rag-parse-java `112` 例，全部 0 失败 0 错误。
- **Spring 装配**：本仓没有任何全量上下文加载测试，测试通过不能证明容器起得来，因此另写脚本分析 bean 依赖图 —— **246 个 bean 的构造注入图无环**（构造注入的环在启动期直接失败，必须证明）。全仓 `@Lazy` 出现 0 处，重构保持了这个性质。
- **死代码**：11 个改动类中无残留的未引用私有方法 / 常量 / 字段。
- **行为等价**：全部为 Extract Class / Extract Method，未改任何逻辑分支。

## 三处有意保留

1. **`RetrievalService.search` 保持 127 行。** 试算过提取"跨库召回"段：会产生一个 **9 参数**的方法。参数爆炸比长方法更糟。它是 19 步线性管线、无嵌套、每步都有解释"为什么"的注释——本质复杂度，拆分只为满足行数指标。
2. **`kb-rag-parse-java` 未改一行。** 已是策略模式 + 完整异常体系 + 详尽 Javadoc，只有 5 个方法超 40 行。最长的 `PythonRegexTranslator.translate`（81 行）是单遍字符扫描器，拆开要在方法间回写 `i`/`translated`/`groupsByName`，只会更难读。
3. **`RetrievalService` 22 / `IndexPipelineService` 20 个依赖是合理的。** 它们是管线编排器，依赖数反映的是管线**阶段数**而非职责混乱；再降需要引入 Stage 接口 + 胖 Context，那是过度设计。

## 文档同步

| 文档 | 处理 |
|---|---|
| `kb-rag-server/CHANGELOG.md` | 新增「重构」章节，含实测数字表 |
| `kb-rag-deploy/CHANGELOG.md` | `[Unreleased] / Changed` 首条，写给运维：无 Flyway、无配置键、无对外行为变更，**升级零操作** |
| `kb-rag-deploy/docs/ARCHITECTURE.md` | 升 v2.8；§3.4 补两个协作者（多模态路由此前在该表是空白），§3.5 补编排/执行分离与失败语义 |
| `openapi/kb-server.yaml` | **不改**：对外契约与 degraded 枚举零变化，版本号保持 `0.26.0-m24` |
| 里程碑契约 `M*-CONTRACTS.md` | **不改**：契约零变化 |

§3.5 原有一句「`page` 策略由管线直接分流到 `PageSplitter`」已随本次重构失准（分流现在在 `ChunkSplitter` 内，由管线传入标志），一并订正。

## 影响面

对外 HTTP 契约、数据库 schema、配置键、容器与依赖均无变化。纯代码结构调整。
