### PR TITLE
fix(registration): 修复限流器 Bean 启动失败

### DIFF
--- a/kb-rag-server/kb-app/src/main/java/io/kbrag/app/registration/RegistrationRateLimiter.java
+++ b/kb-rag-server/kb-app/src/main/java/io/kbrag/app/registration/RegistrationRateLimiter.java
@@ -6,6 +6,7 @@ import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import io.kbrag.common.util.HashUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
@@ -32,6 +33,7 @@ public class RegistrationRateLimiter {
     private final Clock clock;
     private final Cache<String, FixedWindowCounter> counters;
 
+    @Autowired
     public RegistrationRateLimiter(RegistrationProperties properties) {
         this(properties, Clock.systemUTC());
     }

--- a/kb-rag-server/kb-app/src/test/java/io/kbrag/app/registration/RegistrationRateLimiterTest.java
+++ b/kb-rag-server/kb-app/src/test/java/io/kbrag/app/registration/RegistrationRateLimiterTest.java
@@ -3,6 +3,7 @@ package io.kbrag.app.registration;
 import io.kbrag.common.api.ErrorCode;
 import io.kbrag.common.exception.BizException;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -27,6 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author owlzhangfq@gmail.com
  */
 class RegistrationRateLimiterTest {
+
+    @Test
+    void shouldBeCreatedBySpringWithTheRuntimeConstructor() {
+        try (AnnotationConfigApplicationContext context =
+                     new AnnotationConfigApplicationContext(
+                             RegistrationProperties.class, RegistrationRateLimiter.class)) {
+            assertTrue(context.containsBean("registrationRateLimiter"));
+        }
+    }
 
     @Test
     void shouldEnforceEmailAndIpLayersAndResetAtTheNextHour() {


### PR DESCRIPTION
## 问题

RegistrationRateLimiter 同时存在运行时构造器和测试时钟构造器，但未明确 Spring 应选用的构造器，导致应用启动时尝试调用不存在的无参构造器。

## 修复

- 在运行时构造器上显式标注 Autowired
- 增加 AnnotationConfigApplicationContext 回归测试，覆盖真实 Spring Bean 创建路径

## 验证

- JDK 17：mvn -B -ntp verify -DexcludedGroups=browser
- 结果：BUILD SUCCESS，所有服务端测试 0 failures、0 errors
- 真实本地依赖启动：应用成功输出 Started KbRagServerApplication，健康检查返回 status UP
- git diff --check 通过
- GitNexus 影响分析：LOW，无额外执行流受影响