### PR TITLE
fix(server): 模型配额预占的 INSERT/UPDATE 顺序导致 InnoDB 死锁

### DIFF
--- a/kb-rag-deploy/CHANGELOG.md
+++ b/kb-rag-deploy/CHANGELOG.md
@@ -43,6 +43,16 @@
 
 ### Fixed
 
+- **索引大文档时模型预占死锁导致整个索引任务失败（M24 后修复）**：日志里表现为
+  `MySQLTransactionRollbackException: Deadlock found when trying to get lock`，堆栈落在
+  `ModelUsageMonthlyMapper.reserve`，**运维视角看到的是「文档一直索引失败、重试还是失败，但数据库
+  和模型服务都正常」**。根因是配额预占事务先 `INSERT IGNORE` 建计数器行、再 `UPDATE` 同一行：行已
+  存在时前者取 S 锁、后者要 X 锁，两个并发预占各持 S 各等 X，InnoDB 杀掉其中一个。一篇文档的嵌入
+  分批是并发的且都计费到同一个租户月同一行，所以**文档越大越必然触发**，小文档可能一直不复现。
+  修复后热路径只剩一条 `UPDATE`。**无 Flyway 迁移、无新增或改名的配置键与环境变量、无新容器或
+  第三方依赖、对外 HTTP 契约不变，OpenAPI 版本号保持 `0.26.0-m24` 不动——升级零操作**；升级后原先
+  失败的文档重新触发索引即可正常完成。`docs/ARCHITECTURE.md` 升 v2.8，`M24-CONTRACTS.md` §1 补
+  预占语句顺序不变量。
 - **`.htm` 上传被白名单挡下（M12 后修复）**：M12 在 kb-rag-parser 注册的是 `html` 与 `htm` 两个
   扩展名，`UPLOAD_ALLOWED_EXTENSIONS` 默认值当期却只追加了 `html`。上传路径唯一的校验闸门
   `UploadValidator` 因此把 `.htm` 判为 `unsupported file extension`——解析侧支持、入口不放行，

--- a/kb-rag-deploy/docs/ARCHITECTURE.md
+++ b/kb-rag-deploy/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # kb-rag 架构文档
 
 
-> 版本：v2.8（基线 = v2.7 + kb-app 四个上帝类按职责拆解，2026-09-02；v2.7 基线为 M24，其余历史见 Git）
+> 版本：v2.9（基线 = v2.8 + M24 后修复：模型预占死锁，2026-09-02；v2.8 基线为 kb-app 上帝类拆解，其余历史见 Git）
 > 日期：2026-09-02
 > 作者：RichardFyoung / Claude
 >
@@ -127,7 +127,7 @@ kb-api ──► kb-app ──► kb-domain ──► kb-common
 | `SamlProcessor`（M16） | `XmlDsigSamlProcessor` | SAML 2.0 Response 签名验证（自实现 XML-DSig，不引入 Spring Security SAML） |
 | `CasValidator`（M16） | `HttpCasValidator` | CAS ticket 服务端二次校验 |
 | `MemoryStore`（M19） | `EsMemoryStore` | 记忆节点检索副本：单物理索引 `kb_memory_nodes_v1` 所有记忆库共用（隔离靠 `library_id`+`user_id` filter）；vector mapping 懒加载（首个带 embedding 的写入按维度 putMapping）；kNN+BM25 并联，零 Key 降级 BM25 单路；过期节点查询期过滤 |
-| `ModelCallMeter`（M24） | `ModelUsageService` / 测试用 `NOOP` | Provider HTTP 出站前做租户月配额原子预占，响应后以供应商 usage 或保守估算结算；适配器不知道数据库细节 |
+| `ModelCallMeter`（M24） | `ModelUsageService` / 测试用 `NOOP` | Provider HTTP 出站前做租户月配额原子预占，响应后以供应商 usage 或保守估算结算；适配器不知道数据库细节。**预占事务内条件 `UPDATE` 必须先于任何建行语句**：行已存在时 `INSERT IGNORE` 取 S 锁、`UPDATE` 要 X 锁，两个并发预占各持 S 各等 X 即死锁（M24 后修复，见 M24 契约 §1.1 引用块） |
 
 **零 Key / 能力开关统一装置**：`ModelProviderConfig` 是唯一读模型凭据的地方，凭据为空即注入 `Unconfigured*` 实现；`GraphStoreConfig`（NEO4J_URI 空 → `DisabledGraphStore`）与 `QdrantClientConfig`（QDRANT_URI 空 → 不建 client、不注册健康探针）镜像同一模式。上游代码只写 `isConfigured()/isEnabled()` 一个分支，全链路无 null 检查——这是需求 §5"防御式编程只做一处且高复用"的落地点。
 

--- a/kb-rag-deploy/docs/M24-CONTRACTS.md
+++ b/kb-rag-deploy/docs/M24-CONTRACTS.md
@@ -17,6 +17,15 @@ M24 回答两个生产问题：一次模型调用应归属哪个租户、一个�
 1. **先预占、后调用**：模型 HTTP 请求发出前，用一条条件 `UPDATE` 原子判断
    `used_tokens + reserved_tokens + 本次预占 <= monthly_token_quota`。禁止先 `SUM` 再写入，后者在并发下会
    让多个请求同时越过同一个余额。
+
+   > **预占语句顺序（M24 后修复补齐）**：这条 `UPDATE` 必须是预占事务里对
+   > `t_kb_model_usage_monthly` 的**第一条**语句，计数器行只在 `UPDATE` 影响 0 行、且经不加锁的
+   > 存在性查询确认该行确实缺席时才补建。原实现每次调用先 `INSERT IGNORE` 建行再 `UPDATE`：行已存在时
+   > `INSERT IGNORE` 会为判定唯一键冲突而对该行加 S 锁，随后的 `UPDATE` 需要把它升级为 X 锁——两个
+   > 并发预占各持 S 各等 X，InnoDB 判定死锁并杀掉其中一个。同一文档的嵌入分批是并发的且计费到同一个
+   > 租户月，因此大文档必然触发。超配额时同样不得回落到 `INSERT IGNORE`：超配额会持续到月末，那会让
+   > 同一把 S 锁回到每一次被拒调用上。
+
 2. **真实用量替换预占**：供应商响应带 usage 时，以其 input/output/total 结算；兼容 OpenAI
    `prompt_tokens/completion_tokens` 与 DashScope `input_tokens/output_tokens` 命名。
 3. **未知用量保守结算**：供应商没有 usage 时按预占量结算，`estimated=1`。进程崩溃遗留的 RESERVED
@@ -92,7 +101,7 @@ CallerRuns 回压场景也不能误清提交者上下文。图谱抽取和图片
 
 ## 7. 测试与验收
 
-单元测试覆盖：原子配额拒绝、价格快照、真实/未知用量结算、崩溃保守结算、OpenAI/DashScope usage
+单元测试覆盖：原子配额拒绝、预占热路径不建行与首次调用补建后重试（M24 后修复）、价格快照、真实/未知用量结算、崩溃保守结算、OpenAI/DashScope usage
 解析、供应商返回后解析失败不释放、UTF-8/输出预算、压缩图片像素上界、Token 加法溢出、异步上下文传播、
 租户配额更新和索引补偿租户归属。管理台执行 test/lint/build；OpenAPI、Flyway、配置与两份需求文档进入
 部署契约校验；里程碑结束执行整个仓库的全量单元测试门禁。

--- a/kb-rag-server/CHANGELOG.md
+++ b/kb-rag-server/CHANGELOG.md
@@ -7,6 +7,27 @@
 
 尚未打过 tag，以下条目全部属于首个发布版本的内容，按里程碑倒序排列。
 
+### 修复（M24 后修复：并发预占把 `INSERT IGNORE` 和 `UPDATE` 压在同一行上，触发 InnoDB 死锁）
+
+- **现象**：索引大文档时 `ChunkEmbedder` 抛 `MySQLTransactionRollbackException: Deadlock found`，
+  堆栈落在 `ModelUsageMonthlyMapper.reserve`，整个索引任务随之失败。
+- **根因**：`ModelUsageService.reserve` 事务里先 `monthlyMapper.ensure`（`INSERT IGNORE`）再
+  `monthlyMapper.reserve`（条件 `UPDATE`），两条语句打的是**同一行**。除该租户当月第一次调用外行都
+  已存在，此时 `INSERT IGNORE` 为判定 `uk_tenant_month` 冲突会对该行加 **S 锁**，紧接着的 `UPDATE`
+  需要把它升级成 **X 锁**。两个并发事务各持 S、各等 X，构成互等——InnoDB 只能杀掉一个。
+  而 `ChunkEmbedder.embedConcurrently` 把同一文档的多个批次并发提交，**每个批次计费到同一个租户月、
+  同一行**，所以文档越大越必然触发。
+- **修复**：改为先 `UPDATE`，只有它影响 0 行、且经一次**不加锁的一致性读**（新增
+  `ModelUsageMonthlyMapper.countRow`）确认计数器行确实缺席时，才补建并重试一次。热路径（行已存在）
+  从此只有一条 `UPDATE`、一把 X 锁，不存在锁升级。并发预占仍会在该行上串行等待，这正是配额闸门应有
+  的行为——**串行不是死锁**。
+- **为什么不用"再 `INSERT IGNORE` 一次"来判断行在不在**：超配额是持续到月末的状态，那会把同一把 S 锁
+  放回超配额期间的每一次被拒调用上，死锁只是换条路径回来。
+- 未加死锁重试：根因已消除，且死锁抛出时 Spring 事务已标记 rollback-only，方法内重试无效；真要重试
+  得放到 `ModelUsageSupport.execute` 之外，属另一项决策。
+- 单元测试新增 2 例（热路径不建行、首次调用补建后重试），并修正既有拒绝用例——它此前未 stub 行存在性，
+  实际测的是首次调用路径。变异验证：把 `ensure` 挪回热路径，3 个用例转红。
+- 无 schema 迁移、无配置键、无 API 变更。测试 1350 → 1352 全绿。
 ### 重构（kb-app 上帝类按职责拆解，行为不变）
 
 - **背景**：四个应用服务把多份互不相干的职责挤在一个类里，构造依赖分别达到 31 / 25 / 22 / 21 个。

--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/modelusage/ModelUsageService.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/modelusage/ModelUsageService.java
@@ -80,8 +80,7 @@ public class ModelUsageService implements ModelCallMeter {
     public ModelCallTicket reserve(ModelCallSpec spec) {
         ModelUsageContext context = requireContext();
         String month = currentMonth();
-        monthlyMapper.ensure(context.tenantId(), month);
-        if (monthlyMapper.reserve(context.tenantId(), month, spec.reservedTokens()) != 1) {
+        if (!takeQuota(context.tenantId(), month, spec.reservedTokens())) {
             Tenant tenant = findTenant(context.tenantId());
             if (tenant == null) {
                 log.error("model usage tenant not found, errorCode={}, tenantId={}",
@@ -123,6 +122,45 @@ public class ModelUsageService implements ModelCallMeter {
             throw new BizException(ErrorCode.INTERNAL_ERROR, "模型用量预占记录失败");
         }
         return new ModelCallTicket(usage.getUsageId(), spec.reservedTokens(), true);
+    }
+
+    /**
+     * Takes the tenant month's quota gate, creating the counter row only when it is genuinely absent.
+     *
+     * <p><b>The order of these three statements is the fix for a production deadlock.</b> The counter row
+     * used to be ensured on every call, before the update. INSERT IGNORE against an existing row takes a
+     * shared lock on it to resolve the duplicate key, and the update that follows needs an exclusive lock
+     * on that same row - so two concurrent reservations for one tenant month each held S and each waited
+     * for X, which InnoDB resolves by killing one of them. One document's embedding batches run in
+     * parallel and all bill the same tenant month, so a large document hit this reliably.
+     *
+     * <p>Attempting the update first removes the upgrade entirely on the hot path: the row exists for
+     * every call but the very first of a tenant's month, and a single UPDATE takes one exclusive lock and
+     * never waits on itself. Concurrent reservations still serialise on that row, which is the point -
+     * a quota gate has to be decided one caller at a time. Serialising is not deadlocking.
+     *
+     * <p><b>Why the existence check rather than just retrying the insert.</b> An update that changes no
+     * row means one of two things: the row is missing, or the quota is exhausted. Only the first calls for
+     * an insert. Being over quota lasts until the month rolls over, so letting INSERT IGNORE answer the
+     * question would put its shared lock back on every rejected call for the rest of the month - the same
+     * deadlock, reached along the failure path.
+     *
+     * @param tenantId   tenant business id
+     * @param usageMonth billing month, {@code YYYY-MM}
+     * @param tokens     tokens to put in flight
+     * @return {@code true} when the reservation was taken
+     */
+    private boolean takeQuota(String tenantId, String usageMonth, long tokens) {
+        if (monthlyMapper.reserve(tenantId, usageMonth, tokens) == 1) {
+            return true;
+        }
+        if (monthlyMapper.countRow(tenantId, usageMonth) > 0) {
+            return false;
+        }
+        // First call of this tenant month. A concurrent caller may win the insert, which is why the
+        // reservation is retried rather than assumed: INSERT IGNORE reports 0 for the loser too.
+        monthlyMapper.ensure(tenantId, usageMonth);
+        return monthlyMapper.reserve(tenantId, usageMonth, tokens) == 1;
     }
 
     @Override

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/modelusage/ModelUsageServiceTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/modelusage/ModelUsageServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -77,6 +78,8 @@ class ModelUsageServiceTest {
     @Test
     void shouldRejectBeforeInsertingLedgerWhenAtomicQuotaReservationFails() {
         when(monthlyMapper.reserve(anyString(), anyString(), anyLong())).thenReturn(0);
+        // The counter row is there - the reservation failed on the quota, not on a missing row.
+        when(monthlyMapper.countRow(anyString(), anyString())).thenReturn(1);
         Tenant tenant = new Tenant();
         tenant.setTenantId(TENANT_ID);
         tenant.setMonthlyTokenQuota(100L);
@@ -87,6 +90,37 @@ class ModelUsageServiceTest {
 
         assertEquals(ErrorCode.MODEL_QUOTA_EXCEEDED, failure.getErrorCode());
         verify(usageMapper, never()).insert(any(ModelUsage.class));
+        // Over quota lasts all month. Inserting here would put INSERT IGNORE's shared lock back on
+        // every rejected call, which is the deadlock this ordering exists to avoid.
+        verify(monthlyMapper, never()).ensure(anyString(), anyString());
+    }
+
+    @Test
+    void shouldNotInsertTheCounterRowOnTheHotPath() {
+        when(monthlyMapper.reserve(anyString(), anyString(), anyLong())).thenReturn(1);
+
+        service.reserve(new ModelCallSpec("dashscope", ModelCallSpec.EMBEDDING, "text-embedding-v4", 100));
+
+        // The regression under guard: ensuring the row on every call made INSERT IGNORE take a shared
+        // lock on it, which the following UPDATE then had to upgrade. One document's parallel embedding
+        // batches all bill the same tenant month, so two of them deadlocked instead of queuing.
+        verify(monthlyMapper, never()).ensure(anyString(), anyString());
+        verify(monthlyMapper).reserve(anyString(), anyString(), anyLong());
+    }
+
+    @Test
+    void shouldCreateTheCounterRowAndRetryOnTheFirstCallOfATenantMonth() {
+        // Missing row first, present after the insert.
+        when(monthlyMapper.reserve(anyString(), anyString(), anyLong())).thenReturn(0, 1);
+        when(monthlyMapper.countRow(anyString(), anyString())).thenReturn(0);
+        when(monthlyMapper.ensure(anyString(), anyString())).thenReturn(1);
+
+        ModelCallTicket ticket = service.reserve(
+                new ModelCallSpec("dashscope", ModelCallSpec.EMBEDDING, "text-embedding-v4", 100));
+
+        assertEquals(USAGE_ID, ticket.usageId());
+        verify(monthlyMapper).ensure(anyString(), anyString());
+        verify(monthlyMapper, times(2)).reserve(anyString(), anyString(), anyLong());
     }
 
     @Test

--- a/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/ModelUsageMonthlyMapper.java
+++ b/kb-rag-server/kb-domain/src/main/java/io/kbrag/domain/mapper/ModelUsageMonthlyMapper.java
@@ -5,6 +5,7 @@ import io.kbrag.domain.entity.ModelUsageMonthly;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
 /**
@@ -15,13 +16,40 @@ import org.apache.ibatis.annotations.Update;
 @Mapper
 public interface ModelUsageMonthlyMapper extends BaseMapper<ModelUsageMonthly> {
 
-    /** Creates the counter row once; concurrent first calls are absorbed by INSERT IGNORE. */
+    /**
+     * Creates the counter row once; concurrent first calls are absorbed by INSERT IGNORE.
+     *
+     * <p><b>Call it only when the row is known to be missing.</b> When the row already exists this
+     * statement still hits the {@code uk_tenant_month} unique key, and InnoDB takes a <em>shared</em>
+     * lock on the existing row to decide the duplicate. A transaction that then updates the same row
+     * has to upgrade that S lock to an X lock - two concurrent callers each holding S and each waiting
+     * for X deadlock rather than queue. That is exactly what one document's parallel embedding batches
+     * produced, since every batch bills the same tenant month.
+     */
     @Insert("""
             INSERT IGNORE INTO t_kb_model_usage_monthly
                 (tenant_id, usage_month, used_tokens, reserved_tokens)
             VALUES (#{tenantId}, #{usageMonth}, 0, 0)
             """)
     int ensure(@Param("tenantId") String tenantId, @Param("usageMonth") String usageMonth);
+
+    /**
+     * Tells whether the counter row of a tenant month is already there.
+     *
+     * <p>A plain consistent read, which takes no lock - and that is the whole reason the reservation
+     * path asks this question here instead of letting {@link #ensure} answer it implicitly. Being over
+     * quota is a lasting state: a tenant that has exhausted its month would otherwise pay INSERT
+     * IGNORE's shared lock on every single call until the month rolls over.
+     *
+     * @param tenantId   tenant business id
+     * @param usageMonth billing month, {@code YYYY-MM}
+     * @return 1 when the row exists, 0 otherwise
+     */
+    @Select("""
+            SELECT COUNT(1) FROM t_kb_model_usage_monthly
+            WHERE tenant_id = #{tenantId} AND usage_month = #{usageMonth} AND deleted = 0
+            """)
+    int countRow(@Param("tenantId") String tenantId, @Param("usageMonth") String usageMonth);
 
     /**
      * Reserves only while the tenant's live quota still covers used plus in-flight tokens.


### PR DESCRIPTION
## 现象

索引大文档时抛出，整个索引任务随之失败：

```
MySQLTransactionRollbackException: Deadlock found when trying to get lock; try restarting transaction
### The error may involve io.kbrag.domain.mapper.ModelUsageMonthlyMapper.reserve-Inline
	at io.kbrag.app.modelusage.ModelUsageService.reserve(ModelUsageService.java:84)
	at io.kbrag.infrastructure.provider.ModelUsageSupport.execute(ModelUsageSupport.java:57)
	at io.kbrag.app.index.ChunkEmbedder.embedBatch(ChunkEmbedder.java:130)
	at io.kbrag.app.index.ChunkEmbedder.lambda$embedConcurrently$0(ChunkEmbedder.java:113)
```

数据库和模型服务都正常——**运维视角看到的是「文档一直索引失败，重试还是失败」**，而且小文档往往一直不复现。

## 根因

`ModelUsageService.reserve` 的事务里有两条语句，打的是**同一行**：

```java
monthlyMapper.ensure(tenantId, month);                    // INSERT IGNORE
monthlyMapper.reserve(tenantId, month, reservedTokens);   // 条件 UPDATE
```

`t_kb_model_usage_monthly` 上有 `UNIQUE KEY uk_tenant_month (tenant_id, usage_month)`。除该租户当月第一次调用外，计数器行都已存在，于是：

1. `INSERT IGNORE` 撞上唯一键 → InnoDB 为判定重复，对**已存在的那一行加 S 锁**
2. 紧接着的 `UPDATE` 要改这一行 → 需要**把 S 升级为 X**

两个并发事务各自持有 S、各自等待 X，谁都不肯放手 —— 这是互等，不是排队，InnoDB 只能杀掉其中一个。

**为什么大文档必然触发**：`ChunkEmbedder.embedConcurrently` 把同一篇文档的多个批次并发提交到 `EMBED_EXECUTOR`，而这些批次**计费到同一个租户、同一个月、同一行**。批次越多，撞上的概率越接近 1。

## 修复

把建行从热路径挪走，让 `UPDATE` 成为对该行的第一条语句：

```java
private boolean takeQuota(String tenantId, String usageMonth, long tokens) {
    if (monthlyMapper.reserve(tenantId, usageMonth, tokens) == 1) {
        return true;                                   // 热路径：一条 UPDATE、一把 X 锁
    }
    if (monthlyMapper.countRow(tenantId, usageMonth) > 0) {
        return false;                                  // 行在 → 就是配额不足
    }
    monthlyMapper.ensure(tenantId, usageMonth);        // 冷路径：确认缺席才建行
    return monthlyMapper.reserve(tenantId, usageMonth, tokens) == 1;
}
```

热路径（行已存在，即除首次外的每一次调用）从此只有一条 `UPDATE`、一把 X 锁，**没有锁升级，也就没有互等**。并发预占仍会在这一行上串行等待 —— 这正是配额闸门该有的行为，一个准入决定必须一次一个调用者来做。**串行不是死锁。**

### 两个容易踩空的地方

**一、为什么不直接"再 `INSERT IGNORE` 一次"来判断行在不在。**
超配额是**持续到月末**的状态。若冷路径直接 `INSERT IGNORE`，那把 S 锁会回到超配额期间的**每一次被拒调用**上 —— 同一个死锁，换条失败路径回来。所以新增了 `ModelUsageMonthlyMapper.countRow`，一次**不加锁的一致性读**来分辨"行缺席"和"配额不足"。

**二、没有加死锁重试。**
根因已经消除；而且死锁抛出时 Spring 事务已被标记 rollback-only，在 `@Transactional` 方法内重试是无效的 —— 真要重试得放到 `ModelUsageSupport.execute` 之外，那是另一项决策，不该塞进这个修复。

### 残余风险（已评估）

`reserve` 的 `UPDATE ... JOIN t_kb_tenant` 会对租户行加 S 锁，运维改配额是 `UPDATE t_kb_tenant` 取 X 锁。但改配额那条**不碰 monthly 行**，构不成环 —— 等待而非死锁。

## 验证

- **变异验证**：把 `ensure` 挪回热路径（还原成出事的写法），**3 个用例转红** —— `shouldNotInsertTheCounterRowOnTheHotPath`、`shouldRejectBeforeInsertingLedgerWhenAtomicQuotaReservationFails`、`shouldCreateTheCounterRowAndRetryOnTheFirstCallOfATenantMonth`。这是测试确实锁住了本次修复的证据。
- **测试**：新增 2 例（热路径不建行、首次调用补建后重试）；并修正既有的拒绝用例 —— 它此前没有 stub 行存在性，Mockito 默认返回 0，实际测的是"首次调用"而非它声称的"配额不足"。rebase 到 #59 之后 `mvn -o clean test` 非增量重跑：`402+67+798+85 = 1352` 例全绿（1350 → 1352）。
- **同类排查**：全仓 `INSERT IGNORE` / `ON DUPLICATE KEY` 只有这一处，无同类缺陷。
- 死锁本身要真实 MySQL 并发才能复现，单测锁住的是**导致死锁的调用序列**（热路径是否还会 INSERT），这是该缺陷在单测层可稳定复现的代理。

## 文档同步

| 文档 | 处理 |
|---|---|
| `kb-rag-server/CHANGELOG.md` | 新增「M24 后修复」章节，置于 #59 的重构章节之上（时间倒序） |
| `kb-rag-deploy/CHANGELOG.md` | `Fixed` 首条，写给运维：现象、为何小文档不复现、**升级零操作** |
| `docs/M24-CONTRACTS.md` | §1 不变量补「预占语句顺序」引用块；§7 测试清单补齐 |
| `docs/ARCHITECTURE.md` | 升 **v2.9**；`ModelCallMeter` 行补顺序约束 |
| `openapi/kb-server.yaml` | **不改**：对外契约零变化，版本号保持 `0.26.0-m24` |

## 影响面

无 Flyway 迁移、无新增或改名的配置键与环境变量、无新容器或第三方依赖、对外 HTTP 契约不变 —— **升级零操作**。升级后原先失败的文档重新触发索引即可正常完成。

## 与 #59 的冲突（已解决）

本 PR 原先与 #59 在 `ARCHITECTURE.md` 版本号行和 `kb-rag-server/CHANGELOG.md` 插入位置上冲突。#59 已先行合并，本分支已 rebase 到其之上：版本号按预告推进为 **v2.9**（基线 = v2.8 + 本修复），CHANGELOG 两个章节按时间倒序并存，测试数字按 rebase 后的基线重新实测。代码文件无交叉。
