### PR TITLE
chore: 忽略本地 Agent 配置目录 .agents/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ secrets*
 
 # ===== IDE 与本地 Agent 配置 =====
 .claude/
+.agents/
 AGENTS.md
 CLAUDE.md
 .idea/


### PR DESCRIPTION
## 改动

`.gitignore` 的「IDE 与本地 Agent 配置」一节加入 `.agents/`。

## 为什么

`.agents/` 与已忽略的 `.claude/`、`AGENTS.md` 同类：都是各人机器上的 Agent 工具配置，内容因人而异，不构成项目的一部分。目前该目录下是 `skills/`。

不忽略的话，它会一直挂在 `git status` 里，成为每次提交时都要绕开的噪音，也容易被误 `git add -A` 带进无关的 PR。

## 说明

该目录此前从未被追踪过，所以不需要 `git rm --cached` 清理历史，单加一行忽略规则即可。