### PR TITLE
docs(readme): 头部澄清解析服务为 Java/Python 两套实现

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@
 向量 + BM25 双路混合检索 → 标注与评测闭环 → 对外开放平台（REST + MCP），
 并内置面向 Agent 的记忆库（长期记忆抽取 / 画像 / 记忆检索）。
 
-**一句话架构**：Java 主服务（检索/管理编排）+ Python 解析服务（文档转 Markdown）+
-React 管理台，三者围绕 MySQL（事实源）/ Elasticsearch 与 Qdrant（检索引擎）/
-MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过 docker-compose 一键拉起中间件。
+**一句话架构**：Java 主服务（检索/管理编排）+ 解析服务（文档转 Markdown，Java 与 Python
+两套实现，行为等价、二选一部署）+ React 管理台，三者围绕 MySQL（事实源）/ Elasticsearch
+与 Qdrant（检索引擎）/ MinIO（对象存储）/ Neo4j（可选，图检索）构建，全部通过
+docker-compose 一键拉起中间件。
 
 > 本仓库由原先四个独立仓库（`kb-rag-server` / `kb-rag-parser` / `kb-rag-web` /
-> `kb-rag-deploy`）合并而成，各子项目的完整提交历史已一并保留。
+> `kb-rag-deploy`）合并而成，各子项目的完整提交历史已一并保留；
+> `kb-rag-parse-java` 是合并之后新增的 Java 解析实现，与 `kb-rag-parser`（Python）二选一。
 
 ## 作品演示
 
@@ -479,7 +481,7 @@ kb-rag-parser/.venv/bin/python kb-rag-parse-java/tools/crosscheck.py
 | [`kb-rag-deploy/docs/LOGIN-CAPTCHA-CONTRACT.md`](kb-rag-deploy/docs/LOGIN-CAPTCHA-CONTRACT.md) | 登录滑块验证码与凭据记忆契约 |
 | [`kb-rag-deploy/sql/kb_rag_full_schema.sql`](kb-rag-deploy/sql/kb_rag_full_schema.sql) | 全量建表语句快照（V1~V25，48 张表），用于快速了解数据模型；实际建表以 Flyway 迁移脚本为准 |
 | [`kb-rag-deploy/docs/openapi/kb-server.yaml`](kb-rag-deploy/docs/openapi/kb-server.yaml) | Java 主服务 OpenAPI 契约 |
-| [`kb-rag-deploy/docs/openapi/kb-parser.yaml`](kb-rag-deploy/docs/openapi/kb-parser.yaml) | Python 解析服务 OpenAPI 契约 |
+| [`kb-rag-deploy/docs/openapi/kb-parser.yaml`](kb-rag-deploy/docs/openapi/kb-parser.yaml) | 解析服务 OpenAPI 契约（Java / Python 两套实现共用的规范来源） |
 | [`docs/MCP接入指南.md`](docs/MCP接入指南.md) | MCP 客户端（Claude Desktop / Cursor 等）接入配置与工具目录 |
 | [`docs/记忆库接入指南.md`](docs/记忆库接入指南.md) | 记忆库 REST + MCP 接入、Memory Key 管理 |
 | [`docs/知识库需求文档.md`](docs/知识库需求文档.md) | 需求全集与设计取舍 |


### PR DESCRIPTION
## 背景

`kb-rag-parse-java` 于 #55 引入后，README **头部**仍把解析服务单说成"Python 解析服务"，与正文（架构图下方要点、目录结构表）里"两套实现、行为等价、二选一部署"的说法不一致。读者在首屏形成的印象和往下读到的内容对不上。

## 改了什么

| 位置 | 改动 |
| --- | --- |
| 一句话架构 | "Python 解析服务" → "解析服务（文档转 Markdown，Java 与 Python 两套实现，行为等价、二选一部署）" |
| 仓库来源说明 | 保持"原先四个独立仓库合并而成"的史实，另起一句说明 `kb-rag-parse-java` 是合并**之后**新增的实现 |
| 文档导航 | `kb-parser.yaml` 的描述由"Python 解析服务 OpenAPI 契约"改为"Java / Python 两套实现共用的规范来源" |

## 为什么这样写

两处表述我做了事实核实后才定稿：

**1. `kb-rag-parse-java` 不是合并来源之一。** 四个原始仓库的内容均在 2026-07-27 合入；`kb-rag-parse-java` 的首次提交是 2026-09-02（`aa9f702`，#55）。因此它不能列进"由 X 合并而成"的括号里，只能作为合并后新增的实现单独说明。

```
kb-rag-deploy:    2026-07-27
kb-rag-server:    2026-07-27
kb-rag-parser:    2026-07-27
kb-rag-web:       2026-07-27
kb-rag-parse-java: 2026-09-02   ← 合并之后新增
```

**2. `kb-parser.yaml` 是两侧共用的契约，不是 Python 独有的。** 依据 `kb-rag-parse-java/README.md:5`：契约与两侧共同的规范来源一致。原描述会让人误以为 Java 实现另有一份契约。

**3. 目录名以仓库实际为准**：`kb-rag-parse-java`（不是 `kb-rag-parser-java`）、`kb-rag-parser`（不是 `kb-rag-parser-python`）。README 其余部分的链接和表格用的都是实际目录名，头部必须一致，否则链接和正文会互相打架。

## 校验

- 全部本地链接有效（脚本遍历，0 失效）
- 40 个代码围栏配对，6 个 mermaid 块完好
- 全文再无 `Python 解析服务` 的歧义表述（仅存的一处是"本地复现 CI"代码块里的注释，确指 Python 那套，准确）

纯文档改动，7 insertions / 5 deletions，不涉及代码与配置。